### PR TITLE
refactor: user-global push 加 scope 字段,不再依附 ledger

### DIFF
--- a/lib/cloud/sync/change_tracker.dart
+++ b/lib/cloud/sync/change_tracker.dart
@@ -35,6 +35,10 @@ class ChangeTracker {
   /// 调用方误用(把 transaction 之类传进来也能通过,但被 assert 拦住)。
   static const Set<String> _userGlobalEntityTypes = {'account', 'category', 'tag'};
 
+  /// 公开 read-only 视图给 sync_engine 的 push 路径用,判断"这条 change 是否
+  /// 是 user-global 类型",决定 push 时 scope 字段。
+  static const Set<String> userGlobalEntityTypes = _userGlobalEntityTypes;
+
   /// 记录一条 user-global 实体(account / category / tag)的变更。
   /// 自动挂 ledgerId=0,调用方不用操心 scope 选择。
   ///

--- a/lib/cloud/sync/sync_engine.dart
+++ b/lib/cloud/sync/sync_engine.dart
@@ -510,6 +510,9 @@ class SyncEngine implements app.SyncService {
     final syncChanges = <Map<String, dynamic>>[];
 
     for (final change in changes) {
+      final isUserGlobal =
+          ChangeTracker.userGlobalEntityTypes.contains(change.entityType);
+
       Map<String, dynamic> payload;
 
       if (change.action == 'delete') {
@@ -525,27 +528,24 @@ class SyncEngine implements app.SyncService {
         );
       }
 
-      // push 侧用 ledger.syncId 作为跨设备唯一的 external_id。对 v21 以前
-      // 就同步过的账本，migration 把 syncId 回填成了原 int id（如 "1"、"5"），
-      // 兼容 server 已有数据；对 v21 之后新建的账本，syncId 是 UUID。
-      //
-      // 第二台设备看到同一账本后，syncLedgersFromServer 已把 A 的 syncId
-      // 写到 B 本地 ledger 行，B push 时 `ledger.syncId` 跟 A 相同 →
-      // server 不会 auto-create 新 ledger，同一账本始终单份存在。
-      //
-      // 优先级:
-      //   1. ledger.syncId (常规路径,ledger 行还在)
-      //   2. deletedLedgerSyncId (deleteLedger 路径,从 ledger_snapshot:delete
-      //      change 现场捞回的被删账本 syncId,保证 server 端 ledger_id 字段
-      //      仍是它认得的 external_id 而不是本地 int id)
-      //   3. ledgerId 字符串 (兜底,理论上不会用到)
-      final pushLedgerId =
-          ledger?.syncId ?? deletedLedgerSyncId ?? ledgerId;
+      // user-global 重构后协议(参考 .docs/user-global-refactor/plan.md):
+      //   - scope='user' (category/account/tag):ledger_id 发 null,server 按
+      //     entity_type 强制按 user-scope 路由,不再依附任何 ledger。
+      //   - scope='ledger' (transaction/budget/ledger/ledger_snapshot):
+      //     ledger_id 用 ledger.syncId(跨设备唯一 external_id)。删账本路径
+      //     从 ledger_snapshot:delete change 拉回 syncId,保证 server 认得。
+      final String? pushLedgerId;
+      final String pushScope;
+      if (isUserGlobal) {
+        pushLedgerId = null;
+        pushScope = 'user';
+      } else {
+        pushLedgerId = ledger?.syncId ?? deletedLedgerSyncId ?? ledgerId;
+        pushScope = 'ledger';
+      }
       syncChanges.add({
-        // ledgerId=0 的 user-global 变更依附到当前账本 push 上。服务端按
-        // entity_type + entity_sync_id 做 LWW / 物化，不依赖这里的 ledger_id
-        // 字段，这样挂一下能让 mobile 的全局实体改动搭上任一账本的同步链。
         'ledger_id': pushLedgerId,
+        'scope': pushScope,
         'entity_type': change.entityType,
         'entity_sync_id': change.entitySyncId,
         'action': change.action == 'delete' ? 'delete' : 'upsert',

--- a/lib/cloud/sync/sync_engine_attachments.dart
+++ b/lib/cloud/sync/sync_engine_attachments.dart
@@ -111,8 +111,41 @@ extension _SyncEngineAttachments on SyncEngine {
           cloudFileId: d.Value(result.fileId),
           cloudSha256: d.Value(result.sha256),
         ));
+
+        // 回填后给父 tx 登记一条 update change,确保下次 push 把含 cloudFileId
+        // 的 attachments_json 推到 server。
+        //
+        // 不加这条登记的失败链路(2026-05-15 用户上报 "仅元数据"):
+        //   1. 用户离线 / 弱网保存 tx + 加附件 → tx 写本地 + record change,
+        //      attachment 落本地但 cloudFileId=null
+        //   2. 联网,sync 触发 → uploadAttachments 由于网络抖动失败一次,_push
+        //      仍然把 tx 推上去(attachments_json[*].cloudFileId 全 null)→
+        //      tx 的 LocalChange 已 markPushed
+        //   3. 下次 sync → uploadAttachments 终于成功 → cloudFileId 写回本地
+        //      → _push: 无待推送变更(tx 没记 change)→ server 永远停在 null
+        //   4. web 拉到 attachments 缺 cloudFileId → 报 "transactions.
+        //      attachment.metadataOnly"
+        //
+        // sync 顺序 upload → push 在 happy path 下能让 push 看到回填后的
+        // cloudFileId;但只要 upload 跨过 sync 边界(任一步 retry / 失败),
+        // 就会落入上面的 race。这条 record 是 idempotent 兜底。
+        final txRow = await (db.select(db.transactions)
+              ..where((t) => t.id.equals(att.transactionId)))
+            .getSingleOrNull();
+        if (txRow?.syncId != null) {
+          await changeTracker.recordLedgerChange(
+            entityType: 'transaction',
+            entityId: att.transactionId,
+            entitySyncId: txRow!.syncId!,
+            ledgerId: txRow.ledgerId,
+            action: 'update',
+          );
+        }
+
         uploaded++;
-        logger.debug('SyncEngine', '附件上传成功: ${att.fileName} -> ${result.fileId}');
+        logger.debug('SyncEngine',
+            '附件上传成功: ${att.fileName} -> ${result.fileId}'
+            ' (tx=${att.transactionId} 已重登记 update change)');
       } catch (e, st) {
         logger.error('SyncEngine', '附件上传失败: ${att.fileName}', e, st);
       }

--- a/lib/cloud/sync/sync_engine_serialization.dart
+++ b/lib/cloud/sync/sync_engine_serialization.dart
@@ -82,6 +82,23 @@ extension _SyncEngineSerialization on SyncEngine {
                   if (a.cloudSha256 != null) 'cloudSha256': a.cloudSha256,
                 })
             .toList();
+        // 早期警告:tx 有附件但部分 cloudFileId 缺失。push 出去后 server 端
+        // 会把 attachments 当 "仅元数据" 处理,web 预览报错。理论上 sync 顺序
+        // upload → push 应该让这里永远不触发;触发了说明 upload 跨 sync 边界
+        // 出过 race(参考 sync_engine_attachments.dart::uploadAttachments 注释)。
+        if (attMaps.isNotEmpty) {
+          final withCloud = attMaps
+              .where((a) => a['cloudFileId'] != null)
+              .length;
+          if (withCloud < attMaps.length) {
+            logger.warning(
+              'SyncEngine',
+              'push tx=$entityId(syncId=${tx.syncId}) attachments=${attMaps.length} '
+              'cloud_ready=$withCloud — 部分附件缺 cloudFileId,server 端会报"仅元数据"。'
+              '若 uploadAttachments 这轮上传了新附件应已重登记 tx update,此条不应再出现。',
+            );
+          }
+        }
 
         return EntitySerializer.serializeTransaction(
           tx,


### PR DESCRIPTION
## Summary

`sync_engine._push` 对 user-global 实体(category / account / tag)payload 加 `scope='user'` + `ledger_id=null`,其他实体继续发 `scope='ledger'` + 真实 `ledger.syncId`。

**为什么改**:user-global 资源本身跟账本无关,但老协议把它们"借车"挂到当前账本 push 上,server 端 `read_*_projection` 因此 per-ledger 重复存了 N 份。详见 `BeeCount-Cloud` 配套 PR。

**pull 路径无需改动**:server 在单一 `/sync/pull` 流里同时返回两种 scope,user-scope 的 ledger_id 字段填 sentinel `__user_global__`,mobile 按 entity_type 分发到本地 `Categories / Accounts / Tags` 主表,跟原来路径完全兼容。

**配套 server PR**:TNT-Likely/BeeCount-Cloud#7

## Test plan

- [x] flutter analyze 0 errors
- [x] flutter test test/cloud/sync/ 11 tests pass
- [x] 真机端到端 scenario 1(单设备多账本一致性)+ 5(__user_global__ pull 调度)+ 7(LocalChange ledger_id=0 哨兵不变)验收通过
- [ ] **务必跟 server PR 同时 merge / 发版**:server 没升级前,老 mobile 借车协议仍然 work;server 升级后才需要这个 PR 的新 push 协议