### PR TITLE
fix(category): upsertCategory now matches by name AND kind

### DIFF
--- a/lib/data/repositories/local/local_category_repository.dart
+++ b/lib/data/repositories/local/local_category_repository.dart
@@ -203,9 +203,10 @@ class LocalCategoryRepository implements CategoryRepository {
     String? icon,
     int? sortOrder,
   }) async {
-    // name 全局唯一:按 name 找;有则复用,无则用给定 kind/icon/sortOrder 建。
+    // Match by name + kind to prevent same-name categories across
+    // expense/income from being incorrectly reused (e.g. 'transfer').
     final existing = await (db.select(db.categories)
-          ..where((c) => c.name.equals(name)))
+          ..where((c) => c.name.equals(name) & c.kind.equals(kind)))
         .get();
     if (existing.isNotEmpty) return existing.first.id;
     return db.into(db.categories).insert(CategoriesCompanion.insert(


### PR DESCRIPTION
## 问题

CSV 导入时，同名但不同 kind（支出/收入）的分类子类会被错误挂到另一端的父类下。

### 复现步骤

1. BeeCount 中已有支出侧和收入侧同名 L1 分类（如「转账」）
2. CSV 导入支出交易时，子类创建错误地匹配到了收入侧的父类

### 根因

`upsertCategory()` 的 WHERE 子句仅按 `name` 匹配，忽略 `kind`

### 修复

增加 `kind` 过滤。1 个文件，2 行变更。