### PR TITLE
v3.2.2: in-app 更新选错 APK + 自定义提示词失效

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1645,6 +1645,7 @@
   "aiOcrRecognizing": "Recognizing bill...",
   "aiOcrNoAmount": "No valid amount recognized, please add manually",
   "aiNotConfiguredHint": "AI service not configured. Go to \"Me → AI Settings\" to set up.",
+  "aiOcrCheckLog": "Recognition failed. Check logs for details.",
   "aiNotConfiguredNotificationTitle": "❌ Cannot recognize screenshot",
   "aiNotConfiguredNotificationBody": "AI service not configured. Tap to set up.",
   "aiOcrNoLedger": "Ledger not found",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7410,6 +7410,12 @@ abstract class AppLocalizations {
   /// **'AI service not configured. Go to \"Me → AI Settings\" to set up.'**
   String get aiNotConfiguredHint;
 
+  /// No description provided for @aiOcrCheckLog.
+  ///
+  /// In en, this message translates to:
+  /// **'Recognition failed. Check logs for details.'**
+  String get aiOcrCheckLog;
+
   /// No description provided for @aiNotConfiguredNotificationTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3880,6 +3880,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiNotConfiguredHint => 'AI service not configured. Go to \"Me → AI Settings\" to set up.';
 
   @override
+  String get aiOcrCheckLog => 'Recognition failed. Check logs for details.';
+
+  @override
   String get aiNotConfiguredNotificationTitle => '❌ Cannot recognize screenshot';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3880,6 +3880,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get aiNotConfiguredHint => '未配置 AI 服务，请前往「我的 → AI 设置」配置';
 
   @override
+  String get aiOcrCheckLog => '识别失败，请查看日志了解详情';
+
+  @override
   String get aiNotConfiguredNotificationTitle => '❌ 无法识别截图';
 
   @override
@@ -10290,6 +10293,9 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get aiNotConfiguredHint => '未配置 AI 服務，請前往「我的 → AI 設定」配置';
+
+  @override
+  String get aiOcrCheckLog => '識別失敗，請查看日誌瞭解詳情';
 
   @override
   String get aiNotConfiguredNotificationTitle => '❌ 無法識別截圖';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1539,6 +1539,7 @@
   "aiOcrRecognizing": "正在识别账单...",
   "aiOcrNoAmount": "未识别到有效金额，请手动记账",
   "aiNotConfiguredHint": "未配置 AI 服务，请前往「我的 → AI 设置」配置",
+  "aiOcrCheckLog": "识别失败，请查看日志了解详情",
   "aiNotConfiguredNotificationTitle": "❌ 无法识别截图",
   "aiNotConfiguredNotificationBody": "未配置 AI 服务，点击前往设置",
   "aiOcrNoLedger": "未找到账本",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -134,6 +134,7 @@
   "aiOcrFailed": "識別失敗: {error}",
   "aiOcrNoAmount": "未識別到有效金額，請手動記帳",
   "aiNotConfiguredHint": "未配置 AI 服務，請前往「我的 → AI 設定」配置",
+  "aiOcrCheckLog": "識別失敗，請查看日誌瞭解詳情",
   "aiNotConfiguredNotificationTitle": "❌ 無法識別截圖",
   "aiNotConfiguredNotificationBody": "未配置 AI 服務，點選前往設定",
   "aiOcrNoLedger": "未找到帳本",

--- a/lib/services/ai/bill_extraction_service.dart
+++ b/lib/services/ai/bill_extraction_service.dart
@@ -28,20 +28,33 @@ class BillExtractionService {
   /// 用户自定义提示词模板
   String? _customPromptTemplate;
 
+  /// Lazy init future。构造时不立即跑 SharedPreferences read,首次 extract 调
+  /// 用前自动 await(也允许 caller 显式提前调 [init] 预热)。避免 caller 漏调
+  /// init() 导致自定义提示词失效。
+  Future<void>? _initFuture;
+
   BillExtractionService({
     this.expenseCategories,
     this.incomeCategories,
     this.accounts,
   });
 
-  /// 初始化（加载用户配置）
-  Future<void> init() async {
+  /// 初始化(加载用户配置)。可显式调用预热,也可由 [_ensureInitialized] 自动
+  /// 触发。重复调用幂等 — 第一次 init 后 [_initFuture] 已固定,后续 extract
+  /// 复用同一个 future,不重复读 prefs。
+  Future<void> init() {
+    return _initFuture ??= _doInit();
+  }
+
+  Future<void> _doInit() async {
     final prefs = await SharedPreferences.getInstance();
     final saved = prefs.getString(AIConstants.keyAiCustomPrompt);
-    // 空字符串视为未配置，避免新装/异常下走出空提示词导致 AI 无法识账
+    // 空字符串视为未配置,避免新装/异常下走出空提示词导致 AI 无法识账
     _customPromptTemplate =
         (saved != null && saved.trim().isNotEmpty) ? saved : null;
   }
+
+  Future<void> _ensureInitialized() => init();
 
   // ============================================================
   // 公开 API
@@ -55,6 +68,7 @@ class BillExtractionService {
       logger.warning(_tag, '输入文本为空');
       return null;
     }
+    await _ensureInitialized();
 
     try {
       final prompt = _buildPrompt(
@@ -63,6 +77,8 @@ class BillExtractionService {
       );
 
       logger.debug(_tag, '提取文本账单，prompt长度: ${prompt.length}');
+      // 打印完整 prompt 用于诊断自定义提示词是否生效(空模板 fallback 默认模板等)
+      logger.debug(_tag, '完整 prompt:\n$prompt');
 
       final response = await AIProviderFactory.chat(
         prompt,
@@ -88,6 +104,7 @@ class BillExtractionService {
       logger.warning(_tag, '图片文件不存在');
       return null;
     }
+    await _ensureInitialized();
 
     try {
       final prompt = _buildPrompt(
@@ -96,6 +113,8 @@ class BillExtractionService {
       );
 
       logger.debug(_tag, '提取图片账单，prompt长度: ${prompt.length}');
+      // 打印完整 prompt 用于诊断自定义提示词是否生效
+      logger.debug(_tag, '完整 prompt:\n$prompt');
 
       final response = await AIProviderFactory.vision(
         image,

--- a/lib/services/update/update_checker.dart
+++ b/lib/services/update/update_checker.dart
@@ -140,16 +140,11 @@ class UpdateChecker {
         logger.info('UpdateChecker', '最新版本: $latestVersion');
 
         if (_isNewerVersion(latestVersion, currentVersion)) {
-          // 找到APK下载链接
+          // 找到 APK 下载链接 — v3.2.1 起 Release 含多个 APK(arm64 主包 /
+          // armeabi-v7a / x86_64 / universal),需要按设备选择,否则 arm64 真机
+          // 装到 armv7 包会走系统 32-bit 兼容层导致严重卡顿
           final assets = data['assets'] as List;
-          String? apkUrl;
-
-          for (final asset in assets) {
-            if (asset['name'].toString().endsWith('.apk')) {
-              apkUrl = asset['browser_download_url'];
-              break;
-            }
-          }
+          final apkUrl = _pickApkUrl(assets, latestVersion);
 
           if (apkUrl != null) {
             return UpdateResult(
@@ -187,6 +182,40 @@ class UpdateChecker {
         message: '__UPDATE_CHECK_EXCEPTION__:$e',
       );
     }
+  }
+
+  /// 从 GitHub Release assets 列表里挑出适配当前设备的 APK。
+  ///
+  /// v3.2.1 起 Release 含多个按 ABI 拆分的 APK:
+  ///   - beecount-<ver>.apk             主分发(arm64-v8a,99% 现役真机)
+  ///   - beecount-<ver>-armeabi-v7a.apk armv7 老 32-bit 设备
+  ///   - beecount-<ver>-x86_64.apk      Intel/Win/Linux 模拟器
+  ///   - beecount-<ver>-universal.apk   三 ABI 全打,兜底
+  ///
+  /// 历史 bug:之前 `endsWith('.apk') break` 取第一个,因 GitHub assets 按
+  /// 字母序排列,第一个就是 `-armeabi-v7a.apk` — arm64 真机装上跑 32-bit 兼容
+  /// 模式 CPU 指令集降级 + 寄存器宽度从 64bit 切 32bit,体感严重卡顿。
+  ///
+  /// 选择策略(按优先级):
+  ///   1. `beecount-<ver>.apk` 主包(arm64)— 现役真机 99% 是 arm64
+  ///   2. universal — 主包不存在时兜底
+  ///   3. 任何 .apk — 都没有时取第一个
+  static String? _pickApkUrl(List assets, String version) {
+    final apkByName = <String, String>{};
+    for (final asset in assets) {
+      final name = asset['name'].toString();
+      if (name.endsWith('.apk')) {
+        apkByName[name] = asset['browser_download_url'];
+      }
+    }
+    if (apkByName.isEmpty) return null;
+
+    final mainPkgName = 'beecount-$version.apk';
+    final universalName = 'beecount-$version-universal.apk';
+
+    if (apkByName.containsKey(mainPkgName)) return apkByName[mainPkgName];
+    if (apkByName.containsKey(universalName)) return apkByName[universalName];
+    return apkByName.values.first;
   }
 
   // 辅助方法

--- a/lib/utils/image_billing_helper.dart
+++ b/lib/utils/image_billing_helper.dart
@@ -98,14 +98,17 @@ class ImageBillingHelper {
         return;
       }
 
+      // BillExtractionService 内部 lazy init,首次 extract 自动加载用户自定义 prompt。
       final billInfo = await BillExtractionService().extractFromImage(imageFile);
 
       if (!context.mounted) return;
       Navigator.of(context).pop();
 
-      // billInfo == null:AI 调用失败 / 无效 / 解析不出账单(自身或网络问题)
+      // billInfo == null:AI 调用失败 / 返回格式错 / 网络问题。具体原因 service
+      // 内部已经 logger.warning/error 打了,UI 统一提示让用户去看日志,避免英文化
+      // AI 原始错误造成的乱码 / 隐私问题。
       if (billInfo == null) {
-        showToast(context, l10n.aiOcrFailed(l10n.aiNotConfiguredHint));
+        showToast(context, l10n.aiOcrCheckLog);
         return;
       }
 


### PR DESCRIPTION
## Summary
- **修复 in-app 更新选错 APK**:旧逻辑 `endsWith('.apk') break` 会按字母序优先匹配到 armeabi-v7a 包,导致 arm64 真机跑 32 位包出现严重卡顿(华为/荣耀首先反馈)。新增 `_pickApkUrl` 优先匹配 `beecount-<version>.apk` 主分发包,其次 universal,最后兜底。
- **修复 AI 自定义提示词失效**:`BillExtractionService` 缺乏 lazy init,部分 caller(语音/拍照路径)实例化后未显式 `init()`,导致 `_customPromptTemplate` 一直为 null 回退默认模板。改为 `_initFuture` 单次幂等加载 + 首次 extract 前自动 await。空字符串仍回退默认。
- **统一识别失败提示**:之前所有 null 返回都 toast「未配置 AI」,误导用户。新增 `aiOcrCheckLog` 国际化文案,真实原因看应用内日志(AI 原始报错不在 UI 上暴露,避免英文化/隐私)。
- **诊断日志**:`logger.debug` 打印完整 prompt(含变量替换后),方便排查空模板/变量未替换问题。

## Test plan
- [ ] arm64 设备从 in-app 更新下载,确认下到 `beecount-3.2.2.apk`(非 armeabi-v7a)
- [ ] 设置自定义提示词后,首次拍照/语音/文本任一路径都应使用自定义模板(看 logger.debug 打印的完整 prompt)
- [ ] 自定义提示词留空时回退到 `defaultPromptTemplate`
- [ ] AI 未配置 → toast「未配置 AI」;AI 配置了但返回失败/格式错 → toast「识别失败,请查看日志」