### PR TITLE
feat(calendar): 日历页支持在选中日期直接记账

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2410,6 +2410,8 @@
   "calendarTitle": "Calendar",
   "calendarToday": "Today",
   "calendarNoTransactions": "No transactions",
+  "calendarAddTransaction": "Add entry on this day",
+  "calendarAddTransactionTooltip": "Add a record on the selected day",
   "commonUncategorized": "Uncategorized",
   "commonSaved": "Saved",
   "aiProviderManageTitle": "Provider Management",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10422,6 +10422,18 @@ abstract class AppLocalizations {
   /// **'No transactions'**
   String get calendarNoTransactions;
 
+  /// No description provided for @calendarAddTransaction.
+  ///
+  /// In en, this message translates to:
+  /// **'Add entry on this day'**
+  String get calendarAddTransaction;
+
+  /// No description provided for @calendarAddTransactionTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a record on the selected day'**
+  String get calendarAddTransactionTooltip;
+
   /// No description provided for @commonUncategorized.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5454,6 +5454,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get calendarNoTransactions => 'No transactions';
 
   @override
+  String get calendarAddTransaction => 'Add entry on this day';
+
+  @override
+  String get calendarAddTransactionTooltip => 'Add a record on the selected day';
+
+  @override
   String get commonUncategorized => 'Uncategorized';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5454,6 +5454,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get calendarNoTransactions => '当天无交易';
 
   @override
+  String get calendarAddTransaction => '在该日记账';
+
+  @override
+  String get calendarAddTransactionTooltip => '添加该日记账';
+
+  @override
   String get commonUncategorized => '未分类';
 
   @override
@@ -11867,6 +11873,12 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get calendarNoTransactions => '當天無交易';
+
+  @override
+  String get calendarAddTransaction => '在該日記帳';
+
+  @override
+  String get calendarAddTransactionTooltip => '新增該日記帳';
 
   @override
   String get commonUncategorized => '未分類';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2370,6 +2370,8 @@
   "calendarTitle": "日历",
   "calendarToday": "今天",
   "calendarNoTransactions": "当天无交易",
+  "calendarAddTransaction": "在该日记账",
+  "calendarAddTransactionTooltip": "添加该日记账",
   "commonUncategorized": "未分类",
   "commonSaved": "已保存",
   "aiProviderManageTitle": "服务商管理",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -2169,6 +2169,8 @@
   "calendarTitle": "日曆",
   "calendarToday": "今天",
   "calendarNoTransactions": "當天無交易",
+  "calendarAddTransaction": "在該日記帳",
+  "calendarAddTransactionTooltip": "新增該日記帳",
   "commonUncategorized": "未分類",
   "commonSaved": "已儲存",
   "aiProviderManageTitle": "服務商管理",

--- a/lib/pages/calendar/calendar_page.dart
+++ b/lib/pages/calendar/calendar_page.dart
@@ -15,6 +15,7 @@ import '../../utils/currencies.dart';
 import '../../providers.dart';
 import '../../providers/calendar_providers.dart';
 import '../../l10n/app_localizations.dart';
+import '../transaction/transaction_editor_page.dart';
 
 class CalendarPage extends ConsumerStatefulWidget {
   const CalendarPage({super.key});
@@ -66,6 +67,31 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
     });
     ref.read(calendarSelectedMonthProvider.notifier).state = _focusedMonth;
     ref.read(calendarSelectedDateProvider.notifier).state = _selectedDay;
+  }
+
+  Future<void> _addTransactionForSelectedDate() async {
+    // 优先使用当前选中日期，未选中时回退到今天。
+    // 把时间锁到中午,避开 UTC 边界导致跨日的问题(交易列表按日期分组,
+    // 凌晨 00:00 在某些时区可能被算作前一天)。
+    final base = _selectedDay ?? DateTime.now();
+    final initialDate = DateTime(base.year, base.month, base.day, 12, 0, 0);
+
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TransactionEditorPage(
+          initialKind: 'expense',
+          quickAdd: true,
+          initialDate: initialDate,
+        ),
+      ),
+    );
+
+    // 编辑器关闭后,主动刷新日历的统计与当日交易列表
+    // (FutureProvider 不会因 Drift 写入自动重算)
+    if (mounted) {
+      ref.read(calendarRefreshProvider.notifier).state++;
+    }
   }
 
   @override
