### PR TITLE
feat: 交易列表项分类名常驻 + 详情页按入口区分账本范围

### DIFF
--- a/lib/data/repositories/local/local_repository.dart
+++ b/lib/data/repositories/local/local_repository.dart
@@ -2044,8 +2044,8 @@ class LocalRepository extends BaseRepository {
       _tagRepo.getAllTagTransactionCounts();
 
   @override
-  Future<({int count, double expense, double income})> getTagStats(int tagId) =>
-      _tagRepo.getTagStats(tagId);
+  Future<({int count, double expense, double income})> getTagStats(int tagId, {int? ledgerId}) =>
+      _tagRepo.getTagStats(tagId, ledgerId: ledgerId);
 
   @override
   Future<List<Transaction>> getTransactionsByTag(int tagId) =>
@@ -2074,8 +2074,8 @@ class LocalRepository extends BaseRepository {
       _tagRepo.watchTagsForTransaction(transactionId);
 
   @override
-  Stream<List<Transaction>> watchTransactionsByTag(int tagId) =>
-      _tagRepo.watchTransactionsByTag(tagId);
+  Stream<List<Transaction>> watchTransactionsByTag(int tagId, {int? ledgerId}) =>
+      _tagRepo.watchTransactionsByTag(tagId, ledgerId: ledgerId);
 
   @override
   Future<bool> isTagNameDuplicate({required String name, int? excludeId}) =>

--- a/lib/data/repositories/local/local_tag_repository.dart
+++ b/lib/data/repositories/local/local_tag_repository.dart
@@ -354,7 +354,10 @@ class LocalTagRepository implements TagRepository {
   }
 
   @override
-  Future<({int count, double expense, double income})> getTagStats(int tagId) async {
+  Future<({int count, double expense, double income})> getTagStats(int tagId, {int? ledgerId}) async {
+    final ledgerFilter = ledgerId != null ? 'AND tx.ledger_id = ?' : '';
+    final vars = <d.Variable>[d.Variable.withInt(tagId)];
+    if (ledgerId != null) vars.add(d.Variable.withInt(ledgerId));
     final result = await db.customSelect(
       '''
       SELECT
@@ -363,9 +366,9 @@ class LocalTagRepository implements TagRepository {
         COALESCE(SUM(CASE WHEN tx.type = 'income' THEN tx.amount ELSE 0 END), 0) as income
       FROM transaction_tags tt
       INNER JOIN transactions tx ON tt.transaction_id = tx.id
-      WHERE tt.tag_id = ?
+      WHERE tt.tag_id = ? $ledgerFilter
       ''',
-      variables: [d.Variable.withInt(tagId)],
+      variables: vars,
       readsFrom: {db.transactionTags, db.transactions},
     ).getSingle();
 
@@ -509,16 +512,19 @@ class LocalTagRepository implements TagRepository {
   }
 
   @override
-  Stream<List<Transaction>> watchTransactionsByTag(int tagId) {
+  Stream<List<Transaction>> watchTransactionsByTag(int tagId, {int? ledgerId}) {
+    final ledgerFilter = ledgerId != null ? 'AND tx.ledger_id = ?' : '';
+    final vars = <d.Variable>[d.Variable.withInt(tagId)];
+    if (ledgerId != null) vars.add(d.Variable.withInt(ledgerId));
     return db.customSelect(
       '''
       SELECT tx.*
       FROM transactions tx
       INNER JOIN transaction_tags tt ON tx.id = tt.transaction_id
-      WHERE tt.tag_id = ?
+      WHERE tt.tag_id = ? $ledgerFilter
       ORDER BY tx.happened_at DESC
       ''',
-      variables: [d.Variable.withInt(tagId)],
+      variables: vars,
       readsFrom: {db.transactions, db.transactionTags},
     ).watch().map((rows) {
       return rows.map((row) {

--- a/lib/data/repositories/tag_repository.dart
+++ b/lib/data/repositories/tag_repository.dart
@@ -98,7 +98,7 @@ abstract class TagRepository {
   Future<Map<int, int>> getAllTagTransactionCounts();
 
   /// 获取标签统计信息（总笔数、总支出、总收入）
-  Future<({int count, double expense, double income})> getTagStats(int tagId);
+  Future<({int count, double expense, double income})> getTagStats(int tagId, {int? ledgerId});
 
   /// 获取标签下的所有交易
   Future<List<Transaction>> getTransactionsByTag(int tagId);
@@ -127,7 +127,7 @@ abstract class TagRepository {
   Stream<List<Tag>> watchTagsForTransaction(int transactionId);
 
   /// 监听标签下的交易
-  Stream<List<Transaction>> watchTransactionsByTag(int tagId);
+  Stream<List<Transaction>> watchTransactionsByTag(int tagId, {int? ledgerId});
 
   // ============================================
   // 辅助方法

--- a/lib/pages/account/account_detail_page.dart
+++ b/lib/pages/account/account_detail_page.dart
@@ -1208,6 +1208,7 @@ class _TransactionTile extends ConsumerWidget {
 
     String displayTitle;
     String? displaySubtitle;
+    String? noteSuffix; // 非转账时，备注接在分类名后面（对齐首页）
 
     if (transaction.type == 'transfer') {
       if (transaction.note?.isNotEmpty == true) {
@@ -1232,14 +1233,12 @@ class _TransactionTile extends ConsumerWidget {
         }
       }
     } else {
-      if (transaction.note?.isNotEmpty == true) {
-        displayTitle = transaction.note!;
-      } else if (category != null) {
-        displayTitle = category.name;
-      } else {
-        displayTitle = transaction.type == 'income'
-            ? l10n.homeIncome
-            : l10n.homeExpense;
+      // 分类名常驻，备注接在分类名后面（对齐首页 / TransactionListItem）
+      displayTitle = category != null
+          ? category.name
+          : (transaction.type == 'income' ? l10n.homeIncome : l10n.homeExpense);
+      if (transaction.note?.isNotEmpty == true && transaction.note != displayTitle) {
+        noteSuffix = transaction.note;
       }
     }
 
@@ -1281,12 +1280,24 @@ class _TransactionTile extends ConsumerWidget {
                   Row(
                     children: [
                       Flexible(
-                        child: Text(
-                          displayTitle,
-                          style: TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w500,
-                            color: BeeTokens.textPrimary(context),
+                        child: Text.rich(
+                          TextSpan(
+                            text: displayTitle,
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.w500,
+                              color: BeeTokens.textPrimary(context),
+                            ),
+                            children: [
+                              if (noteSuffix != null)
+                                TextSpan(
+                                  text: '  ($noteSuffix)',
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    color: BeeTokens.textSecondary(context),
+                                  ),
+                                ),
+                            ],
                           ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,

--- a/lib/pages/category/category_edit_page.dart
+++ b/lib/pages/category/category_edit_page.dart
@@ -201,6 +201,7 @@ class _CategoryEditPageState extends ConsumerState<CategoryEditPage> {
                             builder: (context) => CategoryDetailPage(
                               categoryId: widget.category!.id,
                               categoryName: widget.category!.name,
+                              allLedgers: true,
                             ),
                           ),
                         );

--- a/lib/pages/tag/tag_detail_page.dart
+++ b/lib/pages/tag/tag_detail_page.dart
@@ -19,11 +19,13 @@ import 'tag_edit_page.dart';
 class TagDetailPage extends ConsumerStatefulWidget {
   final int tagId;
   final String tagName;
+  final bool allLedgers; // true=全部账本(从标签管理进入)，false=当前账本(从明细进入)
 
   const TagDetailPage({
     super.key,
     required this.tagId,
     required this.tagName,
+    this.allLedgers = false,
   });
 
   @override
@@ -72,8 +74,9 @@ class _TagDetailPageState extends ConsumerState<TagDetailPage> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final tagAsync = ref.watch(_tagStreamProvider(widget.tagId));
-    final statsAsync = ref.watch(_tagStatsProvider(widget.tagId));
-    final transactionsAsync = ref.watch(_tagTransactionsStreamProvider(widget.tagId));
+    final ledgerScope = widget.allLedgers ? null : ref.watch(currentLedgerIdProvider);
+    final statsAsync = ref.watch(_tagStatsProvider((tagId: widget.tagId, ledgerId: ledgerScope)));
+    final transactionsAsync = ref.watch(_tagTransactionsStreamProvider((tagId: widget.tagId, ledgerId: ledgerScope)));
 
     return Scaffold(
       backgroundColor: BeeTokens.scaffoldBackground(context),
@@ -270,6 +273,11 @@ class _TagDetailPageState extends ConsumerState<TagDetailPage> {
       );
     }
 
+    // 全部账本模式下，构建账本名映射，用于在交易项展示账本标签
+    final ledgerNames = widget.allLedgers
+        ? {for (final l in (ref.watch(ledgersStreamProvider).valueOrNull ?? [])) l.id: l.name}
+        : const <int, String>{};
+
     // 按日期分组
     final Map<String, List<db.Transaction>> groupedTransactions = {};
     for (final transaction in transactions) {
@@ -308,6 +316,7 @@ class _TagDetailPageState extends ConsumerState<TagDetailPage> {
                 category: category,
                 title: transaction.note ?? '',
                 categoryName: categoryName,
+                ledgerName: ledgerNames[transaction.ledgerId],
                 amount: transaction.amount,
                 isExpense: transaction.type == 'expense',
                 happenedAt: transaction.happenedAt,
@@ -429,14 +438,14 @@ final _tagStreamProvider = StreamProvider.family<db.Tag?, int>((ref, tagId) {
 });
 
 /// 获取标签统计信息
-final _tagStatsProvider = FutureProvider.family<({int count, double expense, double income}), int>((ref, tagId) async {
+final _tagStatsProvider = FutureProvider.family<({int count, double expense, double income}), ({int tagId, int? ledgerId})>((ref, params) async {
   ref.watch(tagListRefreshProvider);
   final repo = ref.watch(repositoryProvider);
-  return await repo.getTagStats(tagId);
+  return await repo.getTagStats(params.tagId, ledgerId: params.ledgerId);
 });
 
 /// 监听标签下的交易
-final _tagTransactionsStreamProvider = StreamProvider.family<List<db.Transaction>, int>((ref, tagId) {
+final _tagTransactionsStreamProvider = StreamProvider.family<List<db.Transaction>, ({int tagId, int? ledgerId})>((ref, params) {
   final repo = ref.watch(repositoryProvider);
-  return repo.watchTransactionsByTag(tagId);
+  return repo.watchTransactionsByTag(params.tagId, ledgerId: params.ledgerId);
 });

--- a/lib/pages/tag/tag_detail_page.dart
+++ b/lib/pages/tag/tag_detail_page.dart
@@ -301,15 +301,13 @@ class _TagDetailPageState extends ConsumerState<TagDetailPage> {
             ...dayTransactions.map((transaction) {
               final category = _categoryCache[transaction.categoryId];
               final categoryName = CategoryUtils.getDisplayName(category?.name, context);
-              final isTransfer = transaction.type == 'transfer';
 
-              // 和首页保持一致：有备注显示备注，无备注显示分类名称
-              final hasNote = transaction.note?.isNotEmpty == true;
+              // 和首页保持一致：分类名常驻，备注接在后面
               return TransactionListItem(
                 icon: getCategoryIconData(category: category, categoryName: categoryName),
                 category: category,
-                title: hasNote ? transaction.note! : categoryName,
-                categoryName: hasNote ? null : categoryName,
+                title: transaction.note ?? '',
+                categoryName: categoryName,
                 amount: transaction.amount,
                 isExpense: transaction.type == 'expense',
                 happenedAt: transaction.happenedAt,

--- a/lib/pages/tag/tag_manage_page.dart
+++ b/lib/pages/tag/tag_manage_page.dart
@@ -144,6 +144,7 @@ class _TagManagePageState extends ConsumerState<TagManagePage> {
         builder: (_) => TagDetailPage(
           tagId: tag.id,
           tagName: tag.name,
+          allLedgers: true,
         ),
       ),
     );

--- a/lib/pages/transaction/category_detail_page.dart
+++ b/lib/pages/transaction/category_detail_page.dart
@@ -373,7 +373,8 @@ class _CategoryDetailPageState extends ConsumerState<CategoryDetailPage> {
             return TransactionListItem(
               icon: _getTransactionIcon(transaction),
               category: category,
-              title: _getTransactionTitle(transaction),
+              title: transaction.note ?? '',
+              categoryName: CategoryUtils.getDisplayName(category?.name ?? widget.categoryName, context),
               amount: transaction.amount,
               isExpense: transaction.type == 'expense',
               happenedAt: transaction.happenedAt,
@@ -451,7 +452,8 @@ class _CategoryDetailPageState extends ConsumerState<CategoryDetailPage> {
               return TransactionListItem(
               icon: _getTransactionIcon(transaction),
               category: category,
-              title: _getTransactionTitle(transaction),
+              title: transaction.note ?? '',
+              categoryName: CategoryUtils.getDisplayName(category?.name ?? widget.categoryName, context),
               amount: transaction.amount,
               isExpense: transaction.type == 'expense',
               happenedAt: transaction.happenedAt,
@@ -509,14 +511,6 @@ class _CategoryDetailPageState extends ConsumerState<CategoryDetailPage> {
     return getCategoryIconData(category: category, categoryName: categoryName);
   }
 
-  String _getTransactionTitle(db.Transaction transaction) {
-    final categoryAsync = ref.read(_categoryStreamProvider(widget.categoryId));
-    final categoryName = categoryAsync.value?.name ?? widget.categoryName;
-    // 优先显示备注，无备注时显示翻译后的分类名
-    return transaction.note?.isNotEmpty == true
-      ? transaction.note!
-      : CategoryUtils.getDisplayName(categoryName, context);
-  }
 }
 
 class _SummaryItem extends ConsumerWidget {

--- a/lib/pages/transaction/category_detail_page.dart
+++ b/lib/pages/transaction/category_detail_page.dart
@@ -23,6 +23,7 @@ class CategoryDetailPage extends ConsumerStatefulWidget {
   final DateTime? startDate; // 周期开始时间（可选）
   final DateTime? endDate;   // 周期结束时间（可选）
   final String? periodLabel; // 周期标签（如"2024年11月"）
+  final bool allLedgers; // true=全部账本(从分类管理进入)，false=当前账本(从明细进入)
 
   const CategoryDetailPage({
     super.key,
@@ -31,6 +32,7 @@ class CategoryDetailPage extends ConsumerStatefulWidget {
     this.startDate,
     this.endDate,
     this.periodLabel,
+    this.allLedgers = false,
   });
 
   @override
@@ -43,7 +45,8 @@ class _CategoryDetailPageState extends ConsumerState<CategoryDetailPage> {
   @override
   Widget build(BuildContext context) {
     final categoryAsync = ref.watch(_categoryStreamProvider(widget.categoryId));
-    final transactionsAsync = ref.watch(_categoryTransactionsWithSortProvider(widget.categoryId));
+    final ledgerScope = widget.allLedgers ? null : ref.watch(currentLedgerIdProvider);
+    final transactionsAsync = ref.watch(_categoryTransactionsWithSortProvider((categoryId: widget.categoryId, ledgerId: ledgerScope)));
     final currentSortType = ref.watch(_categorySortTypeProvider(widget.categoryId));
 
     // 如果有周期限制，需要筛选交易数据
@@ -325,6 +328,11 @@ class _CategoryDetailPageState extends ConsumerState<CategoryDetailPage> {
       );
     }
 
+    // 全部账本模式下，构建账本名映射，用于在交易项展示账本标签
+    final ledgerNames = widget.allLedgers
+        ? {for (final l in (ref.watch(ledgersStreamProvider).valueOrNull ?? [])) l.id: l.name}
+        : const <int, String>{};
+
     // 金额排序时：预计算UI列表，避免动态插入导致卡顿
     if (currentSortType == SortType.amountDesc || currentSortType == SortType.amountAsc) {
       // 先计算每个日期的统计数据（避免重复计算）
@@ -375,6 +383,7 @@ class _CategoryDetailPageState extends ConsumerState<CategoryDetailPage> {
               category: category,
               title: transaction.note ?? '',
               categoryName: CategoryUtils.getDisplayName(category?.name ?? widget.categoryName, context),
+              ledgerName: ledgerNames[transaction.ledgerId],
               amount: transaction.amount,
               isExpense: transaction.type == 'expense',
               happenedAt: transaction.happenedAt,
@@ -454,6 +463,7 @@ class _CategoryDetailPageState extends ConsumerState<CategoryDetailPage> {
               category: category,
               title: transaction.note ?? '',
               categoryName: CategoryUtils.getDisplayName(category?.name ?? widget.categoryName, context),
+              ledgerName: ledgerNames[transaction.ledgerId],
               amount: transaction.amount,
               isExpense: transaction.type == 'expense',
               happenedAt: transaction.happenedAt,
@@ -574,10 +584,9 @@ final _categoryStreamProvider = StreamProvider.family<db.Category?, int>((ref, c
 });
 
 // 基础数据流：监听分类下交易变化（仅当前账本）
-final _categoryTransactionsStreamProvider = StreamProvider.family<List<db.Transaction>, int>((ref, categoryId) {
+final _categoryTransactionsStreamProvider = StreamProvider.family<List<db.Transaction>, ({int categoryId, int? ledgerId})>((ref, params) {
   final repo = ref.watch(repositoryProvider);
-  final ledgerId = ref.watch(currentLedgerIdProvider);
-  return repo.watchTransactionsByCategory(categoryId, ledgerId: ledgerId);
+  return repo.watchTransactionsByCategory(params.categoryId, ledgerId: params.ledgerId);
 });
 
 // 排序状态管理
@@ -586,9 +595,9 @@ final _categorySortTypeProvider = StateProvider.family<SortType, int>((ref, cate
 });
 
 // 派生数据：排序后的交易列表（自动响应排序状态变化）
-final _categoryTransactionsWithSortProvider = Provider.family<AsyncValue<List<db.Transaction>>, int>((ref, categoryId) {
-  final transactionsAsync = ref.watch(_categoryTransactionsStreamProvider(categoryId));
-  final sortType = ref.watch(_categorySortTypeProvider(categoryId));
+final _categoryTransactionsWithSortProvider = Provider.family<AsyncValue<List<db.Transaction>>, ({int categoryId, int? ledgerId})>((ref, params) {
+  final transactionsAsync = ref.watch(_categoryTransactionsStreamProvider(params));
+  final sortType = ref.watch(_categorySortTypeProvider(params.categoryId));
 
   return transactionsAsync.when(
     loading: () => const AsyncValue.loading(),
@@ -612,27 +621,6 @@ final _categoryTransactionsWithSortProvider = Provider.family<AsyncValue<List<db
       }
 
       return AsyncValue.data(sorted);
-    },
-  );
-});
-
-// 派生数据：汇总统计（自动基于交易数据计算）
-final _categorySummaryProvider = Provider.family<AsyncValue<({int totalCount, double totalAmount, double averageAmount})>, int>((ref, categoryId) {
-  final transactionsAsync = ref.watch(_categoryTransactionsStreamProvider(categoryId));
-
-  return transactionsAsync.when(
-    loading: () => const AsyncValue.loading(),
-    error: (error, stack) => AsyncValue.error(error, stack),
-    data: (transactions) {
-      final totalCount = transactions.length;
-      final totalAmount = transactions.fold(0.0, (sum, t) => sum + t.amount);
-      final averageAmount = totalCount > 0 ? totalAmount / totalCount : 0.0;
-
-      return AsyncValue.data((
-        totalCount: totalCount,
-        totalAmount: totalAmount,
-        averageAmount: averageAmount,
-      ));
     },
   );
 });

--- a/lib/pages/transaction/search_page.dart
+++ b/lib/pages/transaction/search_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:drift/drift.dart' as d;
 import '../../data/db.dart';
 import '../../providers.dart';
 import '../../providers/budget_providers.dart';
@@ -966,11 +965,8 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                               TransactionListItem(
                                 icon: iconData,
                                 category: item.category,
-                                title: subtitle.isNotEmpty
-                                    ? subtitle
-                                    : categoryName,
-                                categoryName:
-                                    subtitle.isNotEmpty ? null : categoryName,
+                                title: subtitle,
+                                categoryName: categoryName,
                                 amount: item.t.amount,
                                 isExpense: isExpense,
                                 hide: hide,

--- a/lib/widgets/biz/transaction_list.dart
+++ b/lib/widgets/biz/transaction_list.dart
@@ -501,10 +501,10 @@ class TransactionListState extends ConsumerState<TransactionList> {
                           ? (subtitle.isNotEmpty ? subtitle : AppLocalizations.of(context).transferTitle)
                           : isAdjustment
                             ? categoryName
-                            : (subtitle.isNotEmpty ? subtitle : categoryName),
+                            : subtitle,
                         categoryName: (isTransfer || isAdjustment)
                           ? null
-                          : (subtitle.isNotEmpty ? null : categoryName),
+                          : categoryName,
                         amount: it.t.amount,
                         isExpense: isExpense,
                         isTransfer: isTransfer,

--- a/lib/widgets/biz/transaction_list_item.dart
+++ b/lib/widgets/biz/transaction_list_item.dart
@@ -20,6 +20,7 @@ class TransactionListItem extends ConsumerWidget {
   final VoidCallback? onTap;
   final VoidCallback? onCategoryTap; // 点击分类图标/名称的回调
   final String? categoryName; // 分类名称，用于显示
+  final String? ledgerName; // 账本名称（仅"全部账本"模式下显示标签）
   final VoidCallback? onDelete; // 删除回调
   final String? accountName; // 账户名称，用于显示
   final DateTime? happenedAt; // 交易时间，用于显示时分
@@ -51,6 +52,7 @@ class TransactionListItem extends ConsumerWidget {
       this.onTap,
       this.onCategoryTap,
       this.categoryName,
+      this.ledgerName,
       this.onDelete,
       this.accountName,
       this.happenedAt,
@@ -201,22 +203,47 @@ class TransactionListItem extends ConsumerWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     // 第一行：分类名（常驻）+ 备注接在后面（括号、次要色、整体单行省略，对齐 web 端）
-                    Text.rich(
-                      TextSpan(
-                        text: categoryName ?? title,
-                        style: BeeTextTokens.title(context),
-                        children: [
-                          if (categoryName != null && title.isNotEmpty && title != categoryName)
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text.rich(
                             TextSpan(
-                              text: '  ($title)',
-                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: BeeTokens.textSecondary(context),
+                              text: categoryName ?? title,
+                              style: BeeTextTokens.title(context),
+                              children: [
+                                if (categoryName != null && title.isNotEmpty && title != categoryName)
+                                  TextSpan(
+                                    text: '  ($title)',
+                                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: BeeTokens.textSecondary(context),
+                                    ),
+                                  ),
+                              ],
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        // 全部账本模式：展示账本名标签（参考账户详情页）
+                        if (ledgerName != null && ledgerName!.isNotEmpty) ...[
+                          const SizedBox(width: 6),
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: ref.watch(primaryColorProvider).withValues(alpha: 0.1),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: Text(
+                              ledgerName!,
+                              style: TextStyle(
+                                fontSize: 11,
+                                color: ref.watch(primaryColorProvider),
+                                fontWeight: FontWeight.w500,
                               ),
                             ),
+                          ),
                         ],
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+                      ],
                     ),
                     // 第三行：时间 · 账户 · 附件
                     if (_hasSecondaryInfo(ref))

--- a/lib/widgets/biz/transaction_list_item.dart
+++ b/lib/widgets/biz/transaction_list_item.dart
@@ -200,26 +200,24 @@ class TransactionListItem extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // 第一行：分类名称（始终显示）
-                    Text(
-                      categoryName ?? title,
+                    // 第一行：分类名（常驻）+ 备注接在后面（括号、次要色、整体单行省略，对齐 web 端）
+                    Text.rich(
+                      TextSpan(
+                        text: categoryName ?? title,
+                        style: BeeTextTokens.title(context),
+                        children: [
+                          if (categoryName != null && title.isNotEmpty && title != categoryName)
+                            TextSpan(
+                              text: '  ($title)',
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: BeeTokens.textSecondary(context),
+                              ),
+                            ),
+                        ],
+                      ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: BeeTextTokens.title(context),
                     ),
-                    // 第二行：备注（当title与categoryName不同时显示）
-                    if (categoryName != null && categoryName != title)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 2),
-                        child: Text(
-                          title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: BeeTokens.textSecondary(context),
-                          ),
-                        ),
-                      ),
                     // 第三行：时间 · 账户 · 附件
                     if (_hasSecondaryInfo(ref))
                       Padding(


### PR DESCRIPTION
## 改动

### 1. 交易列表项分类名常驻
- 第一行改为「分类名 (备注)」：分类名常驻、备注小字括号后缀、整体单行省略号，对齐 web 端
- 首页 / 搜索 / 日历 / 标签详情 / 分类详情 / 账户详情统一应用（账户详情转账保留账户视角，不并入通用组件）

### 2. 分类/标签详情页按入口区分账本范围
- 交易列表 / 搜索 / 统计进入 → 当前账本；分类管理 / 标签管理进入 → 全部账本
- 两个详情页加 `allLedgers` 参数；标签 repo 的 `watchTransactionsByTag` / `getTagStats` 增加可选 `ledgerId`（云端无单独实现，不涉及）
- 全部账本模式下，交易项展示所属账本名标签（参考账户详情页样式）
- 顺带移除未使用的 `_categorySummaryProvider`

## 验证
- 全部改动文件 `flutter analyze` 0 issue