### PR TITLE
fix: 冷启动同步崩溃 — _resolveCategoryId 同名多行 + AIConfigNotifier dispose

### DIFF
--- a/lib/cloud/sync/sync_engine_resolvers.dart
+++ b/lib/cloud/sync/sync_engine_resolvers.dart
@@ -40,6 +40,18 @@ extension _SyncEngineResolvers on SyncEngine {
   }
 
   /// 根据分类名和类型查找 categoryId
+  ///
+  /// **跟 _resolveAccountId 同样的坑**:多次同步 / seed 默认分类 + 共享账本
+  /// 拉 Owner 分类等场景下,本地 categories 表里同名行可能 > 1(同名不同
+  /// syncId,或一个有 syncId 一个没 syncId 的 seed)。原来用 `getSingleOrNull`
+  /// 一旦撞到就抛 "Too many elements",在 SyncEngine pull transaction 里
+  /// 抛 → 整批 137+ 条 changes 全回滚 → "账本下来但 categories / tx 全为 0"。
+  /// 用 limit(1).get() 兜底:正常情况(命中 1 行 / 0 行)行为不变,异常(>1 行)
+  /// 时优先取第一个不抛错。
+  ///
+  /// 注意:caller 应该先尝试 _resolveCategoryIdBySyncId(rawCategoryId)
+  /// (按 syncId 精确查),本函数只是 name fallback —— 老 payload 没 syncId
+  /// 时才走这里,允许"挑一个同名的"。
   Future<int?> _resolveCategoryId({
     String? categoryName,
     String? categoryKind,
@@ -50,8 +62,9 @@ extension _SyncEngineResolvers on SyncEngine {
     if (categoryKind != null) {
       query.where((c) => c.kind.equals(categoryKind));
     }
-    final cat = await query.getSingleOrNull();
-    return cat?.id;
+    query.limit(1);
+    final rows = await query.get();
+    return rows.isEmpty ? null : rows.first.id;
   }
 
   /// 根据账户名查找 accountId

--- a/lib/providers/ai_config_providers.dart
+++ b/lib/providers/ai_config_providers.dart
@@ -79,6 +79,12 @@ class AIConfigNotifier extends StateNotifier<AIConfigData> {
         prefs.getString(AIConstants.keyAiStrategy) ?? 'cloud_first';
     final strategy = _parseStrategy(strategyStr);
 
+    // ctor 里 fire-and-forget 调本函数,await prefs 期间 notifier 可能被
+    // dispose(provider 重建 / 用户登出等场景)。直接 state= 会抛
+    // "Tried to use AIConfigNotifier after dispose was called"。
+    // StateNotifier 提供 mounted 标志,disposed 后 false。
+    if (!mounted) return;
+
     state = AIConfigData(
       enabled: prefs.getBool(AIConstants.keyAiBillExtractionEnabled) ?? false,
       useVision: prefs.getBool(AIConstants.keyAiUseVision) ?? true,


### PR DESCRIPTION
## 背景

mobile 冷启动首次同步会崩,表现为"账本下来了但 categories / accounts / tags / tx 全是 0"。Stack trace:

```
[WARN] [SyncProvider] replayAllChanges 失败: Bad state: Too many elements
#2 _SyncEngineResolvers._resolveCategoryId (sync_engine_resolvers.dart:53)
#3 _SyncEngineApply._applyTransactionChange (sync_engine_apply.dart:124)
#5 SyncEngine._pull (sync_engine.dart:740)
```

drift `db.transaction(...)` 把整页 500 changes 包一个事务,任何一条 apply 抛错就回滚整批。

另外日志里还有一个独立的崩溃:`Tried to use AIConfigNotifier after dispose was called`,await SharedPreferences 期间 notifier 被 dispose 后继续 `state=` 触发,顺手一起修了。

## 根因(1) _resolveCategoryId 不防同名多行

`_resolveAccountId` 早就用 `limit(1).get()` 兜底了(代码注释里就承认"多次同步后 accounts 表可能出现重名"),但 `_resolveCategoryId` 漏改。

server 数据脏的来源:虚拟分类(转账等)在 mobile seed 时强制创建,**每个新设备 seed 都会生成一份不同 sync_id 的"转账" category sync_change**。多设备测试 / 重装迁移历史下来,server `sync_changes` 表沉淀多份同 name + kind 不同 sync_id。mobile pull 把它们逐条 apply 后,本地 `categories` 表(没 unique(name, kind) 约束)就真有多行同名。老 tx payload 没带 `categoryId` 走 name fallback → `getSingleOrNull` 撞 ≥ 2 行 → "Too many elements" → 整批回滚。

## 根因(2) AIConfigNotifier setState after dispose

```dart
AIConfigNotifier() : super(const AIConfigData()) {
  _loadFromPrefs();   // fire-and-forget
}

Future<void> _loadFromPrefs() async {
  final prefs = await SharedPreferences.getInstance();  // ← await 期间可能被 dispose
  ...
  state = AIConfigData(...);  // ← 抛 "Tried to use after dispose"
}
```

加 `if (!mounted) return;` 守卫即可。

## 修复

1. `_resolveCategoryId`: `getSingleOrNull()` → `limit(1).get()` + `rows.firstOrNull?.id`,对齐 `_resolveAccountId` 注释里已有的兜底姿势。同时补注释解释根因。
2. `AIConfigNotifier._loadFromPrefs`: `await prefs` 之后加 `if (!mounted) return;`。

## 为啥 prod 3.2.0 不崩

prod 3.2.0 跟 main 是**同一份代码**(3.2.0 之后只有 README/资源/拆仓 commit,`lib/` 没动)。差异在数据:dev 测试账号沉淀了脏 sync_changes,prod 真账号干净。bug 一直在,只是 prod 用户日常没踩到 trigger。任何 prod 用户多设备初次装机 seed 完同步,或者从老 mobile 数据迁移过来,都会复现。

## Test plan

- [ ] dev 设备冷启动,test@example.com 账号,server 上同 name + kind 不同 sync_id 的 category 事件存在 → mobile 应该 137 条 changes 全部 apply 成功,本地 categories / accounts / tx 都有数据
- [ ] 同名分类(同 kind)时 `_resolveCategoryId` 返回 first hit,不抛错
- [ ] 打开 AI 配置页 → 切回主页 → 再打开 → 不应再有 AIConfigNotifier dispose error
- [ ] 已有干净数据用户(prod 风格)不受影响:同名只有 1 行时行为不变
