### PR TITLE
fix(sync): 同名实体抛错兜底 + seed 确定性 syncId + 业务代码走 repo

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -209,8 +209,7 @@ class _BeeAppState extends ConsumerState<BeeApp>
         //     a. fast skip:无 unpushed change + 已在远端 → 跳
         //     b. 否则:uploadAttachments + push + downloadAttachments
         //   并发限制由 SQLite mutex 自然控制(Drift 内部排队,不会真并发写)
-        final db = ref.read(databaseProvider);
-        final ledgers = await db.select(db.ledgers).get();
+        final ledgers = await ref.read(repositoryProvider).getAllLedgers();
         if (ledgers.isEmpty) {
           logger.info('AppStart', '本地无账本,跳过首次同步');
           return;

--- a/lib/data/repositories/account_repository.dart
+++ b/lib/data/repositories/account_repository.dart
@@ -24,7 +24,9 @@ abstract class AccountRepository {
   /// 按币种分组获取账户统计
   Future<Map<String, List<Account>>> getAccountsGroupedByCurrency();
 
-  /// 创建账户
+  /// 创建账户。撞同名抛 [DuplicateNameException](name 全局唯一)。
+  /// 静默路径(import / app-link 等)请用 [upsertAccount](get-or-create 语义)。
+  /// [syncId] 可选:seed 类路径显式塞确定性 id,UI 不传走 auto v4。
   Future<int> createAccount({
     required int ledgerId,
     required String name,
@@ -37,6 +39,20 @@ abstract class AccountRepository {
     String? bankName,
     String? cardLastFour,
     String? note,
+    String? syncId,
+  });
+
+  /// 按 name 取账户(name 全局唯一,账户跨账本可用);不存在则建一条。
+  /// 给 import / app-link 等 get-or-create 语义的静默路径用 —— 不会抛
+  /// [DuplicateNameException]。
+  ///
+  /// [ledgerId] 是 legacy 字段(早期 schema 残留),账户实际跨账本可用,默认 0。
+  Future<int> upsertAccount({
+    required String name,
+    int ledgerId = 0,
+    String type = 'cash',
+    String currency = 'CNY',
+    double initialBalance = 0.0,
   });
 
   /// 更新账户
@@ -151,4 +167,12 @@ abstract class AccountRepository {
 
   /// 更新估值账户的当前估值
   Future<void> updateAccountValuation(int accountId, double newValue);
+
+  // ============================================
+  // 共享账本(§7 / v25)— 跨设备共享的 SharedLedgerAccounts 表
+  // ============================================
+
+  /// 按 syncId 查 SharedLedgerAccounts 行;Editor 视角下 tx 的
+  /// accountSyncIdOverride 走这条反查 → 上层再映射成 synthetic Account。
+  Future<SharedLedgerAccount?> getSharedAccountBySyncId(String syncId);
 }

--- a/lib/data/repositories/category_repository.dart
+++ b/lib/data/repositories/category_repository.dart
@@ -3,21 +3,31 @@ import '../db.dart';
 /// 分类Repository接口
 /// 定义分类相关的所有数据操作
 abstract class CategoryRepository {
-  /// 创建分类
+  /// 创建分类。撞同名抛 [DuplicateNameException](name 全局唯一)—— UI 主动
+  /// 建应已先过 [isCategoryNameDuplicate];import / 自动记账等静默路径要 get-or-
+  /// create 语义请用 [upsertCategory]。
+  ///
+  /// 可选 [syncId] / [level] / [parentId]:给 seed 这种需要显式塞确定性
+  /// syncId / 指定层级和父级的路径用;UI 主动建一般不传(走默认 L1 + auto v4 id)。
   Future<int> createCategory({
     required String name,
     required String kind,
     String? icon,
     int? sortOrder,
+    int level = 1,
+    int? parentId,
+    String? syncId,
   });
 
-  /// 创建二级分类
+  /// 创建二级分类。撞同名同样抛 [DuplicateNameException]。
+  /// [syncId] 同 [createCategory]:可选,seed 显式传,UI 不传走 auto v4。
   Future<int> createSubCategory({
     required int parentId,
     required String name,
     required String kind,
     String? icon,
     int? sortOrder,
+    String? syncId,
   });
 
   /// 更新分类
@@ -37,10 +47,14 @@ abstract class CategoryRepository {
   /// 批量删除分类
   Future<void> deleteCategoriesByIds(List<int> ids);
 
-  /// Upsert分类（根据名称和kind查找或创建）
+  /// 按 name 取分类(name 全局唯一);不存在则按给定 kind/icon/sortOrder 建一条。
+  /// 命中已存在时,icon/sortOrder 参数被忽略 —— 保留已有那条的元数据(在 name
+  /// 全局唯一模型下,"X" 是同一个分类,不该被外部 import 覆盖图标/排序)。
   Future<int> upsertCategory({
     required String name,
     required String kind,
+    String? icon,
+    int? sortOrder,
   });
 
   /// 根据ID获取分类

--- a/lib/data/repositories/exceptions.dart
+++ b/lib/data/repositories/exceptions.dart
@@ -1,0 +1,33 @@
+/// Repository 层的异常类型。
+///
+/// 用于让 caller 把"撞了不允许的状态"显式 handle,而不是被静默吞掉。
+library;
+
+/// 创建实体时撞了已有的同名条目。
+///
+/// 抛它的场景:`createCategory` / `createSubCategory` / `createTag` /
+/// `createAccount` 撞到本地已有同名行(name 全局唯一)。caller 应该:
+///   - **UI 主动建**:弹 toast 提示用户改名(同名 UI 警告也在挡)。
+///   - **非交互路径**(import / app-link / 自动记账等):改用 `upsertX`
+///     —— get-or-create 语义,按 name 匹配。
+///
+/// 历史的"撞同名静默复用"做法已废弃 —— 那会把收入 tx 错挂到 expense 分类,
+/// 或者把 caller 传的 icon/sortOrder 静默吞掉,排查极难。fail-loud 才能让
+/// 这类 bug 第一时间冒出来。
+class DuplicateNameException implements Exception {
+  const DuplicateNameException({
+    required this.entityType,
+    required this.name,
+    this.existingId,
+  });
+
+  /// 'category' / 'account' / 'tag' — 给日志和上层 UI 区分。
+  final String entityType;
+  final String name;
+  final int? existingId;
+
+  @override
+  String toString() =>
+      'DuplicateNameException: $entityType "$name" already exists'
+      '${existingId != null ? ' (id=$existingId)' : ''}';
+}

--- a/lib/data/repositories/local/local_account_repository.dart
+++ b/lib/data/repositories/local/local_account_repository.dart
@@ -5,6 +5,7 @@ import '../../db.dart';
 import '../../../services/system/logger_service.dart';
 import '../../../utils/account_type_utils.dart';
 import '../account_repository.dart';
+import '../exceptions.dart';
 
 /// 本地账户Repository实现
 /// 基于 Drift 数据库实现
@@ -93,7 +94,19 @@ class LocalAccountRepository implements AccountRepository {
     String? bankName,
     String? cardLastFour,
     String? note,
+    String? syncId,
   }) async {
+    // 撞同名抛 DuplicateNameException(name 全局唯一)。静默路径(import /
+    // app-link 等)请改用 [upsertAccount]。
+    final existingByName =
+        await (db.select(db.accounts)..where((a) => a.name.equals(name))).get();
+    if (existingByName.isNotEmpty) {
+      throw DuplicateNameException(
+        entityType: 'account',
+        name: name,
+        existingId: existingByName.first.id,
+      );
+    }
     try {
       // 计算同类型最大 sortOrder + 1
       final maxSortOrderResult = await db.customSelect(
@@ -117,7 +130,7 @@ class LocalAccountRepository implements AccountRepository {
         bankName: d.Value(bankName),
         cardLastFour: d.Value(cardLastFour),
         note: d.Value(note),
-        syncId: d.Value(_uuid.v4()),
+        syncId: d.Value(syncId ?? _uuid.v4()),
       );
 
       final id = await db.into(db.accounts).insert(companion);
@@ -129,6 +142,28 @@ class LocalAccountRepository implements AccountRepository {
       logger.error('AccountCreate', '创建账户失败 name=$name', e, stack);
       rethrow;
     }
+  }
+
+  @override
+  Future<int> upsertAccount({
+    required String name,
+    int ledgerId = 0,
+    String type = 'cash',
+    String currency = 'CNY',
+    double initialBalance = 0.0,
+  }) async {
+    final existing = await (db.select(db.accounts)
+          ..where((a) => a.name.equals(name)))
+        .get();
+    if (existing.isNotEmpty) return existing.first.id;
+    // 复用 createAccount(此时 name 不冲突,不会抛)
+    return createAccount(
+      ledgerId: ledgerId,
+      name: name,
+      type: type,
+      currency: currency,
+      initialBalance: initialBalance,
+    );
   }
 
   @override
@@ -816,5 +851,12 @@ class LocalAccountRepository implements AccountRepository {
         updatedAt: d.Value(DateTime.now()),
       ),
     );
+  }
+
+  @override
+  Future<SharedLedgerAccount?> getSharedAccountBySyncId(String syncId) {
+    return (db.select(db.sharedLedgerAccounts)
+          ..where((t) => t.syncId.equals(syncId)))
+        .getSingleOrNull();
   }
 }

--- a/lib/data/repositories/local/local_category_repository.dart
+++ b/lib/data/repositories/local/local_category_repository.dart
@@ -11,6 +11,7 @@ import '../../category_node.dart';
 import '../../../services/system/logger_service.dart';
 import '../../../utils/shared_ledger_picker_filter.dart';
 import '../category_repository.dart';
+import '../exceptions.dart';
 
 /// 本地分类Repository实现
 /// 基于 Drift 数据库实现
@@ -26,14 +27,33 @@ class LocalCategoryRepository implements CategoryRepository {
     required String kind,
     String? icon,
     int? sortOrder,
+    int level = 1,
+    int? parentId,
+    String? syncId,
   }) async {
+    // 撞同名抛 DuplicateNameException(name 全局唯一)。caller 显式 handle:
+    //   - UI 主动建 → 先过 isCategoryNameDuplicate 警告;真冲突 try/catch 弹 toast
+    //   - import / 自动记账等静默路径 → 改用 upsertCategory(get-or-create)
+    // 静默复用会把收入 tx 错挂到 expense 分类或吞掉 caller 传的 icon/sortOrder。
+    final existing = await (db.select(db.categories)
+          ..where((c) => c.name.equals(name)))
+        .get();
+    if (existing.isNotEmpty) {
+      throw DuplicateNameException(
+        entityType: 'category',
+        name: name,
+        existingId: existing.first.id,
+      );
+    }
     return await db.into(db.categories).insert(
       CategoriesCompanion.insert(
         name: name,
         kind: kind,
         icon: d.Value(icon),
         sortOrder: d.Value(sortOrder ?? 0),
-        syncId: d.Value(_uuid.v4()),
+        level: d.Value(level),
+        parentId: d.Value(parentId),
+        syncId: d.Value(syncId ?? _uuid.v4()),
       ),
     );
   }
@@ -45,7 +65,18 @@ class LocalCategoryRepository implements CategoryRepository {
     required String kind,
     String? icon,
     int? sortOrder,
+    String? syncId,
   }) async {
+    final existing = await (db.select(db.categories)
+          ..where((c) => c.name.equals(name)))
+        .get();
+    if (existing.isNotEmpty) {
+      throw DuplicateNameException(
+        entityType: 'category',
+        name: name,
+        existingId: existing.first.id,
+      );
+    }
     return await db.into(db.categories).insert(
       CategoriesCompanion.insert(
         name: name,
@@ -54,7 +85,7 @@ class LocalCategoryRepository implements CategoryRepository {
         parentId: d.Value(parentId),
         level: d.Value(2),
         sortOrder: d.Value(sortOrder ?? 0),
-        syncId: d.Value(_uuid.v4()),
+        syncId: d.Value(syncId ?? _uuid.v4()),
       ),
     );
   }
@@ -169,13 +200,21 @@ class LocalCategoryRepository implements CategoryRepository {
   Future<int> upsertCategory({
     required String name,
     required String kind,
+    String? icon,
+    int? sortOrder,
   }) async {
+    // name 全局唯一:按 name 找;有则复用,无则用给定 kind/icon/sortOrder 建。
     final existing = await (db.select(db.categories)
-          ..where((c) => c.name.equals(name) & c.kind.equals(kind)))
-        .getSingleOrNull();
-    if (existing != null) return existing.id;
+          ..where((c) => c.name.equals(name)))
+        .get();
+    if (existing.isNotEmpty) return existing.first.id;
     return db.into(db.categories).insert(CategoriesCompanion.insert(
-        name: name, kind: kind, icon: const d.Value(null), syncId: d.Value(_uuid.v4())));
+      name: name,
+      kind: kind,
+      icon: d.Value(icon),
+      sortOrder: d.Value(sortOrder ?? 0),
+      syncId: d.Value(_uuid.v4()),
+    ));
   }
 
   @override