@@ -129,14 +155,12 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
                 SectionCard(
                   margin: EdgeInsets.zero,
                   child: dailyTotalsAsync.when(
+                    // 记账等触发 calendarRefreshProvider 时不切到 loading,
+                    // 旧统计保留,等新数据来无缝替换 — 避免日历整页 spinner 闪烁
+                    skipLoadingOnReload: true,
                     data: (dailyTotals) =>
                         _buildCalendar(context, dailyTotals, primaryColor),
-                    loading: () => const Center(
-                      child: Padding(
-                        padding: EdgeInsets.all(40),
-                        child: CircularProgressIndicator(),
-                      ),
-                    ),
+                    loading: () => _buildCalendarSkeleton(context),
                     error: (err, stack) => Center(
                       child: Padding(
                         padding: const EdgeInsets.all(20),
@@ -397,17 +421,93 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
     );
   }
 
-  // 构建选中日期的交易列表（不显示日期和统计）
+  // 构建选中日期的交易列表（上方含"日期 + 在该日记账"紧凑头）
   Widget _buildDateTransactionsList(BuildContext context, int ledgerId, DateTime date) {
     final l10n = AppLocalizations.of(context);
+    final primaryColor = ref.watch(primaryColorProvider);
+    final localeName = Localizations.localeOf(context).toString();
+    final dateLabel = DateFormat.MMMMd(localeName).format(date);
+    final weekdayLabel = DateFormat.E(localeName).format(date);
 
     final transactionsAsync = ref.watch(
       transactionsByDateProvider((ledgerId: ledgerId, date: date)),
     );
 
-    return SectionCard(
+    final header = Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 10),
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                Text(
+                  dateLabel,
+                  style: TextStyle(
+                    color: BeeTokens.textPrimary(context),
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  weekdayLabel,
+                  style: TextStyle(
+                    color: BeeTokens.textTertiary(context),
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(20),
+              onTap: _addTransactionForSelectedDate,
+              child: Ink(
+                decoration: BoxDecoration(
+                  color: primaryColor,
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: [
+                    BoxShadow(
+                      color: primaryColor.withValues(alpha: 0.28),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 14, vertical: 8),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.add_rounded,
+                          size: 18, color: Colors.white),
+                      const SizedBox(width: 4),
+                      Text(
+                        l10n.calendarAddTransaction,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    final card = SectionCard(
       margin: EdgeInsets.zero,
       child: transactionsAsync.when(
+        // 同上:bump 刷新触发的 reload 不切到 loading 分支,旧列表保持显示
+        skipLoadingOnReload: true,
         data: (transactions) {
           if (transactions.isEmpty) {
             return Padding(
@@ -474,15 +574,17 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
             },
           );
         },
-        loading: () => const Padding(
-          padding: EdgeInsets.all(24),
-          child: Center(child: CircularProgressIndicator()),
-        ),
+        loading: () => _buildTransactionsSkeleton(context),
         error: (err, stack) => Padding(
           padding: const EdgeInsets.all(24),
           child: Center(child: Text('Error: $err')),
         ),
       ),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [header, card],
     );
   }
 
@@ -583,5 +685,56 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
 
   String _formatDate(DateTime date) {
     return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  // 日历整页骨架(模拟 6 周 × 7 天 的灰格,接近真实日历高度)
+  // 占位等高:rowHeight 68 × 6 + daysOfWeekHeight 30 + header 50 ≈ 488
+  Widget _buildCalendarSkeleton(BuildContext context) {
+    return DelayedSkeleton(
+      placeholder: const SizedBox(height: 488),
+      child: PulseSkeleton(
+        child: SizedBox(
+          height: 488,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              children: [
+                const SkeletonBar(height: 18, widthFactor: 0.4),
+                const SizedBox(height: 14),
+                for (int row = 0; row < 6; row++)
+                  Row(
+                    children: List.generate(
+                      7,
+                      (_) => const Expanded(
+                        child: Padding(
+                          padding: EdgeInsets.symmetric(
+                              horizontal: 4, vertical: 4),
+                          child: SkeletonBar(height: 56),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // 当日交易列表骨架(3 条 ListTile 风格占位)
+  Widget _buildTransactionsSkeleton(BuildContext context) {
+    return const DelayedSkeleton(
+      placeholder: SizedBox(height: 200),
+      child: PulseSkeleton(
+        child: Column(
+          children: [
+            SkeletonListTile(),
+            SkeletonListTile(),
+            SkeletonListTile(),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/widgets/ui/skeleton.dart
+++ b/lib/widgets/ui/skeleton.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../styles/tokens.dart';
+
+/// 延迟显示骨架屏:< [DelayedSkeleton.defaultDelay] 期间显示等高占位,
+/// >= 才出真正的骨架。快速查询(<300ms)用户根本看不到骨架,
+/// 避免"骨架闪一下就消失"的违和感;慢查询时骨架接管,告诉用户在加载。
+///
+/// 配合 [PulseSkeleton] / [SkeletonBar] 等原语使用:
+/// ```dart
+/// asyncValue.when(
+///   skipLoadingOnReload: true,
+///   data: (d) => ...,
+///   loading: () => DelayedSkeleton(
+///     placeholder: SizedBox(height: 200),
+///     child: PulseSkeleton(child: SkeletonListTile()),
+///   ),
+///   error: ...,
+/// )
+/// ```
+class DelayedSkeleton extends StatefulWidget {
+  static const Duration defaultDelay = Duration(milliseconds: 300);
+
+  final Widget child;
+
+  /// 延迟期间显示的占位。建议传一个等高的 [SizedBox] 避免布局抖动。
+  final Widget placeholder;
+
+  final Duration delay;
+
+  const DelayedSkeleton({
+    super.key,
+    required this.child,
+    this.placeholder = const SizedBox.shrink(),
+    this.delay = defaultDelay,
+  });
+
+  @override
+  State<DelayedSkeleton> createState() => _DelayedSkeletonState();
+}
+
+class _DelayedSkeletonState extends State<DelayedSkeleton> {
+  bool _show = false;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer(widget.delay, () {
+      if (mounted) setState(() => _show = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _show ? widget.child : widget.placeholder;
+  }
+}
+
+/// 让子组件以"呼吸"动画显示(opacity 在 0.55 ↔ 1.0 之间循环),
+/// 比静态灰块更有生命力,告诉用户"正在加载"。
+class PulseSkeleton extends StatefulWidget {
+  final Widget child;
+
+  /// 单次循环时长,默认 900ms,大多数 loading 场景节奏舒适。
+  final Duration period;
+
+  const PulseSkeleton({
+    super.key,
+    required this.child,
+    this.period = const Duration(milliseconds: 900),
+  });
+
+  @override
+  State<PulseSkeleton> createState() => _PulseSkeletonState();
+}
+
+class _PulseSkeletonState extends State<PulseSkeleton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller =
+      AnimationController(vsync: this, duration: widget.period)
+        ..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (_, __) {
+        final v = 0.55 + 0.45 * (1 - _controller.value);
+        return Opacity(opacity: v, child: widget.child);
+      },
+    );
+  }
+}
+
+/// 骨架矩形条原语 — 通用占位灰块,用 [BeeTokens.surfaceSecondary] 自适应亮/暗。
+class SkeletonBar extends StatelessWidget {
+  final double height;
+  final double? width;
+
+  /// 按父容器宽度的比例填充,与 [width] 二选一(都不传则横向 expand)。
+  final double? widthFactor;
+  final BorderRadius? borderRadius;
+
+  const SkeletonBar({
+    super.key,
+    required this.height,
+    this.width,
+    this.widthFactor,
+    this.borderRadius,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final box = Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: BeeTokens.surfaceSecondary(context),
+        borderRadius: borderRadius ?? BorderRadius.circular(6),
+      ),
+    );
+    if (widthFactor != null) {
+      return FractionallySizedBox(
+        alignment: Alignment.centerLeft,
+        widthFactor: widthFactor,
+        child: box,
+      );
+    }
+    return box;
+  }
+}
+
+/// 骨架圆形原语 — 通用,适合头像 / 图标占位。
+class SkeletonCircle extends StatelessWidget {
+  final double size;
+
+  const SkeletonCircle({super.key, required this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: BeeTokens.surfaceSecondary(context),
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}
+
+/// 模拟 ListTile 的骨架行:左圆 + 中间两行文字 + 右侧金额条。
+/// 常用于交易列表、账户列表、分类列表等 loading 占位。
+class SkeletonListTile extends StatelessWidget {
+  final double iconSize;
+  final EdgeInsetsGeometry padding;
+
+  const SkeletonListTile({
+    super.key,
+    this.iconSize = 36,
+    this.padding = const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: padding,
+      child: Row(
+        children: [
+          SkeletonCircle(size: iconSize),
+          const SizedBox(width: 12),
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SkeletonBar(height: 14, width: 110),
+                SizedBox(height: 6),
+                SkeletonBar(height: 11, width: 70),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          const SkeletonBar(height: 16, width: 60),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/ui/ui.dart
+++ b/lib/widgets/ui/ui.dart
@@ -7,3 +7,4 @@ export 'wheel_picker.dart';
 export 'searchable_dropdown.dart';
 export 'message_popover_menu.dart';
 export 'bee_popup_menu.dart';
+export 'skeleton.dart';


### PR DESCRIPTION
## Summary
- 日历页选中日期上方新增「在该日记账」入口,跳转记账编辑器并把该日作为默认日期,完成后日历统计/列表无感刷新
- 抽公共骨架屏组件 (`DelayedSkeleton` / `PulseSkeleton` / `SkeletonBar` / `SkeletonCircle` / `SkeletonListTile`) 到 `lib/widgets/ui/skeleton.dart`,后续其他页面可直接复用
- 配合 `skipLoadingOnReload: true` + 300ms 延迟骨架,避免记账后整页 spinner 闪烁和切日期时列表跳动

Closes #205

## Test plan
- [ ] 进入日历页,选中日期,点「+ 在该日记账」可打开记账编辑器,默认日期为选中日
- [ ] 保存交易后自动返回日历,该日格子和下方交易列表立即出现新数据,且整页无 spinner 闪烁
- [ ] 切换月份/选不同日期,< 300ms 数据库查询无闪烁,慢查询时显示带呼吸动画的骨架屏
- [ ] 暗黑模式 + 英文/繁体下文案、配色、骨架颜色正常
- [ ] 共享账本下记账,categorySyncIdOverride 等字段正常写入(沿用编辑器现有逻辑,未触碰)