### PR TITLE
feat(ios): 自动记账后台静默执行,无需打开 app

### DIFF
--- a/ios/Runner/AppIntentsBridge.swift
+++ b/ios/Runner/AppIntentsBridge.swift
@@ -13,6 +13,15 @@ class AppIntentsBridge: NSObject, FlutterPlugin {
     private static var pendingEvents: [String] = []
     private static let maxPendingEvents = 5
 
+    // openAppWhenRun=false 时,perform() 把事件丢给 Flutter 后必须**等 Flutter
+    // 处理完**再返回。否则 iOS 认为 AppIntent 已结束,会很快 kill 进程,导致
+    // 「正在识别」通知出来了但「成功」通知发不出去。
+    //
+    // Flutter 处理完 processScreenshot 后通过 MethodChannel 调
+    // `notifyBillingComplete`,触发这里的 continuation 让 perform() 返回。
+    private static var billingCompletionContinuations: [CheckedContinuation<Void, Never>] = []
+    private static let continuationLock = NSLock()
+
     static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
             name: channelName,
@@ -39,6 +48,12 @@ class AppIntentsBridge: NSObject, FlutterPlugin {
             } else {
                 result(false)
             }
+        case "notifyBillingComplete":
+            // Flutter 端 processScreenshot 处理完(成功/失败/超时都算)后回调
+            // 唤醒所有等待的 perform() continuations
+            AppIntentsBridge.resumeAllContinuations()
+            print("[AppIntentsBridge] ✅ 收到 Flutter 处理完成信号")
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -60,6 +75,34 @@ class AppIntentsBridge: NSObject, FlutterPlugin {
                 }
                 print("[AppIntentsBridge] 📦 事件已缓存（共\(pendingEvents.count)个）: \(event)")
             }
+        }
+    }
+
+    /// AppIntent perform() 用这个方法等 Flutter 完成处理。
+    /// 默认 25 秒超时(留 5s buffer 给 iOS 的 30s 后台窗口)。
+    static func waitForBillingComplete(timeout: TimeInterval = 25.0) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            continuationLock.lock()
+            billingCompletionContinuations.append(continuation)
+            continuationLock.unlock()
+            print("[AppIntentsBridge] ⏳ perform() 等待 Flutter 处理完成(超时 \(timeout)s)")
+
+            // 兜底超时:如果 Flutter 卡了/挂了,iOS 30s 窗口快到时强制返回
+            DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+                AppIntentsBridge.resumeAllContinuations()
+            }
+        }
+    }
+
+    /// 唤醒所有等待中的 continuations。重复调用安全(已 resume 的会被跳过)。
+    private static func resumeAllContinuations() {
+        continuationLock.lock()
+        let conts = billingCompletionContinuations
+        billingCompletionContinuations.removeAll()
+        continuationLock.unlock()
+
+        for cont in conts {
+            cont.resume()
         }
     }
 }

--- a/ios/Runner/AutoBillingAppIntent.swift
+++ b/ios/Runner/AutoBillingAppIntent.swift
@@ -8,11 +8,20 @@ import AppIntents
 /// 蜜蜂记账 - 截图自动记账 AppIntent
 /// 通过iOS快捷指令触发，实现截图后自动识别并记账
 /// 仅iOS 16+可用，但App可在iOS 15+运行