--- a/lib/data/repositories/local/local_repository.dart
+++ b/lib/data/repositories/local/local_repository.dart
@@ -794,8 +794,24 @@ class LocalRepository extends BaseRepository {
   // ============================================
 
   @override
-  Future<int> createCategory({required String name, required String kind, String? icon, int? sortOrder}) async {
-    final id = await _categoryRepo.createCategory(name: name, kind: kind, icon: icon, sortOrder: sortOrder);
+  Future<int> createCategory({
+    required String name,
+    required String kind,
+    String? icon,
+    int? sortOrder,
+    int level = 1,
+    int? parentId,
+    String? syncId,
+  }) async {
+    final id = await _categoryRepo.createCategory(
+      name: name,
+      kind: kind,
+      icon: icon,
+      sortOrder: sortOrder,
+      level: level,
+      parentId: parentId,
+      syncId: syncId,
+    );
     if (changeTracker != null) {
       final cat = await _categoryRepo.getCategoryById(id);
       if (cat?.syncId != null) {
@@ -815,9 +831,11 @@ class LocalRepository extends BaseRepository {
     required String kind,
     String? icon,
     int? sortOrder,
+    String? syncId,
   }) async {
     final id = await _categoryRepo.createSubCategory(
-      parentId: parentId, name: name, kind: kind, icon: icon, sortOrder: sortOrder,
+      parentId: parentId, name: name, kind: kind, icon: icon,
+      sortOrder: sortOrder, syncId: syncId,
     );
     if (changeTracker != null) {
       final cat = await _categoryRepo.getCategoryById(id);
@@ -894,8 +912,14 @@ class LocalRepository extends BaseRepository {
   }
 
   @override
-  Future<int> upsertCategory({required String name, required String kind}) =>
-      _categoryRepo.upsertCategory(name: name, kind: kind);
+  Future<int> upsertCategory({
+    required String name,
+    required String kind,
+    String? icon,
+    int? sortOrder,
+  }) =>
+      _categoryRepo.upsertCategory(
+          name: name, kind: kind, icon: icon, sortOrder: sortOrder);
 
   @override
   Future<Category?> getCategoryById(int categoryId) =>
@@ -1289,6 +1313,7 @@ class LocalRepository extends BaseRepository {
     String? bankName,
     String? cardLastFour,
     String? note,
+    String? syncId,
   }) async {
     final id = await _accountRepo.createAccount(
       ledgerId: ledgerId,
@@ -1302,6 +1327,7 @@ class LocalRepository extends BaseRepository {
       bankName: bankName,
       cardLastFour: cardLastFour,
       note: note,
+      syncId: syncId,
     );
     if (changeTracker != null) {
       final account = await _accountRepo.getAccount(id);
@@ -1315,6 +1341,28 @@ class LocalRepository extends BaseRepository {
       }
     }
     return id;
+  }
+
+  @override
+  Future<int> upsertAccount({
+    required String name,
+    int ledgerId = 0,
+    String type = 'cash',
+    String currency = 'CNY',
+    double initialBalance = 0.0,
+  }) async {
+    // 委托底层 upsert(同名复用)。新建分支会自动记 sync change(走 createAccount
+    // 已有逻辑);复用分支已有 syncId、不需要再记 create。
+    final existing = await _accountRepo.getAllAccounts();
+    final hit = existing.where((a) => a.name == name).toList();
+    if (hit.isNotEmpty) return hit.first.id;
+    return createAccount(
+      ledgerId: ledgerId,
+      name: name,
+      type: type,
+      currency: currency,
+      initialBalance: initialBalance,
+    );
   }
 
   @override
@@ -1548,6 +1596,10 @@ class LocalRepository extends BaseRepository {
   @override
   Future<void> updateAccountValuation(int accountId, double newValue) =>
       _accountRepo.updateAccountValuation(accountId, newValue);
+
+  @override
+  Future<SharedLedgerAccount?> getSharedAccountBySyncId(String syncId) =>
+      _accountRepo.getSharedAccountBySyncId(syncId);
 
   // ============================================
   // StatisticsRepository 接口实现 - 委托给 LocalStatisticsRepository
@@ -1832,8 +1884,10 @@ class LocalRepository extends BaseRepository {
     required String name,
     String? color,
     int sortOrder = 0,
+    String? syncId,
   }) async {
-    final id = await _tagRepo.createTag(name: name, color: color, sortOrder: sortOrder);
+    final id = await _tagRepo.createTag(
+        name: name, color: color, sortOrder: sortOrder, syncId: syncId);
     if (changeTracker != null) {
       final tag = await _tagRepo.getTagById(id);
       if (tag?.syncId != null) {
@@ -1844,6 +1898,17 @@ class LocalRepository extends BaseRepository {
       }
     }
     return id;
+  }
+
+  @override
+  Future<int> upsertTag({
+    required String name,
+    String? color,
+  }) async {
+    // 委托底层 upsert;新建分支走 createTag 自动记 sync change。
+    final existing = await _tagRepo.getTagByName(name);
+    if (existing != null) return existing.id;
+    return createTag(name: name, color: color);
   }
 
   @override

--- a/lib/data/repositories/local/local_tag_repository.dart
+++ b/lib/data/repositories/local/local_tag_repository.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart' as d;
 import 'package:uuid/uuid.dart';
 
 import '../../db.dart';
+import '../exceptions.dart';
 import '../tag_repository.dart';
 
 /// 本地标签Repository实现
@@ -21,12 +22,42 @@ class LocalTagRepository implements TagRepository {
     required String name,
     String? color,
     int sortOrder = 0,
+    String? syncId,
   }) async {
+    // 撞同名抛 DuplicateNameException(name 全局唯一)。静默路径(import /
+    // 自动记账等)请改用 [upsertTag]。
+    final existing =
+        await (db.select(db.tags)..where((t) => t.name.equals(name))).get();
+    if (existing.isNotEmpty) {
+      throw DuplicateNameException(
+        entityType: 'tag',
+        name: name,
+        existingId: existing.first.id,
+      );
+    }
     return await db.into(db.tags).insert(
       TagsCompanion.insert(
         name: name,
         color: d.Value(color),
         sortOrder: d.Value(sortOrder),
+        syncId: d.Value(syncId ?? _uuid.v4()),
+      ),
+    );
+  }
+
+  @override
+  Future<int> upsertTag({
+    required String name,
+    String? color,
+  }) async {
+    final existing =
+        await (db.select(db.tags)..where((t) => t.name.equals(name))).get();
+    if (existing.isNotEmpty) return existing.first.id;
+    return await db.into(db.tags).insert(
+      TagsCompanion.insert(
+        name: name,
+        color: d.Value(color),
+        sortOrder: const d.Value(0),
         syncId: d.Value(_uuid.v4()),
       ),
     );

--- a/lib/data/repositories/tag_repository.dart
+++ b/lib/data/repositories/tag_repository.dart
@@ -7,11 +7,21 @@ abstract class TagRepository {
   // 基础 CRUD 操作
   // ============================================
 
-  /// 创建标签
+  /// 创建标签。撞同名抛 [DuplicateNameException](name 全局唯一)。
+  /// 静默路径(import / 自动记账等)请用 [upsertTag](get-or-create 语义)。
+  /// [syncId] 可选:seed 类路径显式塞确定性 id,UI 不传走 auto v4。
   Future<int> createTag({
     required String name,
     String? color,
     int sortOrder = 0,
+    String? syncId,
+  });
+
+  /// 按 name 取标签;不存在则建一条。给 import / 自动记账等 get-or-create
+  /// 语义的静默路径用 —— 不会抛 [DuplicateNameException]。
+  Future<int> upsertTag({
+    required String name,
+    String? color,
   });
 
   /// 更新标签

--- a/lib/pages/main/ledgers_page_new.dart
+++ b/lib/pages/main/ledgers_page_new.dart
@@ -13,7 +13,6 @@ import '../../models/ledger_display_item.dart';
 import '../../cloud/transactions_sync_manager.dart';
 import '../../cloud/sync_service.dart';
 import '../../cloud/sync/sync_engine.dart';
-import '../../data/repositories/local/local_repository.dart';
 import '../../widgets/ui/ui.dart';
 import '../../widgets/biz/biz.dart';
 import '../cloud/member_list_page.dart';
@@ -568,56 +567,32 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
     } else if (action == 'members') {
       // 跳转成员管理 — 需要 ledger.syncId(server external_id)。本地仅 ledger
       // (没 syncId,从未同步过的)无成员概念,提示用户先建云账户。
-      // 拿 ledger.syncId(用 LocalRepository 直查;repositoryProvider 在 cloud
-      // 模式可能是 CloudRepository,这里需要本地)
-      final localRepo = ref.read(repositoryProvider);
-      String? syncId;
-      if (localRepo is LocalRepository) {
-        final raw = await localRepo.db.select(localRepo.db.ledgers)
-            .map((l) => (id: l.id, syncId: l.syncId))
-            .get();
-        final entry = raw.firstWhere(
-          (e) => e.id == ledger.id,
-          orElse: () => (id: 0, syncId: null),
-        );
-        syncId = entry.syncId;
-      }
+      final row = await ref.read(repositoryProvider).getLedgerById(ledger.id);
+      final syncId = row?.syncId;
       if (syncId == null || syncId.isEmpty) {
         if (mounted) showToast(context, AppLocalizations.of(context).sharedRequiresCloudSync);
         return;
       }
-      final extId = syncId;
       if (mounted) {
         await Navigator.of(context).push(MaterialPageRoute(
           builder: (_) => MemberListPage(
-            ledgerExternalId: extId,
+            ledgerExternalId: syncId,
             ledgerName: ledger.name,
           ),
         ));
       }
     } else if (action == 'memberStats') {
       // 跟成员管理同源:取 ledger.syncId 再跳 MemberStatsPage。
-      final localRepo = ref.read(repositoryProvider);
-      String? syncId;
-      if (localRepo is LocalRepository) {
-        final raw = await localRepo.db.select(localRepo.db.ledgers)
-            .map((l) => (id: l.id, syncId: l.syncId))
-            .get();
-        final entry = raw.firstWhere(
-          (e) => e.id == ledger.id,
-          orElse: () => (id: 0, syncId: null),
-        );
-        syncId = entry.syncId;
-      }
+      final row = await ref.read(repositoryProvider).getLedgerById(ledger.id);
+      final syncId = row?.syncId;
       if (syncId == null || syncId.isEmpty) {
         if (mounted) showToast(context, AppLocalizations.of(context).sharedRequiresCloudSync);
         return;
       }
-      final extId = syncId;
       if (mounted) {
         await Navigator.of(context).push(MaterialPageRoute(
           builder: (_) => MemberStatsPage(
-            ledgerExternalId: extId,
+            ledgerExternalId: syncId,
             ledgerName: ledger.name,
           ),
         ));

--- a/lib/providers/database_providers.dart
+++ b/lib/providers/database_providers.dart
@@ -163,10 +163,7 @@ final accountForTxProvider =
   }
   final ov = key.syncIdOverride;
   if (ov == null || ov.isEmpty) return null;
-  if (repo is! LocalRepository) return null;
-  final shared = await (repo.db.select(repo.db.sharedLedgerAccounts)
-        ..where((t) => t.syncId.equals(ov)))
-      .getSingleOrNull();
+  final shared = await repo.getSharedAccountBySyncId(ov);
   if (shared == null) return null;
   return Account(
     // 用 syntheticIdForSyncId 而不是 -1 — 跟 picker / 详情页路径统一,

--- a/lib/services/data/seed_service.dart
+++ b/lib/services/data/seed_service.dart
@@ -2,11 +2,34 @@ import '../../data/db.dart';
 import '../../l10n/app_localizations.dart';
 import '../system/logger_service.dart';
 import 'package:drift/drift.dart';
+import 'package:uuid/uuid.dart';
 
 /// 种子数据服务
 /// 负责生成应用初始化时的默认数据（账本、账户、分类等）
 class SeedService {
   SeedService._();
+
+  /// 固定命名空间,给默认 seed 数据生成**确定性** syncId(uuid v5)。
+  /// ⚠️ 不要改这个常量 —— 改了会让同一份默认数据在新老版本算出不同 syncId,
+  /// 反而制造重复。
+  static const _seedSyncNamespace = 'b3e7c0de-0000-4000-8000-beec00000001';
+  static const _seedUuid = Uuid();
+
+  /// 默认分类的确定性 syncId。key 用**稳定的 seed key**(不是翻译后的名字),
+  /// 这样任何设备、任何语言 seed 出来的同一个默认分类都得到同一个 syncId,
+  /// 云端按 syncId 天然只留一份 —— 从源头杜绝多设备各自 seed 造成的重复。
+  /// 收敛存量重复时的 keeper 规则见 data/repositories/entity_dedup.dart。
+  static String deterministicCategorySyncId({
+    required String kind,
+    required int level,
+    required String key,
+  }) =>
+      _seedUuid.v5(_seedSyncNamespace, 'cat:$kind:$level:$key');
+
+  /// 默认账户的确定性 syncId。seed 每个 type(cash/bank_card/credit_card)
+  /// 恰好一个,用 type 作 key。
+  static String deterministicAccountSyncId(String type) =>
+      _seedUuid.v5(_seedSyncNamespace, 'acc:$type');
 
   // ========== 一级分类模式的默认分类 key ==========
 
@@ -401,6 +424,7 @@ class SeedService {
         type: const Value('cash'),
         currency: Value(currency),
         initialBalance: const Value(0.0),
+        syncId: Value(deterministicAccountSyncId('cash')),
       ),
     );
 
@@ -412,6 +436,7 @@ class SeedService {
         type: const Value('bank_card'),
         currency: Value(currency),
         initialBalance: const Value(0.0),
+        syncId: Value(deterministicAccountSyncId('bank_card')),
       ),
     );
 
@@ -423,6 +448,7 @@ class SeedService {
         type: const Value('credit_card'),
         currency: Value(currency),
         initialBalance: const Value(0.0),
+        syncId: Value(deterministicAccountSyncId('credit_card')),
       ),
     );
   }
@@ -597,6 +623,8 @@ class SeedService {
           icon: Value(getDefaultIcon(key)),
           sortOrder: Value(i),
           level: const Value(1),
+          syncId: Value(
+              deterministicCategorySyncId(kind: 'expense', level: 1, key: key)),
         ),
       );
     }
@@ -615,6 +643,8 @@ class SeedService {
           icon: Value(getDefaultIcon(key)),
           sortOrder: Value(i),
           level: const Value(1),
+          syncId: Value(
+              deterministicCategorySyncId(kind: 'income', level: 1, key: key)),
         ),
       );
     }
@@ -639,6 +669,8 @@ class SeedService {
           icon: Value(getDefaultIcon(parentKey)),
           sortOrder: Value(sortOrder++),
           level: const Value(1),
+          syncId: Value(deterministicCategorySyncId(
+              kind: 'expense', level: 1, key: parentKey)),
         ),
       );
 
@@ -657,6 +689,8 @@ class SeedService {
             sortOrder: Value(i),
             level: const Value(2),
             parentId: Value(parentId),
+            syncId: Value(deterministicCategorySyncId(
+                kind: 'expense', level: 2, key: childKey)),
           ),
         );
       }
