### PR TITLE
fix(ai): 智能记账关闭自动关联标签开关后不再挂标签

### DIFF
--- a/lib/services/billing/bill_creation_service.dart
+++ b/lib/services/billing/bill_creation_service.dart
@@ -91,14 +91,19 @@ class BillCreationService {
       note: bill.note,
     );
 
-    // 6. 自动标签
+    // 6. 自动标签:受「智能记账自动关联标签」开关控制(默认开启,关闭后不挂任何标签)。
+    //    与账户功能开关一致直接读 prefs;入参 autoAddTags 作为代码级强制开关,二者取「与」。
     if (autoAddTags) {
-      await _addTags(
-        transactionId,
-        billingTypes: billingTypes,
-        customTagNames: customTagNames ?? bill.tags,
-        l10n: l10n,
-      );
+      final prefs = await SharedPreferences.getInstance();
+      final autoTagsEnabled = prefs.getBool('smartBillingAutoTags') ?? true;
+      if (autoTagsEnabled) {
+        await _addTags(
+          transactionId,
+          billingTypes: billingTypes,
+          customTagNames: customTagNames ?? bill.tags,
+          l10n: l10n,
+        );
+      }
     }
 
     // 7. 汇总日志


### PR DESCRIPTION
## 问题
AI 记账(对话 / 图片 / 语音 / 自动截图 / 自动通知文本)时,即使在「智能记账」设置里关闭了「自动关联标签」开关,仍会自动给交易挂标签。

## 根因
- 开关 provider `smartBillingAutoTagsProvider`(默认开启)只在设置页读写、启动时同步到 prefs。
- 真正打标签的 `BillCreationService.createFromBill` 的 `autoAddTags` 参数默认 `true`,而 5 个渠道经 `AiBookkeeper._persistAll` 调用时都没传该参数 → 恒为 `true`,开关从未被读取,形同虚设。

## 修复
在 `createFromBill` 加标签处读取 `smartBillingAutoTags` 开关(写法与同文件账户功能开关 `account_feature_enabled` 一致),关闭后跳过 `_addTags`。改一处即覆盖全部 5 个 AI 记账渠道,不破坏 `AiBookkeeper` 统一入口封装。

## 测试
- `flutter analyze` 无 issue。