+///
+/// openAppWhenRun = false:Shortcut 触发时不把 app 拉到前台。iOS 仍会
+/// background-launch app 进程把 Flutter Engine 跑起来,AI 识别 + 落库
+/// 全在后台完成,用户只感知到系统通知。
+///
+/// iOS 后台执行硬窗口 30 秒,实测 AI 视觉 + 落库 4-9 秒,留有余量。
+/// 极端情况(网络抖动)若超时被 iOS kill,这张截图不会再被 Shortcut
+/// 重试(Shortcut 已经把图传过来一次就走了),用户感知为「截图后没收到
+/// 通知」,可手动改用相册记账兜底。
 @available(iOS 16.0, *)
 struct AutoBillingAppIntent: AppIntent {
     static var title: LocalizedStringResource = "截图自动记账"
     static var description: LocalizedStringResource = "自动识别截图中的支付信息并创建账单"
-    static var openAppWhenRun: Bool = true
+    static var openAppWhenRun: Bool = false
 
     // 接收截图参数
     @Parameter(title: "截图")
@@ -61,6 +70,9 @@ struct AutoBillingAppIntent: AppIntent {
                         // 使用JSON格式传递，避免路径中的冒号问题
                         let event = "{\"action\":\"auto-billing\",\"imagePath\":\"\(imagePath.path)\"}"
                         AppIntentsBridge.sendEvent(event)
+                        // 等 Flutter 处理完(notifyBillingComplete)再返回,否则 iOS 会
+                        // 在我们发完事件后很快 kill 进程,导致「成功」通知发不出去
+                        await AppIntentsBridge.waitForBillingComplete()
                         return .result()
                     } catch {
                         print("[AppIntent] 保存图片失败: \(error)")
@@ -76,6 +88,7 @@ struct AutoBillingAppIntent: AppIntent {
         // 如果没有图片参数或处理失败，只发送事件（让Flutter端处理）
         let event = "{\"action\":\"auto-billing\"}"
         AppIntentsBridge.sendEvent(event)
+        await AppIntentsBridge.waitForBillingComplete()
         return .result()
     }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1648,6 +1648,43 @@
   "aiOcrCheckLog": "Recognition failed. Check logs for details.",
   "aiNotConfiguredNotificationTitle": "❌ Cannot recognize screenshot",
   "aiNotConfiguredNotificationBody": "AI service not configured. Tap to set up.",
+  "autoBillingNotifyDetectedTitle": "✅ Screenshot detected",
+  "autoBillingNotifyWaitingFileBody": "Waiting for file to be written...",
+  "autoBillingNotifyRecognizingScreenshotTitle": "Recognizing screenshot...",
+  "autoBillingNotifyVisionAnalyzingBody": "Calling AI vision to analyze payment info, please wait",
+  "autoBillingNotifyRecognizingTextTitle": "⏳ Recognizing",
+  "autoBillingNotifyTextAnalyzingBody": "Calling AI to parse payment info...",
+  "autoBillingNotifyRecognizeFailedTitle": "❌ Recognition failed",
+  "autoBillingNotifyRecognizeFailedBody": "Could not extract billing info from screenshot. Check AI config or the image.",
+  "autoBillingNotifyFileUnavailableTitle": "Recognition failed",
+  "autoBillingNotifyFileUnavailableBody": "Screenshot file is not available",
+  "autoBillingNotifyNoLedgerTitle": "❌ Auto billing failed",
+  "autoBillingNotifyNoLedgerBody": "No ledger available. Please create one first.",
+  "autoBillingNotifyNoAmountBody": "Could not recognize the amount",
+  "autoBillingNotifyCreateFailedTitle": "❌ Failed to create",
+  "autoBillingNotifyCreateFailedBody": "Could not create transaction record",
+  "autoBillingNotifyProcessFailedTitle": "❌ Processing failed",
+  "autoBillingNotifyProcessFailedBody": "Error: {error}",
+  "@autoBillingNotifyProcessFailedBody": {
+    "placeholders": { "error": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleTitle": "✅ Auto billing succeeded ¥{amount}",
+  "@autoBillingNotifySuccessSingleTitle": {
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessMultiTitle": "✅ Auto billing succeeded ({count} entries)",
+  "@autoBillingNotifySuccessMultiTitle": {
+    "placeholders": { "count": { "type": "int" } }
+  },
+  "autoBillingNotifySuccessMultiBody": "Total ¥{amount}",
+  "@autoBillingNotifySuccessMultiBody": {
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleBodyNote": "Note: {note}",
+  "@autoBillingNotifySuccessSingleBodyNote": {
+    "placeholders": { "note": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleBodyDefault": "Record created automatically",
   "aiOcrNoLedger": "Ledger not found",
   "aiOcrSuccess": "✅ {type} bill created ¥{amount}",
   "@aiOcrSuccess": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7428,6 +7428,138 @@ abstract class AppLocalizations {
   /// **'AI service not configured. Tap to set up.'**
   String get aiNotConfiguredNotificationBody;
 
+  /// No description provided for @autoBillingNotifyDetectedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'✅ Screenshot detected'**
+  String get autoBillingNotifyDetectedTitle;
+
+  /// No description provided for @autoBillingNotifyWaitingFileBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Waiting for file to be written...'**
+  String get autoBillingNotifyWaitingFileBody;
+
+  /// No description provided for @autoBillingNotifyRecognizingScreenshotTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Recognizing screenshot...'**
+  String get autoBillingNotifyRecognizingScreenshotTitle;
+
+  /// No description provided for @autoBillingNotifyVisionAnalyzingBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Calling AI vision to analyze payment info, please wait'**
+  String get autoBillingNotifyVisionAnalyzingBody;
+
+  /// No description provided for @autoBillingNotifyRecognizingTextTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'⏳ Recognizing'**
+  String get autoBillingNotifyRecognizingTextTitle;
+
+  /// No description provided for @autoBillingNotifyTextAnalyzingBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Calling AI to parse payment info...'**
+  String get autoBillingNotifyTextAnalyzingBody;
+
+  /// No description provided for @autoBillingNotifyRecognizeFailedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'❌ Recognition failed'**
+  String get autoBillingNotifyRecognizeFailedTitle;
+
+  /// No description provided for @autoBillingNotifyRecognizeFailedBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not extract billing info from screenshot. Check AI config or the image.'**
+  String get autoBillingNotifyRecognizeFailedBody;
+
+  /// No description provided for @autoBillingNotifyFileUnavailableTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Recognition failed'**
+  String get autoBillingNotifyFileUnavailableTitle;
+
+  /// No description provided for @autoBillingNotifyFileUnavailableBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Screenshot file is not available'**
+  String get autoBillingNotifyFileUnavailableBody;
+
+  /// No description provided for @autoBillingNotifyNoLedgerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'❌ Auto billing failed'**
+  String get autoBillingNotifyNoLedgerTitle;
+
+  /// No description provided for @autoBillingNotifyNoLedgerBody.
+  ///
+  /// In en, this message translates to:
+  /// **'No ledger available. Please create one first.'**
+  String get autoBillingNotifyNoLedgerBody;
+
+  /// No description provided for @autoBillingNotifyNoAmountBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not recognize the amount'**
+  String get autoBillingNotifyNoAmountBody;
+
+  /// No description provided for @autoBillingNotifyCreateFailedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'❌ Failed to create'**
+  String get autoBillingNotifyCreateFailedTitle;
+
+  /// No description provided for @autoBillingNotifyCreateFailedBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not create transaction record'**
+  String get autoBillingNotifyCreateFailedBody;
+
+  /// No description provided for @autoBillingNotifyProcessFailedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'❌ Processing failed'**
+  String get autoBillingNotifyProcessFailedTitle;
+
+  /// No description provided for @autoBillingNotifyProcessFailedBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Error: {error}'**
+  String autoBillingNotifyProcessFailedBody(String error);
+
+  /// No description provided for @autoBillingNotifySuccessSingleTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'✅ Auto billing succeeded ¥{amount}'**
+  String autoBillingNotifySuccessSingleTitle(String amount);
+
+  /// No description provided for @autoBillingNotifySuccessMultiTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'✅ Auto billing succeeded ({count} entries)'**
+  String autoBillingNotifySuccessMultiTitle(int count);
+
+  /// No description provided for @autoBillingNotifySuccessMultiBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Total ¥{amount}'**
+  String autoBillingNotifySuccessMultiBody(String amount);
+
+  /// No description provided for @autoBillingNotifySuccessSingleBodyNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Note: {note}'**
+  String autoBillingNotifySuccessSingleBodyNote(String note);
+
+  /// No description provided for @autoBillingNotifySuccessSingleBodyDefault.
+  ///
+  /// In en, this message translates to:
+  /// **'Record created automatically'**
+  String get autoBillingNotifySuccessSingleBodyDefault;
+
   /// No description provided for @aiOcrNoLedger.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3889,6 +3889,82 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiNotConfiguredNotificationBody => 'AI service not configured. Tap to set up.';
 
   @override
+  String get autoBillingNotifyDetectedTitle => '✅ Screenshot detected';
+
+  @override
+  String get autoBillingNotifyWaitingFileBody => 'Waiting for file to be written...';
+
+  @override
+  String get autoBillingNotifyRecognizingScreenshotTitle => 'Recognizing screenshot...';
+
+  @override
+  String get autoBillingNotifyVisionAnalyzingBody => 'Calling AI vision to analyze payment info, please wait';
+
+  @override
+  String get autoBillingNotifyRecognizingTextTitle => '⏳ Recognizing';
+
+  @override
+  String get autoBillingNotifyTextAnalyzingBody => 'Calling AI to parse payment info...';
+
+  @override
+  String get autoBillingNotifyRecognizeFailedTitle => '❌ Recognition failed';
+
+  @override
+  String get autoBillingNotifyRecognizeFailedBody => 'Could not extract billing info from screenshot. Check AI config or the image.';
+
+  @override
+  String get autoBillingNotifyFileUnavailableTitle => 'Recognition failed';
+
+  @override
+  String get autoBillingNotifyFileUnavailableBody => 'Screenshot file is not available';
+
+  @override
+  String get autoBillingNotifyNoLedgerTitle => '❌ Auto billing failed';
+
+  @override
+  String get autoBillingNotifyNoLedgerBody => 'No ledger available. Please create one first.';
+
+  @override
+  String get autoBillingNotifyNoAmountBody => 'Could not recognize the amount';
+
+  @override
+  String get autoBillingNotifyCreateFailedTitle => '❌ Failed to create';
+
+  @override
+  String get autoBillingNotifyCreateFailedBody => 'Could not create transaction record';
+
+  @override
+  String get autoBillingNotifyProcessFailedTitle => '❌ Processing failed';
+
+  @override
+  String autoBillingNotifyProcessFailedBody(String error) {
+    return 'Error: $error';
+  }
+
+  @override
+  String autoBillingNotifySuccessSingleTitle(String amount) {
+    return '✅ Auto billing succeeded ¥$amount';
+  }
+
+  @override
+  String autoBillingNotifySuccessMultiTitle(int count) {
+    return '✅ Auto billing succeeded ($count entries)';
+  }
+
+  @override
+  String autoBillingNotifySuccessMultiBody(String amount) {
+    return 'Total ¥$amount';
+  }
+
+  @override
+  String autoBillingNotifySuccessSingleBodyNote(String note) {
+    return 'Note: $note';
+  }
+
+  @override
+  String get autoBillingNotifySuccessSingleBodyDefault => 'Record created automatically';
+
+  @override
   String get aiOcrNoLedger => 'Ledger not found';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3889,6 +3889,82 @@ class AppLocalizationsZh extends AppLocalizations {
   String get aiNotConfiguredNotificationBody => '未配置 AI 服务，点击前往设置';
 
   @override
+  String get autoBillingNotifyDetectedTitle => '✅ 检测到截图';
+
+  @override
+  String get autoBillingNotifyWaitingFileBody => '正在等待文件写入...';
+
+  @override
+  String get autoBillingNotifyRecognizingScreenshotTitle => '正在识别截图...';
+
+  @override
+  String get autoBillingNotifyVisionAnalyzingBody => '正在调用 AI 视觉分析支付信息，请稍候';
+
+  @override
+  String get autoBillingNotifyRecognizingTextTitle => '⏳ 正在识别';
+
+  @override
+  String get autoBillingNotifyTextAnalyzingBody => '正在调用 AI 解析支付信息...';
+
+  @override
+  String get autoBillingNotifyRecognizeFailedTitle => '❌ 识别失败';
+
+  @override
+  String get autoBillingNotifyRecognizeFailedBody => '无法从截图提取账单信息，请检查 AI 配置或图片';
+
+  @override
+  String get autoBillingNotifyFileUnavailableTitle => '识别失败';
+
+  @override
+  String get autoBillingNotifyFileUnavailableBody => '截图文件不可用';
+
+  @override
+  String get autoBillingNotifyNoLedgerTitle => '❌ 自动记账失败';
+
+  @override
+  String get autoBillingNotifyNoLedgerBody => '无可用账本，请先创建账本';
+
+  @override
+  String get autoBillingNotifyNoAmountBody => '未能识别出金额信息';
+
+  @override
+  String get autoBillingNotifyCreateFailedTitle => '❌ 创建失败';
+
+  @override
+  String get autoBillingNotifyCreateFailedBody => '无法创建交易记录';
+
+  @override
+  String get autoBillingNotifyProcessFailedTitle => '❌ 处理失败';
+
+  @override
+  String autoBillingNotifyProcessFailedBody(String error) {
+    return '错误：$error';
+  }
+
+  @override
+  String autoBillingNotifySuccessSingleTitle(String amount) {
+    return '✅ 自动记账成功 ¥$amount';
+  }
+
+  @override
+  String autoBillingNotifySuccessMultiTitle(int count) {
+    return '✅ 自动记账成功 $count 笔';
+  }
+
+  @override
+  String autoBillingNotifySuccessMultiBody(String amount) {
+    return '合计 ¥$amount';
+  }
+
+  @override
+  String autoBillingNotifySuccessSingleBodyNote(String note) {
+    return '备注：$note';
+  }
+
+  @override
+  String get autoBillingNotifySuccessSingleBodyDefault => '已自动创建记录';
+
+  @override
   String get aiOcrNoLedger => '未找到账本';
 
   @override
@@ -10308,6 +10384,82 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get aiNotConfiguredNotificationBody => '未配置 AI 服務，點選前往設定';
+
+  @override
+  String get autoBillingNotifyDetectedTitle => '✅ 偵測到截圖';
+
+  @override
+  String get autoBillingNotifyWaitingFileBody => '正在等待檔案寫入...';
+
+  @override
+  String get autoBillingNotifyRecognizingScreenshotTitle => '正在識別截圖...';
+
+  @override
+  String get autoBillingNotifyVisionAnalyzingBody => '正在呼叫 AI 視覺分析支付資訊，請稍候';
+
+  @override
+  String get autoBillingNotifyRecognizingTextTitle => '⏳ 正在識別';
+
+  @override
+  String get autoBillingNotifyTextAnalyzingBody => '正在呼叫 AI 解析支付資訊...';
+
+  @override
+  String get autoBillingNotifyRecognizeFailedTitle => '❌ 識別失敗';
+
+  @override
+  String get autoBillingNotifyRecognizeFailedBody => '無法從截圖提取帳單資訊，請檢查 AI 配置或圖片';
+
+  @override
+  String get autoBillingNotifyFileUnavailableTitle => '識別失敗';
+
+  @override
+  String get autoBillingNotifyFileUnavailableBody => '截圖檔案不可用';
+
+  @override
+  String get autoBillingNotifyNoLedgerTitle => '❌ 自動記帳失敗';
+
+  @override
+  String get autoBillingNotifyNoLedgerBody => '無可用帳本，請先建立帳本';
+
+  @override
+  String get autoBillingNotifyNoAmountBody => '未能識別出金額資訊';
+
+  @override
+  String get autoBillingNotifyCreateFailedTitle => '❌ 建立失敗';
+
+  @override
+  String get autoBillingNotifyCreateFailedBody => '無法建立交易記錄';
+
+  @override
+  String get autoBillingNotifyProcessFailedTitle => '❌ 處理失敗';
+
+  @override
+  String autoBillingNotifyProcessFailedBody(String error) {
+    return '錯誤：$error';
+  }
+
+  @override
+  String autoBillingNotifySuccessSingleTitle(String amount) {
+    return '✅ 自動記帳成功 ¥$amount';
+  }
+
+  @override
+  String autoBillingNotifySuccessMultiTitle(int count) {
+    return '✅ 自動記帳成功 $count 筆';
+  }
+
+  @override
+  String autoBillingNotifySuccessMultiBody(String amount) {
+    return '合計 ¥$amount';
+  }
+
+  @override
+  String autoBillingNotifySuccessSingleBodyNote(String note) {
+    return '備註：$note';
+  }
+
+  @override
+  String get autoBillingNotifySuccessSingleBodyDefault => '已自動建立記錄';
 
   @override
   String get aiOcrNoLedger => '未找到帳本';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1542,6 +1542,43 @@
   "aiOcrCheckLog": "识别失败，请查看日志了解详情",
   "aiNotConfiguredNotificationTitle": "❌ 无法识别截图",
   "aiNotConfiguredNotificationBody": "未配置 AI 服务，点击前往设置",
+  "autoBillingNotifyDetectedTitle": "✅ 检测到截图",
+  "autoBillingNotifyWaitingFileBody": "正在等待文件写入...",
+  "autoBillingNotifyRecognizingScreenshotTitle": "正在识别截图...",
+  "autoBillingNotifyVisionAnalyzingBody": "正在调用 AI 视觉分析支付信息，请稍候",
+  "autoBillingNotifyRecognizingTextTitle": "⏳ 正在识别",
+  "autoBillingNotifyTextAnalyzingBody": "正在调用 AI 解析支付信息...",
+  "autoBillingNotifyRecognizeFailedTitle": "❌ 识别失败",
+  "autoBillingNotifyRecognizeFailedBody": "无法从截图提取账单信息，请检查 AI 配置或图片",
+  "autoBillingNotifyFileUnavailableTitle": "识别失败",
+  "autoBillingNotifyFileUnavailableBody": "截图文件不可用",
+  "autoBillingNotifyNoLedgerTitle": "❌ 自动记账失败",
+  "autoBillingNotifyNoLedgerBody": "无可用账本，请先创建账本",
+  "autoBillingNotifyNoAmountBody": "未能识别出金额信息",
+  "autoBillingNotifyCreateFailedTitle": "❌ 创建失败",
+  "autoBillingNotifyCreateFailedBody": "无法创建交易记录",
+  "autoBillingNotifyProcessFailedTitle": "❌ 处理失败",
+  "autoBillingNotifyProcessFailedBody": "错误：{error}",
+  "@autoBillingNotifyProcessFailedBody": {
+    "placeholders": { "error": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleTitle": "✅ 自动记账成功 ¥{amount}",
+  "@autoBillingNotifySuccessSingleTitle": {
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessMultiTitle": "✅ 自动记账成功 {count} 笔",
+  "@autoBillingNotifySuccessMultiTitle": {
+    "placeholders": { "count": { "type": "int" } }
+  },
+  "autoBillingNotifySuccessMultiBody": "合计 ¥{amount}",
+  "@autoBillingNotifySuccessMultiBody": {
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleBodyNote": "备注：{note}",
+  "@autoBillingNotifySuccessSingleBodyNote": {
+    "placeholders": { "note": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleBodyDefault": "已自动创建记录",
   "aiOcrNoLedger": "未找到账本",
   "aiOcrSuccess": "✅ {type}账单创建成功 ¥{amount}",
   "@aiOcrSuccess": {

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -137,6 +137,43 @@
   "aiOcrCheckLog": "識別失敗，請查看日誌瞭解詳情",
   "aiNotConfiguredNotificationTitle": "❌ 無法識別截圖",
   "aiNotConfiguredNotificationBody": "未配置 AI 服務，點選前往設定",
+  "autoBillingNotifyDetectedTitle": "✅ 偵測到截圖",
+  "autoBillingNotifyWaitingFileBody": "正在等待檔案寫入...",
+  "autoBillingNotifyRecognizingScreenshotTitle": "正在識別截圖...",
+  "autoBillingNotifyVisionAnalyzingBody": "正在呼叫 AI 視覺分析支付資訊，請稍候",
+  "autoBillingNotifyRecognizingTextTitle": "⏳ 正在識別",
+  "autoBillingNotifyTextAnalyzingBody": "正在呼叫 AI 解析支付資訊...",
+  "autoBillingNotifyRecognizeFailedTitle": "❌ 識別失敗",
+  "autoBillingNotifyRecognizeFailedBody": "無法從截圖提取帳單資訊，請檢查 AI 配置或圖片",
+  "autoBillingNotifyFileUnavailableTitle": "識別失敗",
+  "autoBillingNotifyFileUnavailableBody": "截圖檔案不可用",
+  "autoBillingNotifyNoLedgerTitle": "❌ 自動記帳失敗",
+  "autoBillingNotifyNoLedgerBody": "無可用帳本，請先建立帳本",
+  "autoBillingNotifyNoAmountBody": "未能識別出金額資訊",
+  "autoBillingNotifyCreateFailedTitle": "❌ 建立失敗",
+  "autoBillingNotifyCreateFailedBody": "無法建立交易記錄",
+  "autoBillingNotifyProcessFailedTitle": "❌ 處理失敗",
+  "autoBillingNotifyProcessFailedBody": "錯誤：{error}",
+  "@autoBillingNotifyProcessFailedBody": {
+    "placeholders": { "error": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleTitle": "✅ 自動記帳成功 ¥{amount}",
+  "@autoBillingNotifySuccessSingleTitle": {
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessMultiTitle": "✅ 自動記帳成功 {count} 筆",
+  "@autoBillingNotifySuccessMultiTitle": {
+    "placeholders": { "count": { "type": "int" } }
+  },
+  "autoBillingNotifySuccessMultiBody": "合計 ¥{amount}",
+  "@autoBillingNotifySuccessMultiBody": {
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleBodyNote": "備註：{note}",
+  "@autoBillingNotifySuccessSingleBodyNote": {
+    "placeholders": { "note": { "type": "String" } }
+  },
+  "autoBillingNotifySuccessSingleBodyDefault": "已自動建立記錄",
   "aiOcrNoLedger": "未找到帳本",
   "aiOcrRecognizing": "正在識別帳單...",
   "aiOcrSuccess": "✅ {type}帳單建立成功 ¥{amount}",

--- a/lib/services/ai/ai_bookkeeper.dart
+++ b/lib/services/ai/ai_bookkeeper.dart
@@ -140,21 +140,32 @@ class AiBookkeeper {
           continue;
         }
 
-        // 查实际入库的 category / account 名称,回填到 BillInfo
-        // (UI 卡片显示用,避免显示 AI 原始名称)
-        final updated = await _enrichWithActualNames(bill, txId);
-        final index = saved.length;
-        saved.add(updated);
-        txIds.add(txId);
-
+        // 1. **优先**触发 onSaved 回调(主要用于保存图片附件)。
+        //    放在 _enrichWithActualNames 前面是为了缩短附件保存的时间窗口 ——
+        //    iOS 后台 launch 场景下,用户随时可能切走 / 关 app 导致进程被 kill。
+        //    enrich 是给 UI 卡片显示用,被 kill 影响的只是名称展示,不影响数据
+        //    完整性;附件被 kill 才是数据丢失。
         if (onSaved != null) {
           try {
-            await onSaved(txId, index);
+            await onSaved(txId, txIds.length);
           } catch (e, st) {
-            logger.error(_tag, 'onSaved 回调异常(第 ${index + 1} 笔),不影响主流程',
-                e, st);
+            logger.error(_tag, 'onSaved 回调异常,不影响主流程', e, st);
           }
         }
+
+        // 2. 查实际入库的 category / account 名称,回填到 BillInfo
+        //    (UI 卡片显示用,避免显示 AI 原始名称)。
+        //    enrich 自带兜底不会抛,但即便抛了也要保 savedBills/txIds 长度对齐。
+        BillInfo enriched;
+        try {
+          enriched = await _enrichWithActualNames(bill, txId);
+        } catch (e, st) {
+          logger.error(_tag, 'enrichWithActualNames 异常,用 AI 原始 BillInfo',
+              e, st);
+          enriched = bill;
+        }
+        saved.add(enriched);
+        txIds.add(txId);
       } catch (e, st) {
         failed++;
         logger.error(_tag, '第 ${i + 1} 笔创建异常', e, st);

--- a/lib/services/attachment_service.dart
+++ b/lib/services/attachment_service.dart
@@ -78,11 +78,20 @@ class AttachmentService {
   }
 
   /// 保存附件
-  /// 将图片压缩后保存到附件目录，并在数据库中创建记录
+  ///
+  /// 将图片压缩后保存到附件目录，并在数据库中创建记录。
+  ///
+  /// [urgent] 紧急模式:跳过 `FlutterImageCompress`,直接 sync 文件复制。
+  /// 用于 iOS 后台 launch 场景 —— `FlutterImageCompress` 是 platform channel,
+  /// 一旦 iOS 把 app 推到 background,channel 调用会被冻结,attachment 永远
+  /// 保存不完。`File.copySync()` 是纯 Dart sync 调用,几十 ms 内必返回,不会
+  /// 卡在 platform channel 上。代价是单张图占空间多(原图通常 2-3MB,压缩后
+  /// 200-500KB),自动记账场景一般可接受。
   Future<TransactionAttachment?> saveAttachment({
     required int transactionId,
     required File sourceFile,
     required int index,
+    bool urgent = false,
   }) async {
     try {
       final dir = await getAttachmentDirectory();
@@ -92,32 +101,44 @@ class AttachmentService {
       final fileName = 'tx_${transactionId}_${timestamp}_$index$finalExt';
       final destPath = '${dir.path}/$fileName';
 
-      // 压缩图片并保存
-      final compressedFile = await _compressImage(sourceFile, destPath);
-      if (compressedFile == null) {
-        logger.error('AttachmentService', '图片压缩失败');
-        return null;
+      final File savedFile;
+      int? width;
+      int? height;
+      final int fileSize;
+      if (urgent) {
+        // 跳过压缩,sync copy。iOS background launch 状态下唯一可靠的写法。
+        // 同时跳过 _getImageInfo:它走 ui.instantiateImageCodec 也是 platform
+        // channel,后台冻结时也卡。width/height 留 null 不影响主功能。
+        sourceFile.copySync(destPath);
+        savedFile = File(destPath);
+        fileSize = savedFile.lengthSync();
+      } else {
+        final compressedFile = await _compressImage(sourceFile, destPath);
+        if (compressedFile == null) {
+          logger.error('AttachmentService', '图片压缩失败');
+          return null;
+        }
+        savedFile = compressedFile;
+        final imageInfo = await _getImageInfo(savedFile.path);
+        width = imageInfo?.width;
+        height = imageInfo?.height;
+        fileSize = await savedFile.length();
       }
 
-      // 获取图片尺寸
-      final imageInfo = await _getImageInfo(compressedFile.path);
-
-      // 获取文件大小
-      final fileSize = await compressedFile.length();
-
-      // 保存到数据库
+      // 保存到数据库(Drift FFI,纯 Dart,不走 platform channel,不受冻结影响)
       final repo = ref.read(repositoryProvider);
       final id = await repo.createAttachment(
         transactionId: transactionId,
         fileName: fileName,
         originalName: path.basename(sourceFile.path),
         fileSize: fileSize,
-        width: imageInfo?.width,
-        height: imageInfo?.height,
+        width: width,
+        height: height,
         sortOrder: index,
       );
 
-      logger.info('AttachmentService', '附件保存成功: $fileName');
+      logger.info('AttachmentService',
+          '附件保存成功${urgent ? "(urgent/sync copy)" : ""}: $fileName');
       return repo.getAttachmentById(id);
     } catch (e, stackTrace) {
       logger.error('AttachmentService', '保存附件失败', e, stackTrace);

--- a/lib/services/automation/auto_billing_service.dart
+++ b/lib/services/automation/auto_billing_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -135,6 +136,8 @@ class AutoBillingService {
 
     try {
       const notificationId = 1001;
+      // 最终结果(成功/失败)用独立 ID,避免 iOS 把它当成对 1001 的静默更新
+      const resultNotificationId = 1101;
 
       // 检查文件是否存在
       final file = File(imagePath);
@@ -142,15 +145,16 @@ class AutoBillingService {
       // 如果文件不存在,可能需要短暂等待
       // (无障碍服务直接截图时文件已就绪,ContentObserver 可能需要等待)
       if (!await file.exists()) {
-        print('⏳ 文件尚未就绪,等待最多${AutoBillingConfig.fileWaitTimeout}ms...');
         logger.info('AutoBilling', '文件尚未就绪，开始等待',
             '路径=$imagePath, 超时=${AutoBillingConfig.fileWaitTimeout}ms');
 
         if (showNotification) {
+          final l10n =
+              lookupAppLocalizations(PlatformDispatcher.instance.locale);
           await _showNotification(
             id: notificationId,
-            title: '✅ 检测到截图',
-            body: '正在等待文件写入...',
+            title: l10n.autoBillingNotifyDetectedTitle,
+            body: l10n.autoBillingNotifyWaitingFileBody,
           );
         }
 
@@ -169,14 +173,16 @@ class AutoBillingService {
         }
 
         if (!await file.exists() || await file.length() == 0) {
-          print('❌ 截图文件等待超时 (${waitTime}ms)');
           logger.error('AutoBilling', '截图文件等待超时',
               '路径=$imagePath, 等待时间=${waitTime}ms, 文件存在=${await file.exists()}');
           if (showNotification) {
-            await _showNotification(
-              id: notificationId,
-              title: '识别失败',
-              body: '截图文件不可用',
+            final l10n =
+                lookupAppLocalizations(PlatformDispatcher.instance.locale);
+            await _showFinalNotification(
+              progressId: notificationId,
+              finalId: resultNotificationId,
+              title: l10n.autoBillingNotifyFileUnavailableTitle,
+              body: l10n.autoBillingNotifyFileUnavailableBody,
             );
           }
           return null;
@@ -195,8 +201,9 @@ class AutoBillingService {
         if (showNotification) {
           final l10n = lookupAppLocalizations(
               PlatformDispatcher.instance.locale);
-          await _showNotification(
-            id: notificationId,
+          await _showFinalNotification(
+            progressId: notificationId,
+            finalId: resultNotificationId,
             title: l10n.aiNotConfiguredNotificationTitle,
             body: l10n.aiNotConfiguredNotificationBody,
           );
@@ -206,10 +213,12 @@ class AutoBillingService {
 
       // 更新通知：开始识别
       if (showNotification) {
+        final l10n =
+            lookupAppLocalizations(PlatformDispatcher.instance.locale);
         await _showNotification(
           id: notificationId,
-          title: '正在识别截图...',
-          body: '正在调用 AI 视觉分析支付信息,请稍候',
+          title: l10n.autoBillingNotifyRecognizingScreenshotTitle,
+          body: l10n.autoBillingNotifyVisionAnalyzingBody,
         );
       }
 
@@ -218,10 +227,13 @@ class AutoBillingService {
       if (ledgerId == null) {
         logger.error('AutoBilling', '无可用账本');
         if (showNotification) {
-          await _showNotification(
-            id: notificationId,
-            title: '❌ 自动记账失败',
-            body: '无可用账本,请先创建账本',
+          final l10n =
+              lookupAppLocalizations(PlatformDispatcher.instance.locale);
+          await _showFinalNotification(
+            progressId: notificationId,
+            finalId: resultNotificationId,
+            title: l10n.autoBillingNotifyNoLedgerTitle,
+            body: l10n.autoBillingNotifyNoLedgerBody,
           );
         }
         await _markAsProcessed(imagePath);
@@ -243,6 +255,10 @@ class AutoBillingService {
         l10n: lookupAppLocalizations(PlatformDispatcher.instance.locale),
         // 多笔截图(罕见,但 AI 可能识别出一张账单页里的多笔)时,每笔都挂
         // 同一张原图,与相册路径行为对齐。
+        //
+        // 走 urgent 模式:跳过 FlutterImageCompress(platform channel,后台冻
+        // 结时会卡)和 _getImageInfo,用 sync File.copy 几十 ms 内完成。
+        // 这样 attachment 在 perform() return 前就写完,不依赖用户开 app。
         onSaved: autoAddAttachment
             ? (txId, _) async {
                 try {
@@ -252,6 +268,7 @@ class AutoBillingService {
                     transactionId: txId,
                     sourceFile: file,
                     index: 0,
+                    urgent: true,
                   );
                   _container
                       .read(attachmentListRefreshProvider.notifier)
@@ -272,10 +289,13 @@ class AutoBillingService {
 
       if (!result.success) {
         if (showNotification) {
-          await _showNotification(
-            id: notificationId,
-            title: '❌ 识别失败',
-            body: '无法从截图提取账单信息,请检查 AI 配置或图片',
+          final l10n =
+              lookupAppLocalizations(PlatformDispatcher.instance.locale);
+          await _showFinalNotification(
+            progressId: notificationId,
+            finalId: resultNotificationId,
+            title: l10n.autoBillingNotifyRecognizeFailedTitle,
+            body: l10n.autoBillingNotifyRecognizeFailedBody,
           );
         }
         return null;
@@ -285,10 +305,13 @@ class AutoBillingService {
       await PostProcessor.runC(_container, ledgerId: ledgerId, tags: true);
 
       if (showNotification) {
-        await _showNotification(
-          id: notificationId,
-          title: _successTitle(result),
-          body: _successBody(result),
+        final l10n =
+            lookupAppLocalizations(PlatformDispatcher.instance.locale);
+        await _showFinalNotification(
+          progressId: notificationId,
+          finalId: resultNotificationId,
+          title: _successTitle(result, l10n),
+          body: _successBody(result, l10n),
         );
       }
       logger.info('AutoBilling', '自动记账成功',
@@ -322,14 +345,14 @@ class AutoBillingService {
 
     try {
       const notificationId = 1002;
+      const resultNotificationId = 1102;
+      final l10n = lookupAppLocalizations(PlatformDispatcher.instance.locale);
 
       // 兜底:AI text 未配置 → 系统通知,引导用户去配置
       if (!await AIProviderManager.isCapabilityConfigured(
           AICapabilityType.text)) {
         logger.warning('AutoBilling', 'AI text 未配置,跳过文本记账');
         if (showNotification) {
-          final l10n = lookupAppLocalizations(
-              PlatformDispatcher.instance.locale);
           await _showNotification(
             id: notificationId,
             title: l10n.aiNotConfiguredNotificationTitle,
@@ -343,8 +366,8 @@ class AutoBillingService {
       if (showNotification) {
         await _showNotification(
           id: notificationId,
-          title: '⏳ 正在识别',
-          body: '正在调用 AI 解析支付信息...',
+          title: l10n.autoBillingNotifyRecognizingTextTitle,
+          body: l10n.autoBillingNotifyTextAnalyzingBody,
         );
       }
 
@@ -352,10 +375,11 @@ class AutoBillingService {
       final ledgerId = await _resolveLedgerId();
       if (ledgerId == null) {
         if (showNotification) {
-          await _showNotification(
-            id: notificationId,
-            title: '❌ 自动记账失败',
-            body: '无可用账本,请先创建账本',
+          await _showFinalNotification(
+            progressId: notificationId,
+            finalId: resultNotificationId,
+            title: l10n.autoBillingNotifyNoLedgerTitle,
+            body: l10n.autoBillingNotifyNoLedgerBody,
           );
         }
         return null;
@@ -368,15 +392,16 @@ class AutoBillingService {
           TagSeedService.billingTypeImage, // 通知文本场景沿用 image 标签习惯
           TagSeedService.billingTypeAi,
         ],
-        l10n: lookupAppLocalizations(PlatformDispatcher.instance.locale),
+        l10n: l10n,
       );
 
       if (!result.success) {
         if (showNotification) {
-          await _showNotification(
-            id: notificationId,
-            title: '❌ 识别失败',
-            body: '未能识别出金额信息',
+          await _showFinalNotification(
+            progressId: notificationId,
+            finalId: resultNotificationId,
+            title: l10n.autoBillingNotifyRecognizeFailedTitle,
+            body: l10n.autoBillingNotifyNoAmountBody,
           );
         }
         return null;
@@ -386,20 +411,23 @@ class AutoBillingService {
       await PostProcessor.runC(_container, ledgerId: ledgerId, tags: true);
 
       if (showNotification) {
-        await _showNotification(
-          id: notificationId,
-          title: _successTitle(result),
-          body: _successBody(result),
+        await _showFinalNotification(
+          progressId: notificationId,
+          finalId: resultNotificationId,
+          title: _successTitle(result, l10n),
+          body: _successBody(result, l10n),
         );
       }
       return result.firstTransactionId;
     } catch (e) {
       logger.error('AutoBilling', '文本处理失败', e);
       if (showNotification) {
+        final l10n =
+            lookupAppLocalizations(PlatformDispatcher.instance.locale);
         await _showNotification(
           id: 1002,
-          title: '❌ 处理失败',
-          body: '错误: $e',
+          title: l10n.autoBillingNotifyProcessFailedTitle,
+          body: l10n.autoBillingNotifyProcessFailedBody(e.toString()),
         );
       }
       return null;
@@ -411,20 +439,24 @@ class AutoBillingService {
   }
 
   /// 通知标题统一格式
-  String _successTitle(BookkeepingResult result) {
+  String _successTitle(BookkeepingResult result, AppLocalizations l10n) {
     if (result.isMulti) {
-      return '✅ 自动记账成功 ${result.savedCount} 笔';
+      return l10n.autoBillingNotifySuccessMultiTitle(result.savedCount);
     }
-    return '✅ 自动记账成功 ¥${result.totalAbsAmount.toStringAsFixed(2)}';
+    return l10n.autoBillingNotifySuccessSingleTitle(
+        result.totalAbsAmount.toStringAsFixed(2));
   }
 
   /// 通知正文统一格式
-  String _successBody(BookkeepingResult result) {
+  String _successBody(BookkeepingResult result, AppLocalizations l10n) {
     if (result.isMulti) {
-      return '合计 ¥${result.totalAbsAmount.toStringAsFixed(2)}';
+      return l10n.autoBillingNotifySuccessMultiBody(
+          result.totalAbsAmount.toStringAsFixed(2));
     }
     final note = result.firstBill?.note;
-    return (note != null && note.isNotEmpty) ? '备注: $note' : '已自动创建记录';
+    return (note != null && note.isNotEmpty)
+        ? l10n.autoBillingNotifySuccessSingleBodyNote(note)
+        : l10n.autoBillingNotifySuccessSingleBodyDefault;
   }
 
   /// 显示通知
@@ -449,6 +481,26 @@ class AutoBillingService {
     );
 
     await _notificationsPlugin.show(id, title, body, details);
+  }
+
+  /// 显示「最终结果」通知。
+  ///
+  /// iOS 上,**用同一 ID 重复 `show()` 只会静默更新通知中心条目,不会重新弹
+  /// banner**。所以「正在识别 → 成功/失败」如果共用 ID,用户只能看到第一条
+  /// banner,直到进通知中心才看到结果。
+  ///
+  /// 这个方法用**新 ID** 发结果通知,iOS 把它当作新通知重新弹 banner。
+  /// 不 cancel 旧的「正在识别」—— 实测在 AppIntent background-launch 状态下
+  /// cancel + show 紧挨着的组合 iOS 会把它当成一次「替换」处理,banner 不弹;
+  /// 留着旧的反而能保证新的作为独立通知正常弹出(旧的在结果通知出现后用户可自
+  /// 行清理或自然过期)。
+  Future<void> _showFinalNotification({
+    required int progressId,
+    required int finalId,
+    required String title,
+    required String body,
+  }) async {
+    await _showNotification(id: finalId, title: title, body: body);
   }
 
   /// 释放资源(AI 服务无 native handle,不需要 dispose,保留方法以备后续添加)

--- a/lib/services/platform/app_link_service.dart
+++ b/lib/services/platform/app_link_service.dart
@@ -145,6 +145,10 @@ class AppLinkService {
   static const EventChannel _eventChannel =
       EventChannel('com.beecount.app_intents/events');
 
+  /// iOS AppIntents 方法通道(回调 Swift,告知后台处理已完成可以放 perform 返回)
+  static const MethodChannel _methodChannel =
+      MethodChannel('com.beecount.app_intents');
+
   /// AppIntents 事件订阅
   StreamSubscription<dynamic>? _appIntentSubscription;
 
@@ -215,6 +219,17 @@ class AppLinkService {
       logger.info('AppLink', '快捷指令截图记账完成');
     } catch (e, st) {
       logger.error('AppLink', '快捷指令截图记账失败', e, st);
+    } finally {
+      // iOS: 通知 Swift AppIntent 处理完成,可以放 perform() 返回了。
+      // 不发这个信号的话 perform() 会一直 await(直到 25s 超时),iOS 在 30s
+      // 后台窗口内会 kill 进程,「成功」通知发不出去。
+      if (Platform.isIOS) {
+        try {
+          await _methodChannel.invokeMethod('notifyBillingComplete');
+        } catch (e) {
+          logger.warning('AppLink', '通知 Swift 完成信号失败: $e');
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Related #162

iOS 快捷指令触发截图自动记账,改为**后台静默**:截图 → 系统通知,app 不再被拉到前台。

## 解决的核心问题

之前 `openAppWhenRun = true`,快捷指令必把 BeeCount 拉到前台。用户痛点:
- 任何场景截图(支付、随手记)都要中断当前 app
- 体感「记账打断生活流」

## 实施细节(三个隐藏陷阱)

| 陷阱 | 解决 |
|---|---|
| **iOS 过早 kill 后台 launch 进程** —— perform() return 后 isolate 立即被冻结 | Swift `waitForBillingComplete()` 用 Continuation 等 Flutter 完成信号才 return |
| **同 ID 重复 show notification 只静默更新通知中心,不重弹 banner** | 「进行中」与「最终结果」用不同 ID(1001→1101, 1002→1102) |
| **`FlutterImageCompress` / `ui.instantiateImageCodec` 是 platform channel,后台 launch app 被推到 background 后会被冻结**,实测 attachment 保存卡 2 分钟直到用户开 app | `AttachmentService.saveAttachment(urgent: true)` 跳过压缩,改用 `File.copySync()` + `lengthSync()` 纯 Dart sync 实现,几十 ms 完成 |

## 文件改动

- ios/Runner/AppIntentsBridge.swift -- 加 waitForBillingComplete + notifyBillingComplete handler
- ios/Runner/AutoBillingAppIntent.swift -- openAppWhenRun = false,perform() await Flutter
- lib/services/platform/app_link_service.dart -- finally 块回调 Swift 完成信号
- lib/services/automation/auto_billing_service.dart -- 拆通知 ID,文案 i18n,attachment urgent 模式
- lib/services/attachment_service.dart -- 新增 urgent 参数
- lib/services/ai/ai_bookkeeper.dart -- _persistAll 中 onSaved 优先于 enrich
- lib/l10n/app_{zh,en,zh_TW}.arb -- 新增 15 个 autoBillingNotify* key
- .docs/ios-auto-billing-background/README.md -- 调研沉淀同步更新

## Related issue

- **#162** 「快捷指令第一次不触发」—— 没确定根因是不是同一个,但 background launch + Continuation 等待机制会减少时序相关 race condition,这个 PR 顺带可能改善

## Test plan

- [x] flutter analyze 0 error
- [x] iOS 真机:截图(双击背部 / 控制中心 Shortcut)→ app 不弹出前台 → 「正在识别」通知 → 「✅ 自动记账成功」通知 → 打开 app 可见 transaction 和 attachment
- [x] 验证 attachment 即时关联(不再需要打开 app 才补)
- [x] Console.app 日志确认:[AppIntentsBridge] perform() 等待 Flutter 处理完成 → 收到 Flutter 处理完成信号 链路完整