### PR TITLE
feat: allow future transaction dates

### DIFF
--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -178,7 +178,6 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
       final res = await showWheelDateTimePicker(
         context,
         initial: _date,
-        maxDate: DateTime.now(),
       );
       if (res != null) setState(() => _date = res);
     } else {
@@ -187,7 +186,6 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
         context,
         initial: _date,
         mode: WheelDatePickerMode.ymd,
-        maxDate: DateTime.now(),
       );
       if (res != null) setState(() => _date = res);
     }


### PR DESCRIPTION
## Summary

Allow transaction creation/editing flows to select dates beyond today so users can pre-record known future expenses or income.

## Changes

- remove the `DateTime.now()` upper bound when opening the date picker in `AmountEditorSheet`
- keep using the shared wheel pickers' default max date, which already allows future dates
- this also applies to transfer records because they reuse the same sheet

## Testing

- verified the date restriction came from `AmountEditorSheet`
- confirmed both date-only and date-time pickers no longer receive a `maxDate` of today
- Flutter tooling is not installed in this execution environment, so I could not run `flutter test` / `flutter analyze` locally

Fixes TNT-Likely/BeeCount#212