### PR TITLE
fix(tag): 删除交易时同步清理标签关联记录

### DIFF
--- a/lib/data/repositories/local/local_transaction_repository.dart
+++ b/lib/data/repositories/local/local_transaction_repository.dart
@@ -243,10 +243,15 @@ class LocalTransactionRepository implements TransactionRepository {
 
   @override
   Future<void> deleteTransaction(int id) async {
-    // 先删除关联的附件
+    // 先删除关联的标签
+    await (db.delete(db.transactionTags)
+          ..where((tt) => tt.transactionId.equals(id)))
+        .go();
+
+    // 再删除关联的附件
     await _deleteAttachmentsForTransaction(id);
 
-    // 再删除交易记录
+    // 最后删除交易记录
     await (db.delete(db.transactions)..where((t) => t.id.equals(id))).go();
   }
 


### PR DESCRIPTION
修复删除交易后标签使用次数未减少的问题。根因是 deleteTransaction
方法遗漏了 transaction_tags 表的清理，导致标签统计 SQL 计入了已
删除交易的关联记录。