@@ -679,6 +713,8 @@ class SeedService {
           icon: Value(getDefaultIcon(parentKey)),
           sortOrder: Value(sortOrder++),
           level: const Value(1),
+          syncId: Value(deterministicCategorySyncId(
+              kind: 'income', level: 1, key: parentKey)),
         ),
       );
 
@@ -697,6 +733,8 @@ class SeedService {
             sortOrder: Value(i),
             level: const Value(2),
             parentId: Value(parentId),
+            syncId: Value(deterministicCategorySyncId(
+                kind: 'income', level: 2, key: childKey)),
           ),
         );
       }
@@ -783,6 +821,8 @@ class SeedService {
         icon: const Value('swap_horiz'), // 默认图标
         sortOrder: const Value(-1), // 使用负数排序，确保不会影响正常分类
         level: const Value(1),
+        syncId: Value(deterministicCategorySyncId(
+            kind: 'transfer', level: 1, key: 'transfer')),
       ),
     );
 

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -6,7 +6,6 @@ import 'package:flutter_cloud_sync/flutter_cloud_sync.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:beecount/widgets/ui/wheel_date_picker.dart';
 import '../../data/db.dart';
-import '../../data/repositories/local/local_repository.dart';
 import '../../providers/shared_ledger_providers.dart';
 import '../../styles/tokens.dart';
 import '../../l10n/app_localizations.dart';
