### PR TITLE
feat(promo): BeeAssets 安卓指向正式 Google Play 链接

### DIFF
--- a/lib/services/marketing/product_promos.dart
+++ b/lib/services/marketing/product_promos.dart
@@ -10,7 +10,7 @@ import '../../widgets/biz/product_promo_card.dart';
 
 /// 蜜蜂家当 BeeAssets — 资产可视化产品。
 ///
-/// 当前阶段:iOS 已上架,Android 内测中。
+/// 当前阶段:iOS 已上架 App Store / TestFlight,Android 已上架 Google Play。
 /// 截图按当前 locale 自动切英文 / 中文版。
 ProductPromo beeAssetsPromo(BuildContext context) {
   final l10n = AppLocalizations.of(context);
@@ -28,7 +28,7 @@ ProductPromo beeAssetsPromo(BuildContext context) {
     // App Store 审核期间走 TestFlight,审过后两个并存(App Store 主、TestFlight
     // 次)— TestFlight 永远是"最新构建"通道,重度用户喜欢用
     testFlightUrl: 'https://testflight.apple.com/join/49vTpmDA',
-    // googlePlayUrl: 'https://play.google.com/store/apps/details?id=com.tntlikely.beeassets',
+    googlePlayUrl: 'https://play.google.com/store/apps/details?id=com.tntlikely.beeassets',
     websiteUrl: 'https://assets.beejz.com',
     contactEmail: 'sunxiaoyes@outlook.com',
     screenshotAssets: [


### PR DESCRIPTION
蜜蜂家当 BeeAssets Android 已上架 Google Play,取消注释 googlePlayUrl,更新阶段说明。BeeDNS 仍在内测,googlePlayUrl 保留 null,Android 走原内测邮件申请流程。