### PR TITLE
fix: 修复华为手机自动记账权限问题并优化版本标识

### DIFF
--- a/android/app/src/dev/res/values/strings.xml
+++ b/android/app/src/dev/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Dev版本的无障碍服务名称 -->
+    <string name="accessibility_service_label">蜜蜂记账测试版-截图识别</string>
+    <string name="accessibility_service_description">【测试版】用于检测截图动作并自动进行OCR识别记账。\n\n本服务仅监听截图事件，不会读取或修改您的其他数据。\n\n⚠️ 这是测试版本，可能不稳定。</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- 通用资源 -->
     <string name="app_name">蜜蜂记账</string>
     <string name="widget_description">查看今日和本月的收支情况</string>
-    <string name="accessibility_service_label">蜜蜂记账-截图识别</string>
-    <string name="accessibility_service_description">用于检测截图动作并自动进行OCR识别记账。\n\n本服务仅监听截图事件，不会读取或修改您的其他数据。</string>
+
+    <!-- 无障碍服务相关字符串由 flavor 特定的 strings.xml 定义 -->
+    <!-- dev: android/app/src/dev/res/values/strings.xml -->
+    <!-- prod: android/app/src/prod/res/values/strings.xml -->
 </resources>

--- a/android/app/src/prod/res/values/strings.xml
+++ b/android/app/src/prod/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Prod正式版的无障碍服务名称 -->
+    <string name="accessibility_service_label">蜜蜂记账-截图识别</string>
+    <string name="accessibility_service_description">用于检测截图动作并自动进行OCR识别记账。\n\n本服务仅监听截图事件，不会读取或修改您的其他数据。</string>
+</resources>


### PR DESCRIPTION
1. 修复华为设备自动记账失效问题
   - 实现双重文件读取策略解决华为EMUI/HarmonyOS的SELinux权限限制
   - 方式1: 直接从截图文件路径读取(适用于大多数设备)
   - 方式2: 复制到App私有目录后读取(解决华为权限保护)
   - 添加详细调试日志便于问题排查

2. 区分测试版和正式版的无障碍服务标识
   - 新增dev flavor专属strings.xml,服务名称显示"蜜蜂记账测试版"
   - 新增prod flavor专属strings.xml,服务名称显示"蜜蜂记账"
   - 重构主strings.xml,移除flavor特定配置并添加说明注释