### PR TITLE
fix(sync): fullPush / push 加 in-flight 单飞 + initial sync 节流

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -268,6 +268,19 @@ class _BeeAppState extends ConsumerState<BeeApp>
           logger.error('AppStart', 'Phase1: pull 失败', e, st);
         }
 
+        // d) 推 user-global change(account / category / tag)。
+        //    放在 Phase 2(每个 ledger 并行)之前显式跑一次,确保:
+        //    1) Phase 2 并发 push 时,各 ledger 的 _push/fullPush 调
+        //       pushUserGlobalEntities 都会复用这次的 in-flight,不会重复推
+        //    2) 即使 Phase 2 全部 fast-skip(无 ledger-scope 待推 + 已在远端),
+        //       user-global 的新增/重命名也能推上去(原来 Phase 2 skip 时会漏)
+        try {
+          final pushed = await engine.pushUserGlobalEntities();
+          logger.info('AppStart', 'Phase1: pushUserGlobalEntities pushed=$pushed');
+        } catch (e, st) {
+          logger.error('AppStart', 'Phase1: pushUserGlobalEntities 失败', e, st);
+        }
+
         // ========== Phase 2: 每个 ledger 并行 push + 附件 ==========
         final remoteSyncIds = <String>{
           if (remoteLedgers != null)

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -65,6 +65,15 @@ class _BeeAppState extends ConsumerState<BeeApp>
   static bool _isHandlingAppLink = false;
   static DateTime? _lastAppLinkHandleTime;
 
+  // _triggerInitialCloudSync 节流戳。app 启动期 microtask + listenManual
+  // 两路都会触发,曾导致 fullPush 2-3 路并发把 sync_changes 表撑膨胀 2-2.5x
+  // (详见 .docs/concurrent-fullpush-bloat.md)。5 秒内只跑第一次。
+  //
+  // 注意:fullPush / push 内部已经有 in-flight 单飞兜底,这里是防御性的第二
+  // 层 —— 避免 trigger 内的 phase 1(syncMyProfile / storage.list / pull)
+  // 重复跑浪费 HTTP。
+  DateTime? _lastInitialCloudSyncTriggeredAt;
+
   // 记账按钮相关状态
   late AnimationController _expandController;
   late Animation<double> _expandAnimation;
@@ -191,6 +200,17 @@ class _BeeAppState extends ConsumerState<BeeApp>
   }
 
   void _triggerInitialCloudSync(SyncEngine engine) {
+    // 5 秒幂等节流:microtask + listenManual 在启动期可能两路都触发,这里挡掉
+    // 第二次,phase 1 / phase 2 都只跑一次。详见 [_lastInitialCloudSyncTriggeredAt]。
+    final now = DateTime.now();
+    final last = _lastInitialCloudSyncTriggeredAt;
+    if (last != null && now.difference(last).inSeconds < 5) {
+      logger.info('AppStart',
+          '_triggerInitialCloudSync 5 秒内已触发过(${now.difference(last).inMilliseconds}ms 前),跳过');
+      return;
+    }
+    _lastInitialCloudSyncTriggeredAt = now;
+
     Future(() async {
       try {
         // 启动同步分层策略(2026-05-24 改造):

--- a/lib/cloud/sync/change_tracker.dart
+++ b/lib/cloud/sync/change_tracker.dart
@@ -118,6 +118,46 @@ class ChangeTracker {
     logger.debug('ChangeTracker', '$action $entityType($entitySyncId)');
   }
 
+  /// 登记一个**从 server pull 拉下来**的实体在本地的状态。
+  ///
+  /// 写入一条 `local_changes` 行,**pushedAt 设为 now**(表示"server 已有此
+  /// 实体,本地不需要再推")。
+  ///
+  /// 目的:fullPush 路径上 [SyncEngine._backfillLegacyUserGlobalChanges]
+  /// 通过扫 local_changes 来识别"哪些 user-global 实体已知"。pull apply 进
+  /// 来的实体如果不登记,legacy backfill 会误判为"v18→v19 老数据"并补登记 →
+  /// 第二台设备同步时把 server 已有的 user-global 实体重新推一遍 → server
+  /// sync_changes 表 2x 膨胀。
+  ///
+  /// **幂等**:同一 (entityType, entitySyncId) 多次调用只插一次(同 entity
+  /// 通过 apply update 多次也不会挤爆表)。
+  Future<void> recordPulledFromServer({
+    required String entityType,
+    required int entityId,
+    required String entitySyncId,
+    required int ledgerId,
+  }) async {
+    final existing = await (db.select(db.localChanges)
+          ..where((c) =>
+              c.entityType.equals(entityType) &
+              c.entitySyncId.equals(entitySyncId))
+          ..limit(1))
+        .getSingleOrNull();
+    if (existing != null) return;
+
+    final now = DateTime.now();
+    await db.into(db.localChanges).insert(LocalChangesCompanion.insert(
+      entityType: entityType,
+      entityId: entityId,
+      entitySyncId: entitySyncId,
+      ledgerId: ledgerId,
+      action: 'upsert',
+      pushedAt: d.Value(now),
+    ));
+    logger.debug('ChangeTracker',
+        'pulled-from-server marker: $entityType($entitySyncId)');
+  }
+
   /// 获取所有未推送的变更
   Future<List<LocalChange>> getUnpushedChanges() async {
     return await (db.select(db.localChanges)

--- a/lib/cloud/sync/sync_engine.dart
+++ b/lib/cloud/sync/sync_engine.dart
@@ -139,6 +139,18 @@ class SyncEngine implements app.SyncService {
   /// 详见 [LookupCache](sync_engine_pull.dart)。
   LookupCache? activePullCache;
 
+  /// push / fullPush 的 in-flight 单飞锁。**per-ledger** —— 不同 ledger
+  /// 并发不互相阻塞,只阻塞同 ledger 的并发触发。
+  ///
+  /// 背景:app 启动期 `_triggerInitialCloudSync` 由 microtask + listenManual
+  /// 双入口触发,曾经导致同设备 2-3 路 fullPush 并发,服务端 sync_changes
+  /// 表 2-2.5x 膨胀。详见 `.docs/concurrent-fullpush-bloat.md`。
+  ///
+  /// `_pushInFlight` key 用 String(跟 [push] 入参一致),`_fullPushInFlight`
+  /// 用 int(跟 [fullPush] 入参一致)。
+  final Map<String, Completer<int>> _pushInFlight = {};
+  final Map<int, Completer<void>> _fullPushInFlight = {};
+
   SyncEngine({
     required this.db,
     required this.provider,
@@ -630,8 +642,34 @@ class SyncEngine implements app.SyncService {
     }
   }
 
-  /// 推送本地未同步的变更到服务端
+  /// 推送本地未同步的变更到服务端。
+  ///
+  /// **in-flight 单飞**:同 ledger 的并发调用复用第一个的 future,避免双触发
+  /// 在 sync_changes 表里造成重复 row。不同 ledger 并发不互相阻塞。
   Future<int> push(String ledgerId) async {
+    final inFlight = _pushInFlight[ledgerId];
+    if (inFlight != null) {
+      logger.info('SyncEngine', 'push(ledger=$ledgerId) 已在执行,复用 in-flight');
+      return inFlight.future;
+    }
+    final completer = Completer<int>();
+    completer.future.ignore();   // 防 unhandled async error
+    _pushInFlight[ledgerId] = completer;
+    try {
+      final result = await _doPush(ledgerId);
+      completer.complete(result);
+      return result;
+    } catch (e, st) {
+      completer.completeError(e, st);
+      rethrow;
+    } finally {
+      if (_pushInFlight[ledgerId] == completer) {
+        _pushInFlight.remove(ledgerId);
+      }
+    }
+  }
+
+  Future<int> _doPush(String ledgerId) async {
     final ledgerIdInt = int.tryParse(ledgerId) ?? -1;
     final ledger = await (db.select(db.ledgers)
           ..where((l) => l.id.equals(ledgerIdInt)))

--- a/lib/cloud/sync/sync_engine.dart
+++ b/lib/cloud/sync/sync_engine.dart
@@ -163,6 +163,17 @@ class SyncEngine implements app.SyncService {
   /// 拿到的时候 ChangeTracker 已经 markPushed,再各自处理 ledger-scoped 部分。
   Completer<void>? _userGlobalPushInFlight;
 
+  /// fullPull 的 in-flight 单飞锁。**per-ledger**,跟 fullPush 同款。
+  ///
+  /// 防御性:用户连点"下载"按钮时,避免两次并发 fullPull 重复下载同一份 JSON
+  /// snapshot + 重复 apply。apply 路径是 idempotent upsert(同 syncId 不会插
+  /// 重复行),所以不会数据膨胀,但浪费带宽 + CPU。
+  ///
+  /// 跟 fullPush 不同:**不会**真的把多账本并发拉成 N 倍 —— fullPull 只在用户
+  /// 点"下载"时触发,正常单次调用;这个锁是给"快速连点"等边界场景兜底。
+  final Map<int, Completer<({int inserted, int deletedDup})>>
+      _fullPullInFlight = {};
+
   /// legacy 数据补 ChangeTracker 记录的一次性 flag。
   ///
   /// 历史:v19 migration 给老 account/category/tag 回填了 syncId,但**没在
@@ -1223,8 +1234,35 @@ class SyncEngine implements app.SyncService {
   //   downloadAttachments / _getAttachmentFile / _cleanupTxAttachmentFilesOnDisk
   //   _cleanupCategoryIconFilesOnDisk
 
-  /// 新设备全量拉取
+  /// 新设备全量拉取。
+  ///
+  /// **in-flight 单飞**:防御性,挡用户连点"下载"按钮时两次并发拉取。
   Future<({int inserted, int deletedDup})> runFullPull(
+      {required int ledgerId}) async {
+    final inFlight = _fullPullInFlight[ledgerId];
+    if (inFlight != null) {
+      logger.info('SyncEngine',
+          'runFullPull(ledger=$ledgerId) 已在执行,复用 in-flight');
+      return inFlight.future;
+    }
+    final completer = Completer<({int inserted, int deletedDup})>();
+    completer.future.ignore();
+    _fullPullInFlight[ledgerId] = completer;
+    try {
+      final result = await _doRunFullPull(ledgerId: ledgerId);
+      completer.complete(result);
+      return result;
+    } catch (e, st) {
+      completer.completeError(e, st);
+      rethrow;
+    } finally {
+      if (_fullPullInFlight[ledgerId] == completer) {
+        _fullPullInFlight.remove(ledgerId);
+      }
+    }
+  }
+
+  Future<({int inserted, int deletedDup})> _doRunFullPull(
       {required int ledgerId}) async {
     logger.info('SyncEngine', '开始全量拉取 ledger=$ledgerId');
 

--- a/lib/cloud/sync/sync_engine.dart
+++ b/lib/cloud/sync/sync_engine.dart
@@ -151,6 +151,31 @@ class SyncEngine implements app.SyncService {
   final Map<String, Completer<int>> _pushInFlight = {};
   final Map<int, Completer<void>> _fullPushInFlight = {};
 
+  /// user-global 实体(account/category/tag)推送的**全局**单飞锁。
+  ///
+  /// 用户多账本场景下,Phase 2 并发跑多个 `_push(ledgerN)` / `fullPush(ledgerN)`,
+  /// 每个 caller 各自读 user-global unpushed change → 都 push 一份 → server
+  /// sync_changes 表里 user-global 实体按 ledger 数倍数膨胀(已观察到 4 账本
+  /// 用户的 account/category/tag 4x 膨胀)。
+  ///
+  /// 解法:所有 push 路径都先 `await pushUserGlobalEntities()`,**单飞**保证
+  /// 全 session 只跑一次 user-global push,后续 caller 复用第一个的 future,
+  /// 拿到的时候 ChangeTracker 已经 markPushed,再各自处理 ledger-scoped 部分。
+  Completer<void>? _userGlobalPushInFlight;
+
+  /// legacy 数据补 ChangeTracker 记录的一次性 flag。
+  ///
+  /// 历史:v19 migration 给老 account/category/tag 回填了 syncId,但**没在
+  /// local_changes 表里登记对应的 create change**。如果某用户跨过 v19→v27 都
+  /// 没开过云同步,后面 fullPush 走 ChangeTracker 驱动就拿不到这些 legacy 实
+  /// 体 → 数据丢失。
+  ///
+  /// 解法:每个 session 第一次跑 `pushUserGlobalEntities` 时扫一遍 DB,给
+  /// `local_changes` 里没记录的 user-global 实体补一条 upsert change,后续
+  /// 正常走 ChangeTracker 流程。flag 持久存在 SyncEngine 实例上(per-session),
+  /// 实例重建时(冷启)再跑一次,代价是一次轻量 SELECT。
+  bool _userGlobalLegacyBackfilled = false;
+
   SyncEngine({
     required this.db,
     required this.provider,
@@ -642,10 +667,178 @@ class SyncEngine implements app.SyncService {
     }
   }
 
+  /// 推送 user-global 实体(account / category / tag)的未推 change。
+  ///
+  /// **全局单飞**:并发调用复用第一个的 future。多账本场景下 Phase 2 并行的
+  /// `_push(ledgerN)` / `fullPush(ledgerN)` 都先 await 这个方法,保证 user-global
+  /// 实体每个 session 只推一次。
+  ///
+  /// 注意:**不要在 `_push` / `_pushAllEntities` 内部重复推 user-global**,
+  /// 否则单飞失效。这俩内部应该只处理 ledger-scope change(transaction / budget /
+  /// ledger / ledger_snapshot)。
+  Future<int> pushUserGlobalEntities() async {
+    final inFlight = _userGlobalPushInFlight;
+    if (inFlight != null) {
+      logger.info('SyncEngine', 'pushUserGlobalEntities 已在执行,复用 in-flight');
+      await inFlight.future;
+      return 0;   // 复用不计数,只是等
+    }
+    final completer = Completer<void>();
+    completer.future.ignore();
+    _userGlobalPushInFlight = completer;
+    try {
+      final n = await _doPushUserGlobalEntities();
+      completer.complete();
+      return n;
+    } catch (e, st) {
+      completer.completeError(e, st);
+      rethrow;
+    } finally {
+      if (_userGlobalPushInFlight == completer) {
+        _userGlobalPushInFlight = null;
+      }
+    }
+  }
+
+  Future<int> _doPushUserGlobalEntities() async {
+    // Legacy backfill:v19 migration 给老 user-global 实体填了 syncId 但没登记
+    // local_changes,这里一次性补登记。每 SyncEngine 实例只跑一次。
+    if (!_userGlobalLegacyBackfilled) {
+      await _backfillLegacyUserGlobalChanges();
+      _userGlobalLegacyBackfilled = true;
+    }
+
+    final globalChanges = await changeTracker.getUnpushedChangesForLedger(0);
+    if (globalChanges.isEmpty) {
+      logger.debug('SyncEngine', 'pushUserGlobalEntities: 无未推 user-global change');
+      return 0;
+    }
+
+    final syncChanges = <Map<String, dynamic>>[];
+    for (final change in globalChanges) {
+      Map<String, dynamic> payload;
+      if (change.action == 'delete') {
+        payload = <String, dynamic>{};
+      } else {
+        // user-global 实体序列化不需要 ledger 上下文,ledgerId 传 0 占位
+        // (_serializeEntityForPush 内部用它查 parent ledger.syncId,user-global
+        // 实体不会用到 parentLedgerSyncId)。
+        payload = await _serializeEntityForPush(
+          entityType: change.entityType,
+          entityId: change.entityId,
+          ledgerId: 0,
+        );
+      }
+      syncChanges.add({
+        'ledger_id': null,
+        'scope': 'user',
+        'entity_type': change.entityType,
+        'entity_sync_id': change.entitySyncId,
+        'action': change.action == 'delete' ? 'delete' : 'upsert',
+        'payload': payload,
+        'updated_at': change.createdAt.toUtc().toIso8601String(),
+      });
+    }
+
+    await provider.pushChanges(changes: syncChanges);
+    await changeTracker.markPushed(globalChanges.map((c) => c.id).toList());
+    logger.info('SyncEngine',
+        'pushUserGlobalEntities: 推送 ${globalChanges.length} 条 user-global change');
+    return globalChanges.length;
+  }
+
+  /// 扫 accounts/categories/tags,给 local_changes 里没登记过的 legacy 实体
+  /// 补一条 upsert change。详见 [_userGlobalLegacyBackfilled] doc。
+  ///
+  /// 兼顾兜底两件事:
+  /// 1. 实体 syncId 为 NULL(v22 migration 没覆盖到的脏数据)→ 生成 v4 UUID 写回
+  /// 2. 已有 syncId 但 local_changes 表里完全没记录该实体的 change → 补 upsert
+  Future<void> _backfillLegacyUserGlobalChanges() async {
+    // 预拉:local_changes 表里所有 user-global 实体 syncId,做 in-memory dedup,
+    // 避免逐 entity SELECT。
+    final existingChanges = await (db.select(db.localChanges)
+          ..where((c) => c.entityType.isIn(['account', 'category', 'tag'])))
+        .get();
+    final knownSyncIds = existingChanges.map((c) => c.entitySyncId).toSet();
+
+    var backfilled = 0;
+
+    // accounts
+    final accounts = await db.select(db.accounts).get();
+    for (final a in accounts) {
+      var syncId = a.syncId;
+      if (syncId == null) {
+        syncId = _uuid.v4();
+        await (db.update(db.accounts)..where((row) => row.id.equals(a.id)))
+            .write(AccountsCompanion(syncId: d.Value(syncId)));
+      }
+      if (!knownSyncIds.contains(syncId)) {
+        await changeTracker.recordUserGlobalChange(
+          entityType: 'account',
+          entityId: a.id,
+          entitySyncId: syncId,
+          action: 'upsert',
+        );
+        backfilled++;
+      }
+    }
+
+    // categories
+    final categories = await db.select(db.categories).get();
+    for (final c in categories) {
+      var syncId = c.syncId;
+      if (syncId == null) {
+        syncId = _uuid.v4();
+        await (db.update(db.categories)..where((row) => row.id.equals(c.id)))
+            .write(CategoriesCompanion(syncId: d.Value(syncId)));
+      }
+      if (!knownSyncIds.contains(syncId)) {
+        await changeTracker.recordUserGlobalChange(
+          entityType: 'category',
+          entityId: c.id,
+          entitySyncId: syncId,
+          action: 'upsert',
+        );
+        backfilled++;
+      }
+    }
+
+    // tags
+    final tags = await db.select(db.tags).get();
+    for (final t in tags) {
+      var syncId = t.syncId;
+      if (syncId == null) {
+        syncId = _uuid.v4();
+        await (db.update(db.tags)..where((row) => row.id.equals(t.id)))
+            .write(TagsCompanion(syncId: d.Value(syncId)));
+      }
+      if (!knownSyncIds.contains(syncId)) {
+        await changeTracker.recordUserGlobalChange(
+          entityType: 'tag',
+          entityId: t.id,
+          entitySyncId: syncId,
+          action: 'upsert',
+        );
+        backfilled++;
+      }
+    }
+
+    if (backfilled > 0) {
+      logger.info('SyncEngine',
+          'legacy backfill: 补登记 $backfilled 条 user-global ChangeTracker entry');
+    } else {
+      logger.debug('SyncEngine', 'legacy backfill: 无需补登记');
+    }
+  }
+
   /// 推送本地未同步的变更到服务端。
   ///
   /// **in-flight 单飞**:同 ledger 的并发调用复用第一个的 future,避免双触发
   /// 在 sync_changes 表里造成重复 row。不同 ledger 并发不互相阻塞。
+  ///
+  /// 注意:**只推 ledger-scope change**(transaction / budget / ledger / ledger_snapshot)。
+  /// user-global change(account / category / tag)由 [pushUserGlobalEntities] 统一推
+  /// (在 [_doPush] 开头调用),避免多账本场景下并行 push 重复推送 user-global。
   Future<int> push(String ledgerId) async {
     final inFlight = _pushInFlight[ledgerId];
     if (inFlight != null) {
@@ -671,10 +864,23 @@ class SyncEngine implements app.SyncService {
 
   Future<int> _doPush(String ledgerId) async {
     final ledgerIdInt = int.tryParse(ledgerId) ?? -1;
+
+    // 1) 先推 user-global change(account / category / tag)。
+    //    全局单飞,Phase 2 多 ledger 并行场景下只跑一次,跨 ledger 不再各推一份。
+    //    详见 [pushUserGlobalEntities] doc + .docs/concurrent-fullpush-bloat.md。
+    final userGlobalPushed = await pushUserGlobalEntities();
+
+    // 2) ledgerId="0" / "" 语义是"只推 user-global",上面一步已经做完。
+    if (ledgerIdInt == 0) return userGlobalPushed;
+
     final ledger = await (db.select(db.ledgers)
           ..where((l) => l.id.equals(ledgerIdInt)))
         .getSingleOrNull();
 
+    // 3) 再推这个 ledger 的 ledger-scope change(transaction / budget / ledger /
+    //    ledger_snapshot)。ledger 删除路径:即使 ledger 行已没,ledger_snapshot:
+    //    delete change 还在 local_changes 里,这里照常推。
+    //
     // 关键:ledger 已被本地删除时不能直接 return 0。因为 deleteLedger 会先
     // 登记 ledger_snapshot:delete change 再 hard-delete ledger 行,这条 delete
     // change 的 ledger_id 字段就是这个本地 id。如果这里因 ledger==null 短路,
@@ -685,22 +891,16 @@ class SyncEngine implements app.SyncService {
     // 变更才安全 return。
     final ledgerChanges =
         await changeTracker.getUnpushedChangesForLedger(ledgerIdInt);
-    // 当前账本的变更 + user-scoped（ledgerId=0：tag / category）的未推变更。
-    // 后者是"账户/分类/标签属于用户而非单个账本"的对齐：LocalRepository 在
-    // create/update/deleteTag/Category 时用 ledgerId=0 记录变更，getUnpushed-
-    // ChangesForLedger(ledger.id) 永远查不到它们 → 移动端重命名标签/分类在
-    // web 永远看不到。把 ledgerId=0 的也一起捎带。
-    final globalChanges = ledgerIdInt == 0
-        ? const <LocalChange>[]
-        : await changeTracker.getUnpushedChangesForLedger(0);
-    final changes = [...ledgerChanges, ...globalChanges];
+    // 仅这个 ledger 的 ledger-scope change。user-global 已在上面统一推走。
+    final changes = ledgerChanges;
     if (changes.isEmpty) {
       if (ledger == null) {
         logger.warning('SyncEngine', 'push: 本地账本 $ledgerId 已删除且无待推送变更,跳过');
       } else {
-        logger.debug('SyncEngine', 'push: 无待推送变更');
+        logger.debug('SyncEngine',
+            'push: 无 ledger-scope 待推变更(user-global 已推 $userGlobalPushed 条)');
       }
-      return 0;
+      return userGlobalPushed;
     }
     // 当本地 ledger 行已删,从同批 changes 里捞 ledger_snapshot:delete 的
     // entity_sync_id(= 被删账本的 syncId / UUID),用它给所有相关 change 的
@@ -775,8 +975,8 @@ class SyncEngine implements app.SyncService {
     // 标记已推送
     await changeTracker.markPushed(changes.map((c) => c.id).toList());
     logger.info('SyncEngine',
-        'push: 推送 ${changes.length} 条变更 (当前账本 ${ledgerChanges.length} + 全局 ${globalChanges.length})');
-    return changes.length;
+        'push: 推送 ${changes.length} 条 ledger-scope 变更 + 本会话 user-global $userGlobalPushed 条');
+    return changes.length + userGlobalPushed;
   }
 
   /// 拉取远程变更并应用到本地。

--- a/lib/cloud/sync/sync_engine_apply.dart
+++ b/lib/cloud/sync/sync_engine_apply.dart
@@ -294,8 +294,9 @@ extension SyncEngineApplyExt on SyncEngine {
       }
     }
 
+    final int localId;
     if (existing != null) {
-      final localId = existing.id;
+      localId = existing.id;
       await (db.update(db.accounts)
             ..where((a) => a.id.equals(localId)))
           .write(AccountsCompanion(
@@ -314,7 +315,7 @@ extension SyncEngineApplyExt on SyncEngine {
       ));
       logger.debug('SyncEngine', 'pull: 更新账户 $syncId');
     } else {
-      final newId = await db.into(db.accounts).insert(
+      localId = await db.into(db.accounts).insert(
             AccountsCompanion.insert(
               ledgerId: ledgerIdInt,
               name: name,
@@ -335,9 +336,18 @@ extension SyncEngineApplyExt on SyncEngine {
               syncId: d.Value(syncId),
             ),
           );
-      activePullCache?.putAccount(syncId, newId);
+      activePullCache?.putAccount(syncId, localId);
       logger.debug('SyncEngine', 'pull: 新增账户 $syncId');
     }
+
+    // 登记"已从 server 拉到本地"的标记,防止 _backfillLegacyUserGlobalChanges
+    // 误把 device B pull 来的实体当 legacy 重推。详见 [ChangeTracker.recordPulledFromServer]。
+    await changeTracker.recordPulledFromServer(
+      entityType: 'account',
+      entityId: localId,
+      entitySyncId: syncId,
+      ledgerId: 0,
+    );
   }
 
   Future<void> _applyCategoryChange(
@@ -494,6 +504,14 @@ extension SyncEngineApplyExt on SyncEngine {
         expectedPath: payload['customIconPath'] as String?,
       ));
     }
+
+    // 登记"已从 server 拉到本地"标记,见 [_applyAccountChange] 同款注释。
+    await changeTracker.recordPulledFromServer(
+      entityType: 'category',
+      entityId: localCategoryId,
+      entitySyncId: syncId,
+      ledgerId: 0,
+    );
   }
 
   Future<void> _applyTagChange(BeeCountCloudSyncChange change) async {
@@ -540,8 +558,9 @@ extension SyncEngineApplyExt on SyncEngine {
       }
     }
 
+    final int localId;
     if (existing != null) {
-      final localId = existing.id;
+      localId = existing.id;
       await (db.update(db.tags)..where((t) => t.id.equals(localId)))
           .write(TagsCompanion(
         name: d.Value(name),
@@ -550,7 +569,7 @@ extension SyncEngineApplyExt on SyncEngine {
       ));
       logger.debug('SyncEngine', 'pull: 更新标签 $syncId');
     } else {
-      final newId = await db.into(db.tags).insert(
+      localId = await db.into(db.tags).insert(
             TagsCompanion.insert(
               name: name,
               color: d.Value(color),
@@ -558,9 +577,17 @@ extension SyncEngineApplyExt on SyncEngine {
               syncId: d.Value(syncId),
             ),
           );
-      activePullCache?.putTag(syncId, newId);
+      activePullCache?.putTag(syncId, localId);
       logger.debug('SyncEngine', 'pull: 新增标签 $syncId');
     }
+
+    // 登记"已从 server 拉到本地"标记,见 [_applyAccountChange] 同款注释。
+    await changeTracker.recordPulledFromServer(
+      entityType: 'tag',
+      entityId: localId,
+      entitySyncId: syncId,
+      ledgerId: 0,
+    );
   }
 
   /// 应用预算变更。对齐 account/tag:按 syncId upsert,delete 走同样的路径。

--- a/lib/cloud/sync/sync_engine_serialization.dart
+++ b/lib/cloud/sync/sync_engine_serialization.dart
@@ -400,18 +400,26 @@ extension SyncEngineSerializationExt on SyncEngine {
     logger.info('SyncEngine',
         '全量推送完成 ledger=${ledger.name},markPushed ${nonDeletes.length}/${unpushed.length}(剩余 delete change 留给 _push)');
   }
-  /// 推送所有实体为个体变更（fullPush 时调用）
+  /// 推送所有实体为个体变更(fullPush 时调用)。
+  ///
+  /// **只处理 ledger-scope 实体**(ledger / budget / transaction)。user-global
+  /// 实体(account / category / tag)由调用方通过 [pushUserGlobalEntities] 统一
+  /// 推送 — 本函数入口处会调它一次,跨 ledger 并发的 fullPush 共享同一份
+  /// user-global push,避免重复(详见 .docs/concurrent-fullpush-bloat.md)。
   Future<void> _pushAllEntities(Ledger ledger) async {
-    // 跟增量 _push 保持一致：用 ledger.syncId 作为 server 认的 external_id，
-    // 跨设备时同一账本永远同一个 external_id，不会分裂成多条。
+    // 1) 先推 user-global(单飞,多账本并行 fullPush 时共享同一次推送)
+    await pushUserGlobalEntities();
+
+    // 2) 再处理本 ledger 的 ledger-scope 推送
+    // 跟增量 _push 保持一致:用 ledger.syncId 作为 server 认的 external_id,
+    // 跨设备时同一账本永远同一个 external_id,不会分裂成多条。
     final ledgerId = ledger.syncId ?? ledger.id.toString();
     final now = DateTime.now().toUtc().toIso8601String();
     final syncChanges = <Map<String, dynamic>>[];
 
-    // 先推一条 ledger:upsert,显式带 ledgerName + currency。否则:
+    // 推一条 ledger:upsert,显式带 ledgerName + currency。否则:
     //   - storage.upload 的 metadata 虽然带了 currency,但 server 端 auto-create
     //     ledger 时不一定从 metadata 读 currency(字段名可能对不上,或默认走 CNY)
-    //   - _pushAllEntities 后续推的 accounts/categories/... 都不会带账本币种
     //   - 结果:用户在 app 选 JPY 创建账本,server 端 canonical state 是 CNY
     // 推一条显式的 ledger upsert 可以兜底,server 收到后用 payload 里的 currency
     // 覆盖默认值。
@@ -424,84 +432,12 @@ extension SyncEngineSerializationExt on SyncEngine {
       'updated_at': now,
     });
 
-    // 先上传分类自定义图标，拿到每个分类对应的 cloudFileId/sha256。
-    final categoryIconCloudRefs = await _uploadCategoryIcons();
-
-    // 账户：虽然 Accounts 表有 ledgerId（历史遗留），账户在 UI 层是跨账本可选的，
-    // 所以按全局推送，避免跨账本共享账户在只属于某一账本的 fullPush 中漏推。
-    // server 端按 syncId 幂等，不会重复。
-    final accounts = await db.select(db.accounts).get();
-    for (final account in accounts) {
-      final syncId = account.syncId ?? _uuid.v4();
-      // 确保 syncId 已持久化
-      if (account.syncId == null) {
-        await (db.update(db.accounts)
-              ..where((a) => a.id.equals(account.id)))
-            .write(AccountsCompanion(syncId: d.Value(syncId)));
-      }
-      syncChanges.add({
-        'ledger_id': ledgerId,
-        'entity_type': 'account',
-        'entity_sync_id': syncId,
-        'action': 'upsert',
-        'payload': EntitySerializer.serializeAccount(account),
-        'updated_at': now,
-      });
-    }
-
-    // 分类
+    // tx push 需要查类目/账户/标签的 syncId 做 denormalize 用,这里仍要预拉。
+    // 分类自定义图标已经在 [pushUserGlobalEntities] 走 [_serializeEntityForPush]
+    // 时上传到 server(payload 里带 iconCloudFileId/sha256),这里不需要再批量传。
     final categories = await db.select(db.categories).get();
-    for (final category in categories) {
-      final syncId = category.syncId ?? _uuid.v4();
-      if (category.syncId == null) {
-        await (db.update(db.categories)
-              ..where((c) => c.id.equals(category.id)))
-            .write(CategoriesCompanion(syncId: d.Value(syncId)));
-      }
-      String? parentName;
-      String? parentSyncId;
-      if (category.parentId != null) {
-        final parent = categories
-            .cast<Category?>()
-            .firstWhere((p) => p?.id == category.parentId, orElse: () => null);
-        parentName = parent?.name;
-        parentSyncId = parent?.syncId;
-      }
-      final iconRef = categoryIconCloudRefs[category.id];
-      syncChanges.add({
-        'ledger_id': ledgerId,
-        'entity_type': 'category',
-        'entity_sync_id': syncId,
-        'action': 'upsert',
-        'payload': EntitySerializer.serializeCategory(
-          category,
-          parentName: parentName,
-          parentSyncId: parentSyncId,
-          iconCloudFileId: iconRef?.fileId,
-          iconCloudSha256: iconRef?.sha256,
-        ),
-        'updated_at': now,
-      });
-    }
-
-    // 标签
+    final accounts = await db.select(db.accounts).get();
     final tags = await db.select(db.tags).get();
-    for (final tag in tags) {
-      final syncId = tag.syncId ?? _uuid.v4();
-      if (tag.syncId == null) {
-        await (db.update(db.tags)
-              ..where((t) => t.id.equals(tag.id)))
-            .write(TagsCompanion(syncId: d.Value(syncId)));
-      }
-      syncChanges.add({
-        'ledger_id': ledgerId,
-        'entity_type': 'tag',
-        'entity_sync_id': syncId,
-        'action': 'upsert',
-        'payload': EntitySerializer.serializeTag(tag),
-        'updated_at': now,
-      });
-    }
 
     // 预算:按账本过滤推,不跨账本。分类预算带 categorySyncId。
     final budgets = await (db.select(db.budgets)

--- a/lib/cloud/sync/sync_engine_serialization.dart
+++ b/lib/cloud/sync/sync_engine_serialization.dart
@@ -287,8 +287,34 @@ extension SyncEngineSerializationExt on SyncEngine {
 
   // ==================== 全量推送/拉取 ====================
 
-  /// 首次全量推送（将本地所有数据推送到服务端）
+  /// 首次全量推送(将本地所有数据推送到服务端)。
+  ///
+  /// **in-flight 单飞**:同 ledger 的并发调用复用第一个 future,避免 sync_changes
+  /// 表 2-3x 膨胀。详见 `.docs/concurrent-fullpush-bloat.md`。
   Future<void> fullPush({required int ledgerId}) async {
+    final inFlight = _fullPushInFlight[ledgerId];
+    if (inFlight != null) {
+      logger.info('SyncEngine',
+          'fullPush(ledger=$ledgerId) 已在执行,复用 in-flight');
+      return inFlight.future;
+    }
+    final completer = Completer<void>();
+    completer.future.ignore();   // 防 unhandled async error
+    _fullPushInFlight[ledgerId] = completer;
+    try {
+      await _doFullPush(ledgerId: ledgerId);
+      completer.complete();
+    } catch (e, st) {
+      completer.completeError(e, st);
+      rethrow;
+    } finally {
+      if (_fullPushInFlight[ledgerId] == completer) {
+        _fullPushInFlight.remove(ledgerId);
+      }
+    }
+  }
+
+  Future<void> _doFullPush({required int ledgerId}) async {
     logger.info('SyncEngine', '开始全量推送 ledger=$ledgerId');
 
     final ledger = await (db.select(db.ledgers)

--- a/lib/pages/transaction/transaction_editor_page.dart
+++ b/lib/pages/transaction/transaction_editor_page.dart
@@ -353,20 +353,15 @@ class _TransactionEditorPageState extends ConsumerState<TransactionEditorPage>
                 }
                 ref.read(tagListRefreshProvider.notifier).state++;
               }
-              // override 变化也算 tx update,登记 change 让 sync push 推走
-              // (insertOnConflictUpdate 防重复)
-              final ledgerRow = await (repo.db.select(repo.db.ledgers)
-                    ..where((l) => l.id.equals(ledgerId)))
-                  .getSingleOrNull();
-              if (ledgerRow != null) {
-                await repo.changeTracker?.recordLedgerChange(
-                  entityType: 'transaction',
-                  entityId: transactionId,
-                  entitySyncId: txSyncId,
-                  ledgerId: ledgerId,
-                  action: 'update',
-                );
-              }
+              // 这里**不再**重复 recordLedgerChange(transaction:update)。
+              // 之前为了"override 变化也走 push"专门补一条 update,但
+              // - addTransaction / updateTransaction 已经登记过一次 change
+              // - _serializeEntityForPush('transaction') 在 push 时**统一**读 DB
+              //   最新状态(包括 transaction_tag_overrides 表),payload 自然含
+              //   最新 overrides
+              // 结论:那条补登记的 update 跟前面的 create/update 推同样 payload,
+              // 服务端 sync_changes 表凭空多一条 row(已观察到共享账本 Editor
+              // 创建 tx 时 1 秒内 2 条 identical upsert)。直接砍。
             }
           }
           // 统一处理：自动/手动同步与状态刷新（后台静默）


### PR DESCRIPTION
## 背景

诊断生产 + dev 数据库,撞到 sync_changes 表 2-2.5x 膨胀的 bug。

| 用户 | tx (projection) | tx:upsert (sync_changes) | 膨胀比 |
|---|---|---|---|
| dev owner@example.com | 10,000 | 20,000 | **2x** |
| prod sunxiaoyes@outlook.com | 10,084 | 25,016 | **2.48x** |

生产用户 account / category / tag 膨胀比更高(5-6x),因为每次 fullPush 都会全量重推 user-scoped 实体。

## 根因

1. **`_triggerInitialCloudSync` 双入口**(`lib/app.dart`):`Future.microtask` + `ref.listenManual` 两路在启动期都可能触发,各自跑一个完整流程。
2. **`fullPush` / `push` 没有 in-flight 单飞锁**:跟现有 `_pullInFlight` 不同,N 路并发就 N 倍写入。

证据:
- 生产 2026-04-19 12:18:31 同一设备 0.15 秒内 3 个 timestamp 落地 10018 + 10018 + 4610 条 change(2 完整 + 1 中断)
- dev 0.6 秒内 2 个 timestamp 各落 10000
- 同一条 tx 的 change_id 差 = 500(= 客户端 batch_size),验证服务端把多路 batch 交错落盘

## 修复

### P0:in-flight 单飞

per-ledger Map 单飞,不阻塞跨 ledger 并发(多账本场景仍可并行 push)。

### P1:5 秒幂等节流

防御性第二层 —— fullPush 内部 in-flight 已经拦住重复写,但 phase 1 的 \`syncMyProfile\` / \`storage.list\` / \`pull\` 还是会跑两遍 HTTP,这里挡掉。

## 验证

- \`dart analyze\` 涉及 3 文件无新 warning/error
- \`flutter test test/cloud/sync/sync_engine_e2e_test.dart\` 27 个测试全通过

## 不在范围

- **历史脏数据清理**:生产 sync_changes 已经 2.48x 了,后续做 sync_changes 压缩工具一起处理。
- **\`_pushAllEntities\` 内部"无变化就跳过"剪枝**:先观察 P0 后 fullPush 频率再决定。