@@ -46,15 +45,9 @@ class _TxAuthorInfo {
 final _txAuthorInfoProvider =
     FutureProvider.autoDispose.family<_TxAuthorInfo?, int>((ref, txId) async {
   final repo = ref.watch(repositoryProvider);
-  if (repo is! LocalRepository) return null;
-  final db = repo.db;
-  final tx = await (db.select(db.transactions)
-        ..where((t) => t.id.equals(txId)))
-      .getSingleOrNull();
+  final tx = await repo.getTransactionById(txId);
   if (tx == null) return null;
-  final ledger = await (db.select(db.ledgers)
-        ..where((l) => l.id.equals(tx.ledgerId)))
-      .getSingleOrNull();
+  final ledger = await repo.getLedgerById(tx.ledgerId);
   if (ledger == null || !ledger.isShared) return null;
   final ledgerSyncId = ledger.syncId;
   if (ledgerSyncId == null || ledgerSyncId.isEmpty) return null;


### PR DESCRIPTION
## 背景

3.2.2 fullPull 报 `Bad state: Too many elements` 闪退,根因是跨设备同步 + seed 重跑产生**同名实体多条**(本地有 2 个 name="餐饮" / kind=expense / level=1 的分类),`getSingleOrNull` 撞 >1 行直接抛。

## 改动

### 一、底层兜底(防新增同名脏数据)

- **`create{Tag,Account,Category}` 撞同名抛 `DuplicateNameException`**(name 全局唯一)
  - 三个编辑页 UI 上已经先过 `isXNameDuplicate` 拦截,这里只是兜底,正常路径不会触发
  - 静默路径(import / app-link 等)请改用 `upsert{Tag,Account,Category}` 走 get-or-create 语义,不会抛
- **新增 `lib/data/repositories/exceptions.dart`** 定义 `DuplicateNameException`
- **seed 写入显式塞确定性 uuid v5 `syncId`**(namespace `b3e7c0de-0000-4000-8000-beec00000001`)
  - 同账号 / 同 seed key 跨设备幂等,不再因"两台设备各自 init 一次"产生 syncId 不同的同名分类

### 二、业务代码走 repo(档 1 清理)

把 4 处业务代码直接 `db.select(...)` 改走 Repository:

| 文件 | 改动 |
|---|---|
| `lib/app.dart` | 首次同步前 `db.select(ledgers)` → `repo.getAllLedgers()` |
| `lib/pages/main/ledgers_page_new.dart` | 两段 `localRepo.db.select(ledgers).firstWhere` → `repo.getLedgerById`,删 `LocalRepository` 导入 |
| `lib/widgets/biz/amount_editor_sheet.dart` | provider 里 `db.select(tx/ledger)` → `repo.getTransactionById` + `getLedgerById`,删 `LocalRepository` 导入 |
| `lib/providers/database_providers.dart` | 共享账户按 syncId 反查 → 新增的 `repo.getSharedAccountBySyncId` |

新增 1 个 repo 方法:`AccountRepository.getSharedAccountBySyncId(String syncId): Future<SharedLedgerAccount?>`(interface + LocalAccountRepository 实现 + LocalRepository 委托)。

## 验证

- `dart analyze lib` 对所有改动文件 clean,未引入新 warning/error
- pre-existing 的 `use_build_context_synchronously` 等 info 级别与本次无关

## 不在本 PR 范围

- **历史脏数据合并**:已经出现的同名分类多条,本 PR 不做被动合并(本 PR 只防新增)
- **picker / AI 命令服务 / 共享账本编辑器 override 表**等 repo 绕过点:作为已知债务记录,等下次摸到对应代码再补 repo 方法
- **fullPush 中断恢复**:per-batch markPushed 优化值得做但范围另算