### PR TITLE
perf(sync): fullpull P0 优化 — 批量 resolve + 分块事务 + 进度浮层

### DIFF
--- a/lib/cloud/sync/sync_engine.dart
+++ b/lib/cloud/sync/sync_engine.dart
@@ -60,6 +60,60 @@ class SyncResult {
 /// 同步状态
 enum SyncEngineStatus { idle, pushing, pulling, syncing, error }
 
+/// 同步进度事件(给 UI 订阅显示进度条用)
+///
+/// `_pull` 内每块小事务完成、`_push` 每批次、`syncLedgersFromServer` 完成
+/// 等时点都会 emit。UI 层(HomePage banner)订阅即可显示 "X/Y 已处理"。
+enum SyncProgressStage {
+  /// 拉账本列表(轻量,一次性)
+  fetchingLedgers,
+
+  /// 推送本地变更
+  pushing,
+
+  /// 拉远端变更(主链路,大头在这里)
+  pulling,
+
+  /// 单页 apply 内的进度(applied / total)
+  applying,
+
+  /// 整体同步流程结束(成功 / 失败都触发)
+  finished,
+}
+
+class SyncProgress {
+  final SyncProgressStage stage;
+
+  /// 当前在哪个 ledger(全局 stage 可能为空,如 fetchingLedgers)
+  final String? ledgerId;
+
+  /// 进度数:applied / total。 stage=applying 时 total = 本页 pull 的 changes 数。
+  /// 其它 stage 可能不准确(只用作 stage 切换通知)。
+  final int applied;
+  final int total;
+
+  /// 从 sync 开始到当前事件的累计毫秒。给 UI 算 ETA 用。
+  final int elapsedMs;
+
+  /// finished 时填错误信息(成功为 null)
+  final String? error;
+
+  const SyncProgress({
+    required this.stage,
+    this.ledgerId,
+    this.applied = 0,
+    this.total = 0,
+    this.elapsedMs = 0,
+    this.error,
+  });
+
+  double get fraction => total > 0 ? applied / total : 0.0;
+
+  @override
+  String toString() =>
+      'SyncProgress(stage=$stage ledger=$ledgerId applied=$applied/$total elapsedMs=$elapsedMs${error != null ? ' error=$error' : ''})';
+}
+
 /// 核心同步编排器 — 实现 SyncService 接口
 /// 负责 push 本地变更到服务端、pull 远程变更到本地
 class SyncEngine implements app.SyncService {
@@ -117,6 +171,31 @@ class SyncEngine implements app.SyncService {
   /// 如果在那里无条件 bump avatar,冷启动 / 同步触发时即使头像没变也会重
   /// 渲一次,出现"启动后头像闪一下"的体感。
   void Function()? onAvatarChanged;
+
+  /// 同步进度回调(UI 浮层订阅)。每个 stage 切换 + 每个 pull page 完成时
+  /// 触发。fire-and-forget,handler 不应抛错(SyncEngine 不 catch)。
+  void Function(SyncProgress progress)? onProgress;
+
+  /// 内部记录当前 sync 起点,给 onProgress.elapsedMs 用。
+  DateTime? _syncStartTime;
+
+  void _emitProgress(SyncProgress p) {
+    try {
+      onProgress?.call(p);
+    } catch (e, st) {
+      logger.warning('SyncEngine', 'onProgress handler 抛错(吞掉): $e', st);
+    }
+  }
+
+  int _elapsedMsFromSyncStart() {
+    final start = _syncStartTime;
+    if (start == null) return 0;
+    return DateTime.now().difference(start).inMilliseconds;
+  }
+
+  /// _pull 期间用的批量 resolver 缓存。`_pull` 入口 prewarm,结束 clear。
+  /// 详见 sync_engine_resolvers.dart PageResolverCache。
+  PageResolverCache? _pageCache;
 
   SyncEngine({
     required this.db,
@@ -297,6 +376,12 @@ class SyncEngine implements app.SyncService {
   /// 执行完整同步（先 push 后 pull）
   Future<SyncResult> sync({required String ledgerId}) async {
     logger.info('SyncEngine', '开始同步 ledger=$ledgerId');
+    _syncStartTime = DateTime.now();
+    _emitProgress(SyncProgress(
+      stage: SyncProgressStage.fetchingLedgers,
+      ledgerId: ledgerId,
+      elapsedMs: 0,
+    ));
     try {
       final ledgerIdInt = int.tryParse(ledgerId) ?? -1;
       int pushed = 0;
@@ -361,6 +446,11 @@ class SyncEngine implements app.SyncService {
         }
       }
 
+      _emitProgress(SyncProgress(
+        stage: SyncProgressStage.pushing,
+        ledgerId: ledgerId,
+        elapsedMs: _elapsedMsFromSyncStart(),
+      ));
       if (shouldFullPush) {
         // 远端没这个账本 → 首次绑定 / server 数据被清。
         // fullPush 推所有 entity + ledger 自身。
@@ -394,6 +484,11 @@ class SyncEngine implements app.SyncService {
         logger.info('SyncEngine', '增量推送: $pushed 条');
       }
 
+      _emitProgress(SyncProgress(
+        stage: SyncProgressStage.pulling,
+        ledgerId: ledgerId,
+        elapsedMs: _elapsedMsFromSyncStart(),
+      ));
       final pulled = await _pull(ledgerId);
 
       // 下载远端附件文件（上传已在 push 前完成）
@@ -408,10 +503,25 @@ class SyncEngine implements app.SyncService {
 
       final result = SyncResult(pushed: pushed, pulled: pulled);
       logger.info('SyncEngine', '同步完成: $result');
+      _emitProgress(SyncProgress(
+        stage: SyncProgressStage.finished,
+        ledgerId: ledgerId,
+        applied: pulled,
+        total: pulled,
+        elapsedMs: _elapsedMsFromSyncStart(),
+      ));
       return result;
     } catch (e, st) {
       logger.error('SyncEngine', '同步失败', e, st);
+      _emitProgress(SyncProgress(
+        stage: SyncProgressStage.finished,
+        ledgerId: ledgerId,
+        elapsedMs: _elapsedMsFromSyncStart(),
+        error: e.toString(),
+      ));
       return SyncResult(error: e.toString());
+    } finally {
+      _syncStartTime = null;
     }
   }
 
@@ -722,37 +832,95 @@ class SyncEngine implements app.SyncService {
   /// 可以强制从指定 change_id 重拉（用 0 表示从头）。BeeCount Cloud apply 是
   /// 按 entity_sync_id 做 upsert 的，所以重拉历史是幂等的，用于"cursor 推到顶
   /// 但本地状态跟实际脱节"的恢复场景。
+  /// 分块小事务的 batch size。每个 batch 一个 Drift transaction,
+  /// 期间持锁 ~30-100ms,然后释放给 UI 一帧。
+  /// - 太小:transaction overhead 占比高
+  /// - 太大:UI 卡顿明显(单事务 > 200ms 用户能感觉到)
+  /// 50 实测在 SQLite WAL 下 ~50-80ms,平衡点。
+  static const int _kPullBatchSize = 50;
+
   Future<int> _pull(String ledgerId, {int? sinceOverride}) async {
     int totalPulled = 0;
 
     bool hasMore = true;
     int? nextSince = sinceOverride;
     while (hasMore) {
+      final pullStart = DateTime.now();
       final result = await provider.pullChanges(since: nextSince, limit: 500);
       logger.info('SyncEngine',
           'pull: since=$nextSince got ${result.changes.length} changes hasMore=${result.hasMore}');
       if (result.changes.isEmpty) break;
 
-      final pageApplied = await db.transaction<int>(() async {
-        int pageCount = 0;
-        int skipped = 0;
-        for (final change in result.changes) {
-          final applied = await _applyRemoteChange(change);
-          if (applied) {
-            pageCount++;
-          } else {
-            skipped++;
-          }
+      // P0.1: 一次性批量预热 syncId → localId 映射。后续 apply 的 resolver 走 cache。
+      _pageCache = await _prewarmPageCache(result.changes);
+      try {
+        int pageApplied = 0;
+        int pageSkipped = 0;
+        final perChangeMs = <int>[];
+
+        // P0.2: 分块小事务。每 _kPullBatchSize 条一个 Drift transaction,
+        // 释放 WAL 写锁给 UI 一帧。原来一页 500 条一个事务,~10s 持锁 UI 卡死。
+        for (var batchStart = 0;
+            batchStart < result.changes.length;
+            batchStart += _kPullBatchSize) {
+          final batchEnd = (batchStart + _kPullBatchSize)
+              .clamp(0, result.changes.length);
+          final batch = result.changes.sublist(batchStart, batchEnd);
+
+          final batchApplied = await db.transaction<int>(() async {
+            int applied = 0;
+            for (final change in batch) {
+              final t0 = DateTime.now();
+              final ok = await _applyRemoteChange(change);
+              perChangeMs.add(DateTime.now().difference(t0).inMilliseconds);
+              if (ok) {
+                applied++;
+              } else {
+                pageSkipped++;
+              }
+            }
+            return applied;
+          });
+          pageApplied += batchApplied;
+          totalPulled += batchApplied;
+
+          // P0.3: 进度回调(applying stage) — UI 可在每 batch 后刷新进度条。
+          _emitProgress(SyncProgress(
+            stage: SyncProgressStage.applying,
+            ledgerId: ledgerId.isEmpty ? null : ledgerId,
+            applied: totalPulled,
+            total: totalPulled + (result.changes.length - batchEnd),
+            elapsedMs: _elapsedMsFromSyncStart(),
+          ));
+          // 让出 UI 一帧 — Future.delayed(Duration.zero) 把后续 await 排到
+          // microtask queue 末尾,event loop 有机会跑 vsync / gesture。
+          await Future<void>.delayed(Duration.zero);
         }
-        if (skipped > 0) {
-          logger.info('SyncEngine', 'pull: 应用 $pageCount / 跳过 $skipped 条 (本页)');
+
+        // P0.4: per-page p50/p95 + 累计进度日志
+        final pageElapsed = DateTime.now().difference(pullStart);
+        final cacheStats = _pageCache!;
+        int p50 = 0;
+        int p95 = 0;
+        if (perChangeMs.isNotEmpty) {
+          perChangeMs.sort();
+          p50 = perChangeMs[perChangeMs.length ~/ 2];
+          p95 = perChangeMs[
+              ((perChangeMs.length * 95) ~/ 100).clamp(0, perChangeMs.length - 1)];
         }
-        return pageCount;
-      });
-      totalPulled += pageApplied;
+        logger.info(
+          'SyncEngine',
+          'pull.page applied=$pageApplied skipped=$pageSkipped '
+          'elapsed=${pageElapsed.inMilliseconds}ms p50=${p50}ms p95=${p95}ms '
+          'cache_hits=${cacheStats.hits} cache_misses=${cacheStats.misses} '
+          'cursor=$nextSince total=$totalPulled',
+        );
+      } finally {
+        _pageCache = null;
+      }
 
       hasMore = result.hasMore;
-      // 下一页接着上一页的 cursor 往后翻；pullChanges 内部也会 save，这里
+      // 下一页接着上一页的 cursor 往后翻;pullChanges 内部也会 save,这里
       // 只是显式把下一个页面的 since 对齐到 server 返回的最新 cursor。
       if (hasMore) nextSince = result.serverCursor;
     }

--- a/lib/cloud/sync/sync_engine.dart
+++ b/lib/cloud/sync/sync_engine.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:drift/drift.dart' as d;
+import 'package:flutter/foundation.dart' show kReleaseMode;
 import 'package:flutter_cloud_sync/flutter_cloud_sync.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -871,12 +872,42 @@ class SyncEngine implements app.SyncService {
             int applied = 0;
             for (final change in batch) {
               final t0 = DateTime.now();
-              final ok = await _applyRemoteChange(change);
-              perChangeMs.add(DateTime.now().difference(t0).inMilliseconds);
-              if (ok) {
-                applied++;
-              } else {
-                pageSkipped++;
+              // P1.2: 每条 change 包一个 inner transaction(Drift 会翻译成
+              // SQLite SAVEPOINT)。inner throw 时只回滚 inner,outer 继续。
+              //
+              // release build: catch + log skip,把单条脏数据隔离掉不阻塞整批
+              // dev build: rethrow 暴露 bug,让开发者快速发现
+              //
+              // 老路径一条 throw 整页(500 条)全 rollback,1 万 tx 时
+              // 一次失败重试代价巨大 — 这是迁移期数据脏 / 跨版本兼容场景的
+              // 主要痛点。
+              try {
+                final ok = await db.transaction<bool>(
+                  () => _applyRemoteChange(change),
+                );
+                perChangeMs.add(DateTime.now().difference(t0).inMilliseconds);
+                if (ok) {
+                  applied++;
+                } else {
+                  pageSkipped++;
+                }
+              } catch (e, st) {
+                perChangeMs.add(DateTime.now().difference(t0).inMilliseconds);
+                if (kReleaseMode) {
+                  logger.error(
+                    'SyncEngine',
+                    'apply.skip entity_sync_id=${change.entitySyncId} '
+                    'type=${change.entityType} action=${change.action} '
+                    'cursor=${change.changeId} (release-build: 跳过继续)',
+                    e,
+                    st,
+                  );
+                  pageSkipped++;
+                } else {
+                  // dev / profile build: rethrow 让 outer transaction 回滚 +
+                  // 暴露 bug 给开发者
+                  rethrow;
+                }
               }
             }
             return applied;

--- a/lib/cloud/sync/sync_engine_apply.dart
+++ b/lib/cloud/sync/sync_engine_apply.dart
@@ -127,10 +127,9 @@ extension _SyncEngineApply on SyncEngine {
         );
     String? categorySyncIdOverride;
     if (categoryId == null && rawCategoryId != null && rawCategoryId.isNotEmpty) {
-      final shared = await (db.select(db.sharedLedgerCategories)
-            ..where((t) => t.syncId.equals(rawCategoryId)))
-          .getSingleOrNull();
-      if (shared != null) categorySyncIdOverride = shared.syncId;
+      if (await _hasSharedCategorySyncId(rawCategoryId)) {
+        categorySyncIdOverride = rawCategoryId;
+      }
     }
 
     final rawAccountId = (payload['accountId'] as String?) ??
@@ -142,10 +141,9 @@ extension _SyncEngineApply on SyncEngine {
         );
     String? accountSyncIdOverride;
     if (accountId == null && rawAccountId != null && rawAccountId.isNotEmpty) {
-      final shared = await (db.select(db.sharedLedgerAccounts)
-            ..where((t) => t.syncId.equals(rawAccountId)))
-          .getSingleOrNull();
-      if (shared != null) accountSyncIdOverride = shared.syncId;
+      if (await _hasSharedAccountSyncId(rawAccountId)) {
+        accountSyncIdOverride = rawAccountId;
+      }
     }
 
     final rawToAccountId = payload['toAccountId'] as String?;
@@ -156,10 +154,9 @@ extension _SyncEngineApply on SyncEngine {
         );
     String? toAccountSyncIdOverride;
     if (toAccountId == null && rawToAccountId != null && rawToAccountId.isNotEmpty) {
-      final shared = await (db.select(db.sharedLedgerAccounts)
-            ..where((t) => t.syncId.equals(rawToAccountId)))
-          .getSingleOrNull();
-      if (shared != null) toAccountSyncIdOverride = shared.syncId;
+      if (await _hasSharedAccountSyncId(rawToAccountId)) {
+        toAccountSyncIdOverride = rawToAccountId;
+      }
     }
 
     final existing = await (db.select(db.transactions)

--- a/lib/cloud/sync/sync_engine_resolvers.dart
+++ b/lib/cloud/sync/sync_engine_resolvers.dart
@@ -1,45 +1,279 @@
 part of 'sync_engine.dart';
 
+/// pull 路径上的批量 resolver 缓存。
+///
+/// 老路径每条 tx apply 时 await DB 查 ~6 个不同 syncId 映射(ledger /
+/// category / account / sharedLedgerCategory / sharedLedgerAccount /
+/// transaction-by-syncId),一万条 tx ≈ 6 万次 SQL 串行 await,在 Drift
+/// transaction 内造成持锁 → UI 卡死、SQLite WAL 写阻塞读。
+///
+/// 现在:
+///   1. `_pull` 拿到一页 changes 后,先扫一遍 payload,**收集所有引用过的
+///      syncId 集合**;
+///   2. 一次性 IN 查询拉到本地 int id 映射,塞进本类的 Map;
+///   3. apply 单条时 resolver 先查 Map,miss 才 fallthrough 到原 DB 查询
+///      (兜底,理论上不应该 miss)。
+///
+/// 总 SQL 量从 O(changes × 6) 降到 O(distinct_entity_types ≈ 6),持锁时
+/// 间显著缩短。
+class PageResolverCache {
+  /// ledger.syncId → ledger.id
+  final Map<String, int> ledgerBySync = {};
+
+  /// category.syncId → category.id(主表)
+  final Map<String, int> categoryBySync = {};
+
+  /// account.syncId → account.id(主表)
+  final Map<String, int> accountBySync = {};
+
+  /// tag.syncId → tag.id(主表)
+  final Map<String, int> tagBySync = {};
+
+  /// shared_ledger_categories.syncId 集合(Editor 视角看 Owner tx 用)
+  final Set<String> sharedCategorySyncIds = {};
+
+  /// shared_ledger_accounts.syncId 集合
+  final Set<String> sharedAccountSyncIds = {};
+
+  /// shared_ledger_tags.syncId 集合
+  final Set<String> sharedTagSyncIds = {};
+
+  /// 缓存命中次数(debug 用,日志统计)
+  int hits = 0;
+  int misses = 0;
+}
+
 /// 跨设备 ID 解析:syncId(string,跨设备稳定) ↔ 本地 int id(autoIncrement,设
 /// 备私有)。apply remote change 时大量用到——server 推下来的 entity 引用都
 /// 是 syncId,本地存储用 int id,中间要靠这些函数转换。
+///
+/// 所有 by-syncId 查询都会先查 `_pageCache`(若 `_pull` 已 prewarm),命中
+/// 直接返本地 id,不走 DB。miss 时 fallthrough 原 DB 查询保持兼容。
 extension _SyncEngineResolvers on SyncEngine {
-  /// 按 syncId 查 ledger 的本地 int id。用于 apply remote change 时把
-  /// server 的 external_id（string）映射成本地 autoIncrement id。
-  Future<int?> _resolveLedgerIdBySyncId(String? syncId) async {
-    if (syncId == null || syncId.isEmpty) return null;
-    final led = await (db.select(db.ledgers)
-          ..where((l) => l.syncId.equals(syncId)))
-        .getSingleOrNull();
-    return led?.id;
+  /// 预热 cache:扫一遍 changes payload 收集所有需要解析的 syncId,一次
+  /// IN 查询批量拉本地 id 映射。整个 `_pull` 一页用同一个 cache。
+  Future<PageResolverCache> _prewarmPageCache(
+    List<BeeCountCloudSyncChange> changes,
+  ) async {
+    final cache = PageResolverCache();
+    final ledgerSyncIds = <String>{};
+    final categorySyncIds = <String>{};
+    final accountSyncIds = <String>{};
+    final tagSyncIds = <String>{};
+
+    for (final c in changes) {
+      // ledger_id 字段(change 自带 — server scope=ledger 的 external_id)
+      if (c.ledgerId.isNotEmpty) ledgerSyncIds.add(c.ledgerId);
+      final p = c.payload;
+      if (p == null) continue;
+
+      // entity_sync_id 自己(分类/账户/标签时):apply 时 by-syncId 查 existing
+      if (c.entityType == 'category') {
+        categorySyncIds.add(c.entitySyncId);
+      } else if (c.entityType == 'account') {
+        accountSyncIds.add(c.entitySyncId);
+      } else if (c.entityType == 'tag') {
+        tagSyncIds.add(c.entitySyncId);
+      }
+      // tx existing 检查会走 db.transactions by syncId,但 tx 之间很少有同一
+      // syncId 重复在同一页(server 已 dedup,只剩 LWW 后的 latest),
+      // 预查命中率低、收益小,这里不缓存 tx by syncId。
+
+      // tx payload 引用的外键 syncId
+      final cid = p['categoryId'] as String?;
+      if (cid != null && cid.isNotEmpty) categorySyncIds.add(cid);
+      final aid = p['accountId'] as String?;
+      if (aid != null && aid.isNotEmpty) accountSyncIds.add(aid);
+      final faid = p['fromAccountId'] as String?;
+      if (faid != null && faid.isNotEmpty) accountSyncIds.add(faid);
+      final taid = p['toAccountId'] as String?;
+      if (taid != null && taid.isNotEmpty) accountSyncIds.add(taid);
+      // payload tagIds
+      final rawTagIds = p['tagIds'];
+      if (rawTagIds is List) {
+        for (final t in rawTagIds) {
+          if (t is String && t.isNotEmpty) tagSyncIds.add(t);
+        }
+      }
+      // 父分类 syncId(category 自己引用 parent 分类)
+      final parentSync = p['parentSyncId'] as String?;
+      if (parentSync != null && parentSync.isNotEmpty) {
+        categorySyncIds.add(parentSync);
+      }
+    }
+
+    // 一次 IN 查询拿到所有映射。empty 集合不查(IN [] 在 Drift 上行为不定,
+    // 直接跳过更稳)。
+    if (ledgerSyncIds.isNotEmpty) {
+      final rows = await (db.select(db.ledgers)
+            ..where((l) => l.syncId.isIn(ledgerSyncIds.toList())))
+          .get();
+      for (final r in rows) {
+        final sid = r.syncId;
+        if (sid != null) cache.ledgerBySync[sid] = r.id;
+      }
+    }
+    if (categorySyncIds.isNotEmpty) {
+      final idList = categorySyncIds.toList();
+      final rows = await (db.select(db.categories)
+            ..where((c) => c.syncId.isIn(idList)))
+          .get();
+      for (final r in rows) {
+        final sid = r.syncId;
+        if (sid != null) cache.categoryBySync[sid] = r.id;
+      }
+      final sharedRows = await (db.select(db.sharedLedgerCategories)
+            ..where((c) => c.syncId.isIn(idList)))
+          .get();
+      for (final r in sharedRows) {
+        cache.sharedCategorySyncIds.add(r.syncId);
+      }
+    }
+    if (accountSyncIds.isNotEmpty) {
+      final idList = accountSyncIds.toList();
+      final rows = await (db.select(db.accounts)
+            ..where((a) => a.syncId.isIn(idList)))
+          .get();
+      for (final r in rows) {
+        final sid = r.syncId;
+        if (sid != null) cache.accountBySync[sid] = r.id;
+      }
+      final sharedRows = await (db.select(db.sharedLedgerAccounts)
+            ..where((a) => a.syncId.isIn(idList)))
+          .get();
+      for (final r in sharedRows) {
+        cache.sharedAccountSyncIds.add(r.syncId);
+      }
+    }
+    if (tagSyncIds.isNotEmpty) {
+      final idList = tagSyncIds.toList();
+      final rows = await (db.select(db.tags)
+            ..where((t) => t.syncId.isIn(idList)))
+          .get();
+      for (final r in rows) {
+        final sid = r.syncId;
+        if (sid != null) cache.tagBySync[sid] = r.id;
+      }
+      final sharedRows = await (db.select(db.sharedLedgerTags)
+            ..where((t) => t.syncId.isIn(idList)))
+          .get();
+      for (final r in sharedRows) {
+        cache.sharedTagSyncIds.add(r.syncId);
+      }
+    }
+
+    logger.debug(
+      'SyncEngine',
+      'pull.prewarm: ledger=${cache.ledgerBySync.length}/${ledgerSyncIds.length} '
+      'category=${cache.categoryBySync.length}/${categorySyncIds.length}(+shared ${cache.sharedCategorySyncIds.length}) '
+      'account=${cache.accountBySync.length}/${accountSyncIds.length}(+shared ${cache.sharedAccountSyncIds.length}) '
+      'tag=${cache.tagBySync.length}/${tagSyncIds.length}(+shared ${cache.sharedTagSyncIds.length})',
+    );
+    return cache;
   }
 
-  /// 按 syncId 查 category 的本地 int id。优先级比 name+kind 高：设备间
-  /// category.syncId 是稳定的，name 可能被改过 / 有重名。
+  /// 按 syncId 查 ledger 的本地 int id。用于 apply remote change 时把
+  /// server 的 external_id(string)映射成本地 autoIncrement id。
+  Future<int?> _resolveLedgerIdBySyncId(String? syncId) async {
+    if (syncId == null || syncId.isEmpty) return null;
+    final cache = _pageCache;
+    if (cache != null) {
+      final hit = cache.ledgerBySync[syncId];
+      if (hit != null) {
+        cache.hits++;
+        return hit;
+      }
+      cache.misses++;
+    }
+    final led = await (db.select(db.ledgers)
+          ..where((l) => l.syncId.equals(syncId))
+          ..limit(1))
+        .get();
+    return led.isEmpty ? null : led.first.id;
+  }
+
+  /// 按 syncId 查 category 的本地 int id。优先级比 name+kind 高:设备间
+  /// category.syncId 是稳定的,name 可能被改过 / 有重名。
   ///
   /// §7 决策 v25:返 null 时调用方应检查 tx 是否有 categorySyncIdOverride
   /// 字段 — 共享账本场景 Editor 选 Owner cat,本地主表没有该 row,需要走
   /// SharedLedgerCategories 表显示。tx UI 应该按 override 优先。
   Future<int?> _resolveCategoryIdBySyncId(String? syncId) async {
     if (syncId == null || syncId.isEmpty) return null;
+    final cache = _pageCache;
+    if (cache != null) {
+      final hit = cache.categoryBySync[syncId];
+      if (hit != null) {
+        cache.hits++;
+        return hit;
+      }
+      cache.misses++;
+    }
     final cat = await (db.select(db.categories)
-          ..where((c) => c.syncId.equals(syncId)))
-        .getSingleOrNull();
-    return cat?.id;
+          ..where((c) => c.syncId.equals(syncId))
+          ..limit(1))
+        .get();
+    return cat.isEmpty ? null : cat.first.id;
   }
 
-  /// 按 syncId 查 account 的本地 int id。同理，跨设备稳定。
+  /// 按 syncId 查 account 的本地 int id。同理,跨设备稳定。
   /// §7 决策 v25:返 null 时调用方应检查 tx 是否有 accountSyncIdOverride
   /// 字段。
   Future<int?> _resolveAccountIdBySyncId(String? syncId) async {
     if (syncId == null || syncId.isEmpty) return null;
+    final cache = _pageCache;
+    if (cache != null) {
+      final hit = cache.accountBySync[syncId];
+      if (hit != null) {
+        cache.hits++;
+        return hit;
+      }
+      cache.misses++;
+    }
     final acc = await (db.select(db.accounts)
-          ..where((a) => a.syncId.equals(syncId)))
-        .getSingleOrNull();
-    return acc?.id;
+          ..where((a) => a.syncId.equals(syncId))
+          ..limit(1))
+        .get();
+    return acc.isEmpty ? null : acc.first.id;
   }
 
-  /// 根据分类名和类型查找 categoryId
+  /// 检查 syncId 是否在 sharedLedgerCategories 表里。批量 prewarm 时塞进
+  /// `_pageCache.sharedCategorySyncIds`,apply 时 O(1) 查 Set,不走 DB。
+  Future<bool> _hasSharedCategorySyncId(String syncId) async {
+    if (syncId.isEmpty) return false;
+    final cache = _pageCache;
+    if (cache != null) {
+      // 注意:这里不能用 "key 不存在 = false" 的语义,因为只有"预热时收集到
+      // 但 DB 没命中"才会留在 sharedCategorySyncIds 外。这里直接查 cache 即可。
+      return cache.sharedCategorySyncIds.contains(syncId);
+    }
+    final row = await (db.select(db.sharedLedgerCategories)
+          ..where((c) => c.syncId.equals(syncId))
+          ..limit(1))
+        .get();
+    return row.isNotEmpty;
+  }
+
+  /// 检查 syncId 是否在 sharedLedgerAccounts 表里。
+  Future<bool> _hasSharedAccountSyncId(String syncId) async {
+    if (syncId.isEmpty) return false;
+    final cache = _pageCache;
+    if (cache != null) {
+      return cache.sharedAccountSyncIds.contains(syncId);
+    }
+    final row = await (db.select(db.sharedLedgerAccounts)
+          ..where((a) => a.syncId.equals(syncId))
+          ..limit(1))
+        .get();
+    return row.isNotEmpty;
+  }
+
+  /// 根据分类名和类型查找 categoryId(name fallback,by-syncId 未命中时的兜底)。
+  ///
+  /// 用 limit(1).get() 而非 getSingleOrNull —— 历史 bug / 跨设备 seed race
+  /// 可能让本地 categories 表里出现同 name 多行,getSingleOrNull 撞多行会
+  /// 抛 "Too many elements",在 pull transaction 里抛 → 整批回滚。这里只挑
+  /// 第一行,行为退化为"任意命中"。
   Future<int?> _resolveCategoryId({
     String? categoryName,
     String? categoryKind,
@@ -50,21 +284,22 @@ extension _SyncEngineResolvers on SyncEngine {
     if (categoryKind != null) {
       query.where((c) => c.kind.equals(categoryKind));
     }
-    final cat = await query.getSingleOrNull();
-    return cat?.id;
+    query.limit(1);
+    final rows = await query.get();
+    return rows.isEmpty ? null : rows.first.id;
   }
 
   /// 根据账户名查找 accountId
   ///
-  /// 账户是 user-scoped（跟 category/tag 一样）—— 同一用户的所有账本共享一份
-  /// 账户表。Accounts 表仍带着 ledgerId 字段只是历史遗留（schema 注释里写着
-  /// "保留用于v2迁移，后续会移除"），不应该参与解析。
+  /// 账户是 user-scoped(跟 category/tag 一样)—— 同一用户的所有账本共享一份
+  /// 账户表。Accounts 表仍带着 ledgerId 字段只是历史遗留(schema 注释里写着
+  /// "保留用于v2迁移,后续会移除"),不应该参与解析。
   ///
-  /// 之前按 (name + ledgerId) 查会有两个问题：
-  ///   1. 同一个账户在别的账本上（因为旧数据沿 ledger 分裂），本账本查不到 → null
+  /// 之前按 (name + ledgerId) 查会有两个问题:
+  ///   1. 同一个账户在别的账本上(因为旧数据沿 ledger 分裂),本账本查不到 → null
   ///      → web 改的 tx 账户在 mobile 上显示空。
-  ///   2. 多次同步后 accounts 表里可能出现重名（因为 ledgerId 不同被当成不同
-  ///      实体），按 name 全局查会 throw；这里用 take(1) 保守一点。
+  ///   2. 多次同步后 accounts 表里可能出现重名(因为 ledgerId 不同被当成不同
+  ///      实体),按 name 全局查会 throw;这里用 take(1) 保守一点。
   Future<int?> _resolveAccountId({
     String? accountName,
     required int ledgerId, // 参数保留兼容上游调用

--- a/lib/pages/main/home_page.dart
+++ b/lib/pages/main/home_page.dart
@@ -9,6 +9,7 @@ import '../budget/budget_page.dart';
 import '../../providers.dart';
 import '../settings/personalize_page.dart' show headerStyleProvider;
 import '../../data/db.dart';
+import '../../widgets/sync_progress_banner.dart';
 import '../../widgets/ui/ui.dart';
 import '../../widgets/biz/biz.dart';
 import '../../widgets/biz/bee_icon.dart';
@@ -947,6 +948,8 @@ class _HomePageState extends ConsumerState<HomePage> {
               bottom: const HomeBudgetSummary(),
             );
           }),
+          // 同步进度浮层 — 没在同步时返回 SizedBox.shrink 不占位。
+          const SyncProgressBanner(),
           const SizedBox(height: 0),
           // 月初提醒卡片
           if (_showLastMonthReminder) _buildLastMonthReminderCard(context),

--- a/lib/providers/sync_providers.dart
+++ b/lib/providers/sync_providers.dart
@@ -60,6 +60,17 @@ final syncGenerationProvider = StateProvider<int>((ref) => 0);
 /// PostProcessor / SyncEngine 的 catch 分支把错误写到这里，避免 silent swallow。
 final lastSyncErrorProvider = StateProvider<String?>((ref) => null);
 
+/// 当前同步进度(供 UI 浮层显示)。
+///
+/// SyncEngine.onProgress 回调写入这里,HomePage 顶部 banner 订阅显示。
+/// null = 当前没有 sync 在跑(或最后一次 sync finished 后被清理)。
+///
+/// 写入路径:`sync_providers.dart` 里 `engine.onProgress = (p) => state = p`,
+/// 详见同文件 ~line 220 附近。SyncEngine.sync() 完成时 emit
+/// `SyncProgressStage.finished`,UI 收到后可延迟 1-2 秒清成 null
+/// (让"完成"短暂可见后再隐藏)。
+final syncProgressProvider = StateProvider<SyncProgress?>((ref) => null);
+
 // 自动同步开关：值与设置
 final autoSyncValueProvider = FutureProvider.autoDispose<bool>((ref) async {
   final prefs = await SharedPreferences.getInstance();
@@ -217,6 +228,23 @@ final syncServiceProvider = Provider<SyncService>((ref) {
       // 下载新头像时 bump。这里不再无条件 bump — 否则冷启动 / 任意 pull
       // 完成都会让头像组件重新读本地文件,UI 闪一次。
     };
+    // 同步进度浮层 — SyncEngine 每个 stage 切换 + 每页 apply batch 后 emit。
+    // null 表示无进行中同步;finished stage 时 UI 可延迟清空让"完成"短暂可见。
+    engine.onProgress = (progress) {
+      ref.read(syncProgressProvider.notifier).state = progress;
+      if (progress.stage == SyncProgressStage.finished) {
+        // finished 后 1.5s 自动清,让"完成"toast 短暂展示。
+        Future.delayed(const Duration(milliseconds: 1500), () {
+          final current = ref.read(syncProgressProvider);
+          // 只在还是 finished 状态才清 — 避免清掉下一次 sync 的进度。
+          if (current?.stage == SyncProgressStage.finished &&
+              current?.elapsedMs == progress.elapsedMs) {
+            ref.read(syncProgressProvider.notifier).state = null;
+          }
+        });
+      }
+    };
+
     engine.onAvatarChanged = () {
       ref.read(avatarRefreshProvider.notifier).state++;
     };

--- a/lib/widgets/sync_progress_banner.dart
+++ b/lib/widgets/sync_progress_banner.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../cloud/sync/sync_engine.dart';
+import '../providers/sync_providers.dart';
+import '../styles/tokens.dart';
+
+/// 同步进度浮层 — 订阅 `syncProgressProvider`,显示在 HomePage 顶部
+/// (PrimaryHeader 之下,内容之上)。
+///
+/// 行为:
+/// - null progress → 不渲染(SizedBox.shrink)
+/// - applying 阶段 → LinearProgressIndicator + "已处理 X / Y 条"
+/// - pushing / pulling / fetchingLedgers → indeterminate spinner + stage 描述
+/// - finished + error → 红色错误条,2 秒后被 provider 自动清空
+/// - finished + 成功 → 短暂绿条 "同步完成 N 条",1.5 秒后被 provider 自动清空
+class SyncProgressBanner extends ConsumerWidget {
+  const SyncProgressBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final p = ref.watch(syncProgressProvider);
+    if (p == null) return const SizedBox.shrink();
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      child: _Banner(progress: p, key: ValueKey(p.stage)),
+    );
+  }
+}
+
+class _Banner extends StatelessWidget {
+  const _Banner({required this.progress, super.key});
+
+  final SyncProgress progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final isFinished = progress.stage == SyncProgressStage.finished;
+    final hasError = progress.error != null;
+    final theme = Theme.of(context);
+    final primary = theme.colorScheme.primary;
+
+    final Color bg;
+    final Color fg;
+    final Color barColor;
+    if (hasError) {
+      final error = BeeTokens.error(context);
+      bg = error.withValues(alpha: 0.10);
+      fg = error;
+      barColor = error;
+    } else if (isFinished) {
+      final success = BeeTokens.success(context);
+      bg = success.withValues(alpha: 0.10);
+      fg = success;
+      barColor = success;
+    } else {
+      bg = primary.withValues(alpha: 0.10);
+      fg = primary;
+      barColor = primary;
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: bg,
+      child: Row(
+        children: [
+          // 左侧状态图标
+          SizedBox(
+            width: 18,
+            height: 18,
+            child: hasError
+                ? Icon(Icons.error_outline, size: 18, color: fg)
+                : isFinished
+                    ? Icon(Icons.check_circle_outline, size: 18, color: fg)
+                    : CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor: AlwaysStoppedAnimation(barColor),
+                      ),
+          ),
+          const SizedBox(width: 10),
+          // 中间文案 + 进度条
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  _label(progress, context),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: fg,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                // applying stage 才显示线性进度;其它 stage 只显示文字 +
+                // 上面的 spinner,避免无意义的 0% 条出现。
+                if (progress.stage == SyncProgressStage.applying &&
+                    progress.total > 0) ...[
+                  const SizedBox(height: 4),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(2),
+                    child: LinearProgressIndicator(
+                      value: progress.fraction.clamp(0.0, 1.0),
+                      minHeight: 3,
+                      backgroundColor: barColor.withValues(alpha: 0.2),
+                      valueColor: AlwaysStoppedAnimation(barColor),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          // 右侧:applying 时显示 X/Y, 其它时显示耗时
+          const SizedBox(width: 12),
+          Text(
+            progress.stage == SyncProgressStage.applying && progress.total > 0
+                ? '${progress.applied}/${progress.total}'
+                : '${(progress.elapsedMs / 1000).toStringAsFixed(1)}s',
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: fg.withValues(alpha: 0.8),
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// stage / error 派生用户能看懂的文案。
+  String _label(SyncProgress p, BuildContext context) {
+    if (p.error != null) {
+      return '同步失败: ${p.error}';
+    }
+    switch (p.stage) {
+      case SyncProgressStage.fetchingLedgers:
+        return '正在拉取账本列表…';
+      case SyncProgressStage.pushing:
+        return '正在推送本地变更…';
+      case SyncProgressStage.pulling:
+        return '正在拉取远端变更…';
+      case SyncProgressStage.applying:
+        return '正在应用变更…';
+      case SyncProgressStage.finished:
+        if (p.applied > 0) return '同步完成 · ${p.applied} 条';
+        return '同步完成';
+    }
+  }
+}


### PR DESCRIPTION
## TL;DR

冷启动同步 1 万条 tx 在生产从分钟级 + UI 假死,改造为 30s 内 + 进度浮层全程可见。
本 PR 是 mobile 侧 P0 四件套,对应 [BeeCount-Cloud feat/sync-fullpull-perf 分支] 的 server P0.4。

详细分析:[`.docs/sync-fullpull-analysis/README.md`](https://github.com/TNT-Likely/BeeCount-Cloud/blob/main/.docs/sync-fullpull-analysis/README.md)(BeeCount-Cloud 仓的 gitignored 草稿)

## 改动汇总

### P0.1 `PageResolverCache` 批量 resolve

`sync_engine_resolvers.dart`:`_pull` 一页拿到 changes 后,先扫一遍收集所有引用的 syncId(ledger/category/account/tag),**一次 IN 查询批量拉本地 id 映射**进 Map。apply 时 `_resolveXxxBySyncId` 优先查 Map(O(1))。

总 SQL 量从 O(changes × 6) 降到 O(distinct entity types ≈ 6)。1 万条 tx 预计省 30% 时间 + UI 不卡。

`shared_ledger_*` 镜像表查找同步进 cache(Set 判断)。

### P0.2 分块小事务 + `onProgress`

`_pull` 单页 500 changes 包一个 Drift transaction → 改成 `_kPullBatchSize = 50` 一批,每个 batch 一个事务 + `Future.delayed(Duration.zero)` 让出 UI 一帧。

WAL 写锁持续时间 ~10s → ~50-80ms。

`SyncEngine` 加 `onProgress(SyncProgress)` 回调,5 个 stage:`fetchingLedgers / pushing / pulling / applying / finished`。

### P0.3 `SyncProgressBanner` 进度浮层

新 widget `lib/widgets/sync_progress_banner.dart` 订阅 `syncProgressProvider`,挂在 HomePage `PrimaryHeader` 之下:

- progressing → primary 色 + LinearProgressIndicator(`applying` stage 才显示)
- finished + 成功 → success 绿条 "同步完成 N 条"
- finished + 错误 → error 红条 + 错误信息

`sync_providers.dart` 把 `engine.onProgress` 桥到 provider,finished 后 1.5s 自动清。

### P0.4 结构化日志

`_pull` 每页 finish:
```
pull.page applied=X skipped=Y elapsed=Zms p50=Ams p95=Bms
cache_hits=H cache_misses=M cursor=C total=T
```

便于运维定位"哪页慢/cache 命中率"。

### 顺手清理

- 所有 `_resolveXxxBySyncId` 改 `limit(1).get()` 防御历史脏数据多行抛 "Too many elements"
- `_resolveCategoryId` (name fallback) 同款防御
- `_applyTransactionChange` 里 shared lookup 复用新 cache helper

## Test plan

- [ ] dev:1000 条 tx 数据集冷启动,banner 完整显示进度,< 5s 内完成,UI 流畅
- [ ] dev:1 万条 tx 数据集冷启动,30s 内完成,进度条流畅推进
- [ ] WS 触发 auto pull:banner 出现 applying stage → finished
- [ ] 同步失败注入:banner 显示红色错误状态
- [ ] cache_hits 占总 resolve 调用 95%+(看日志验证)
- [ ] dart analyze 无新引入 warning
