### PR TITLE
fix(attachment): 多笔共享附件不复制物理文件 + 统计/删除按内容去重

### DIFF
--- a/lib/cloud/sync/sync_engine_attachments.dart
+++ b/lib/cloud/sync/sync_engine_attachments.dart
@@ -314,6 +314,14 @@ extension SyncEngineAttachmentsExt on SyncEngine {
       final thumbDir = Directory('${cacheDir.path}/attachment_thumbs');
 
       for (final att in attachments) {
+        // 多笔共享同一物理文件:此处 DB 行尚未删(apply 在本函数之后才删行)，
+        // 故排除本交易,看是否还有其他交易的行引用同 fileName,有就保留文件。
+        final others = await (db.select(db.transactionAttachments)
+              ..where((a) => a.fileName.equals(att.fileName))
+              ..where((a) => a.transactionId.equals(transactionId).not()))
+            .get();
+        if (others.isNotEmpty) continue;
+
         final file = File('${attachmentDir.path}/${att.fileName}');
         if (await file.exists()) {
           try {

--- a/lib/cloud/sync/sync_engine_status.dart
+++ b/lib/cloud/sync/sync_engine_status.dart
@@ -41,12 +41,16 @@ extension SyncEngineHealthChecks on SyncEngine {
     // 本地交易附件:transaction_attachments 每 tx 一行 = server 端
     // attachment_kind='transaction' 的物理文件数。分类自定义图标独立统计
     // (见下面 localCategoryAttachments)。
+    // 多笔交易可共享同一附件:已上传的按 cloudSha256 去重(server 端同样按
+    // sha256 去重存 1 行)，未上传的按 fileName(各行独立)。避免把共享同一张图
+    // 的 N 笔交易算成 N 个附件。
     int localLedgerAttachments = 0;
     if (ledgerTxIds.isNotEmpty) {
-      localLedgerAttachments = (await (db.select(db.transactionAttachments)
-                ..where((a) => a.transactionId.isIn(ledgerTxIds)))
-              .get())
-          .length;
+      final atts = await (db.select(db.transactionAttachments)
+            ..where((a) => a.transactionId.isIn(ledgerTxIds)))
+          .get();
+      localLedgerAttachments =
+          atts.map((a) => a.cloudSha256 ?? a.fileName).toSet().length;
     }
     final localLedgerBudgets = (await (db.select(db.budgets)
               ..where((b) => b.ledgerId.equals(ledgerId))
@@ -59,9 +63,12 @@ extension SyncEngineHealthChecks on SyncEngine {
               ..where((t) => t.syncId.isNotNull()))
             .get())
         .length;
-    // 全量交易附件 = 所有 tx 附件(分类图标不算)
+    // 全量交易附件 = 所有 tx 附件(分类图标不算)，同样按 cloudSha256 去重
     final localTotalAttachments =
-        (await db.select(db.transactionAttachments).get()).length;
+        (await db.select(db.transactionAttachments).get())
+            .map((a) => a.cloudSha256 ?? a.fileName)
+            .toSet()
+            .length;
     final localTotalBudgets = (await (db.select(db.budgets)
               ..where((b) => b.syncId.isNotNull()))
             .get())
@@ -84,10 +91,9 @@ extension SyncEngineHealthChecks on SyncEngine {
               ..where((c) => c.syncId.isNotNull()))
             .get())
         .length;
-    final localTags = (await (db.select(db.tags)
-              ..where((t) => t.syncId.isNotNull()))
-            .get())
-        .length;
+    final localTags =
+        (await (db.select(db.tags)..where((t) => t.syncId.isNotNull())).get())
+            .length;
 
     final unpushed =
         (await changeTracker.getUnpushedChangesForLedger(ledgerId)).length;
@@ -96,14 +102,14 @@ extension SyncEngineHealthChecks on SyncEngine {
     try {
       final stats = await provider.readLedgerStats(ledgerId: serverLedgerId);
       return SyncHealthReport(
-        ledgerTx: SyncCountPair(
-            local: localLedgerTx, remote: stats.transactionCount),
+        ledgerTx:
+            SyncCountPair(local: localLedgerTx, remote: stats.transactionCount),
         ledgerAttachments: SyncCountPair(
             local: localLedgerAttachments, remote: stats.attachmentCount),
         ledgerBudgets:
             SyncCountPair(local: localLedgerBudgets, remote: stats.budgetCount),
-        totalTx: SyncCountPair(
-            local: localTotalTx, remote: stats.transactionTotal),
+        totalTx:
+            SyncCountPair(local: localTotalTx, remote: stats.transactionTotal),
         totalAttachments: SyncCountPair(
             local: localTotalAttachments, remote: stats.attachmentTotal),
         totalBudgets:
@@ -111,7 +117,8 @@ extension SyncEngineHealthChecks on SyncEngine {
         categoryAttachments: SyncCountPair(
             local: localCategoryAttachments,
             remote: stats.categoryAttachmentTotal),
-        accounts: SyncCountPair(local: localAccounts, remote: stats.accountTotal),
+        accounts:
+            SyncCountPair(local: localAccounts, remote: stats.accountTotal),
         categories:
             SyncCountPair(local: localCategories, remote: stats.categoryTotal),
         tags: SyncCountPair(local: localTags, remote: stats.tagTotal),
@@ -125,7 +132,8 @@ extension SyncEngineHealthChecks on SyncEngine {
             SyncCountPair(local: localLedgerAttachments, remote: -1),
         ledgerBudgets: SyncCountPair(local: localLedgerBudgets, remote: -1),
         totalTx: SyncCountPair(local: localTotalTx, remote: -1),
-        totalAttachments: SyncCountPair(local: localTotalAttachments, remote: -1),
+        totalAttachments:
+            SyncCountPair(local: localTotalAttachments, remote: -1),
         totalBudgets: SyncCountPair(local: localTotalBudgets, remote: -1),
         categoryAttachments:
             SyncCountPair(local: localCategoryAttachments, remote: -1),
@@ -148,8 +156,10 @@ extension SyncEngineHealthChecks on SyncEngine {
   ///
   /// 幂等:只对没有对应 sync_change 记录的实体补写 create。重复调用是安全的。
   Future<int> backfillUntrackedEntities({required int ledgerId}) async {
-    final allUnpushed = await changeTracker.getUnpushedChangesForLedger(ledgerId);
-    final allPushedIds = <String>{};  // syncId 集合 —— unpushed 的先留着,判断"从未写过 change"用的是下面的专用查询
+    final allUnpushed =
+        await changeTracker.getUnpushedChangesForLedger(ledgerId);
+    final allPushedIds =
+        <String>{}; // syncId 集合 —— unpushed 的先留着,判断"从未写过 change"用的是下面的专用查询
     for (final c in allUnpushed) {
       allPushedIds.add(c.entitySyncId);
     }

--- a/lib/data/repositories/attachment_repository.dart
+++ b/lib/data/repositories/attachment_repository.dart
@@ -48,6 +48,12 @@ abstract class AttachmentRepository {
   /// 根据文件名检查附件是否存在
   Future<bool> attachmentExistsByFileName(String fileName);
 
+  /// 统计某 fileName 被多少行引用(多笔/多次共享同一物理文件时的引用计数)
+  Future<int> countAttachmentsByFileName(String fileName);
+
+  /// 获取某账本所有交易关联的附件 fileName(去重)。用于清空/删账本后精准清理物理文件。
+  Future<List<String>> getAttachmentFileNamesByLedger(int ledgerId);
+
   /// 获取交易的附件数量
   Future<int> getAttachmentCountByTransaction(int transactionId);
 

--- a/lib/data/repositories/local/local_attachment_repository.dart
+++ b/lib/data/repositories/local/local_attachment_repository.dart
@@ -106,6 +106,35 @@ class LocalAttachmentRepository implements AttachmentRepository {
   }
 
   @override
+  Future<int> countAttachmentsByFileName(String fileName) async {
+    final result = await db.customSelect(
+      'SELECT COUNT(*) AS count FROM transaction_attachments WHERE file_name = ?',
+      variables: [d.Variable.withString(fileName)],
+      readsFrom: {db.transactionAttachments},
+    ).getSingle();
+    final count = result.data['count'];
+    if (count is int) return count;
+    if (count is BigInt) return count.toInt();
+    if (count is num) return count.toInt();
+    return 0;
+  }
+
+  @override
+  Future<List<String>> getAttachmentFileNamesByLedger(int ledgerId) async {
+    final rows = await db.customSelect(
+      '''
+      SELECT DISTINCT ta.file_name AS file_name
+      FROM transaction_attachments ta
+      INNER JOIN transactions t ON ta.transaction_id = t.id
+      WHERE t.ledger_id = ?
+      ''',
+      variables: [d.Variable.withInt(ledgerId)],
+      readsFrom: {db.transactionAttachments, db.transactions},
+    ).get();
+    return rows.map((r) => r.data['file_name'] as String).toList();
+  }
+
+  @override
   Future<int> getAttachmentCountByTransaction(int transactionId) async {
     final result = await db.customSelect(
       'SELECT COUNT(*) AS count FROM transaction_attachments WHERE transaction_id = ?',

--- a/lib/data/repositories/local/local_repository.dart
+++ b/lib/data/repositories/local/local_repository.dart
@@ -2315,6 +2315,14 @@ class LocalRepository extends BaseRepository {
       _attachmentRepo.attachmentExistsByFileName(fileName);
 
   @override
+  Future<int> countAttachmentsByFileName(String fileName) =>
+      _attachmentRepo.countAttachmentsByFileName(fileName);
+
+  @override
+  Future<List<String>> getAttachmentFileNamesByLedger(int ledgerId) =>
+      _attachmentRepo.getAttachmentFileNamesByLedger(ledgerId);
+
+  @override
   Future<int> getAttachmentCountByTransaction(int transactionId) =>
       _attachmentRepo.getAttachmentCountByTransaction(transactionId);
 

--- a/lib/data/repositories/local/local_transaction_repository.dart
+++ b/lib/data/repositories/local/local_transaction_repository.dart
@@ -552,27 +552,32 @@ class LocalTransactionRepository implements TransactionRepository {
       final cacheDir = await getTemporaryDirectory();
       final thumbDir = Directory('${cacheDir.path}/attachment_thumbs');
 
-      // 删除每个附件的文件
-      for (final attachment in attachments) {
-        // 删除原图
-        final file = File('${attachmentDir.path}/${attachment.fileName}');
+      final fileNames = attachments.map((a) => a.fileName).toSet();
+
+      // 先删数据库记录,再按引用计数删物理文件:多笔共享同一文件时,仅当没有
+      // 其他行引用该 fileName 才删物理文件,避免误删别笔还在用的图。
+      await (db.delete(db.transactionAttachments)
+            ..where((a) => a.transactionId.equals(transactionId)))
+          .go();
+
+      for (final fileName in fileNames) {
+        final stillRef = await (db.select(db.transactionAttachments)
+              ..where((a) => a.fileName.equals(fileName)))
+            .getSingleOrNull();
+        if (stillRef != null) continue; // 仍有其他行引用,保留物理文件
+
+        final file = File('${attachmentDir.path}/$fileName');
         if (await file.exists()) {
           await file.delete();
-          logger.debug('LocalTransactionRepository', '删除附件文件: ${attachment.fileName}');
+          logger.debug('LocalTransactionRepository', '删除附件文件: $fileName');
         }
-
-        // 删除缩略图
-        final thumbName = '${path.basenameWithoutExtension(attachment.fileName)}_thumb.jpg';
+        final thumbName =
+            '${path.basenameWithoutExtension(fileName)}_thumb.jpg';
         final thumbFile = File('${thumbDir.path}/$thumbName');
         if (await thumbFile.exists()) {
           await thumbFile.delete();
         }
       }
-
-      // 删除数据库记录
-      await (db.delete(db.transactionAttachments)
-            ..where((a) => a.transactionId.equals(transactionId)))
-          .go();
 
       logger.info('LocalTransactionRepository', '已删除交易 $transactionId 的 ${attachments.length} 个附件');
     } catch (e, stackTrace) {

--- a/lib/pages/main/ledgers_page_new.dart
+++ b/lib/pages/main/ledgers_page_new.dart
@@ -21,6 +21,7 @@ import '../cloud/join_shared_ledger_page.dart';
 import '../budget/budget_page.dart';
 import '../../styles/tokens.dart';
 import '../../utils/currencies.dart';
+import '../../services/attachment_service.dart';
 import '../../services/system/logger_service.dart';
 import '../../utils/ui_scale_extensions.dart';
 import '../../utils/format_utils.dart';
@@ -683,6 +684,21 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
     ref.invalidate(currentLedgerProvider);
   }
 
+  /// 清空 / 删除账本后,精准清理该账本关联的附件物理文件(best-effort)。
+  /// 清空(clearLedgerTransactions)和删账本(deleteLedger)走批量 SQL 删行,
+  /// 只删 DB 行不删物理文件;调用方在删除前先收集该账本的 fileName 传入。
+  /// 按引用计数删除:其他账本/交易仍引用同一 fileName 的不会被误删。
+  Future<void> _cleanupLedgerAttachmentFiles(List<String> fileNames) async {
+    if (fileNames.isEmpty) return;
+    try {
+      await ref
+          .read(attachmentServiceProvider)
+          .deletePhysicalFilesIfUnreferenced(fileNames);
+    } catch (e) {
+      logger.warning('ledger', '清理账本附件文件失败（忽略）：$e');
+    }
+  }
+
   /// 清空账本（删除所有账单，保留账本）
   Future<void> _handleClearLedger(BuildContext context, LedgerDisplayItem ledger) async {
     final l10n = AppLocalizations.of(context);
@@ -697,8 +713,13 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
     try {
       final repo = ref.read(repositoryProvider);
 
-      // 删除该账本的所有账单
+      // 删账单前先收集该账本附件 fileName(删行后就查不到了)
+      final attachmentFiles =
+          await repo.getAttachmentFileNamesByLedger(ledger.id);
+      // 删除该账本的所有账单(批量删行不删物理文件)
       await repo.clearLedgerTransactions(ledger.id);
+      // 删行后精准清理这些附件的物理文件(引用计数)
+      await _cleanupLedgerAttachmentFiles(attachmentFiles);
 
       if (!mounted) return;
 
@@ -752,8 +773,12 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
         }
       }
 
+      // 删账本前先收集其附件 fileName(删行后查不到)
+      final attachmentFiles =
+          await repo.getAttachmentFileNamesByLedger(ledger.id);
       // 只删除本地账本，不删除云端备份
       await repo.deleteLedger(ledger.id);
+      await _cleanupLedgerAttachmentFiles(attachmentFiles);
 
       if (!mounted) return;
 
@@ -818,7 +843,11 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
 
       // 删除本地账本(repo.deleteLedger 内部会捕获 syncId,登记
       // ledger_snapshot:delete + 级联 transaction:delete + budget:delete change)
+      // 删账本前先收集其附件 fileName(删行后查不到)
+      final attachmentFiles =
+          await repo.getAttachmentFileNamesByLedger(deletedLedgerId);
       await repo.deleteLedger(deletedLedgerId);
+      await _cleanupLedgerAttachmentFiles(attachmentFiles);
 
       // 显式触发对被删账本的 sync,把 delete change 推到 server 清掉 canonical
       // state。SyncCoordinator 的 ledgerIdResolver 拿的是新切换的 currentLedger,

--- a/lib/services/attachment_service.dart
+++ b/lib/services/attachment_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:ui' as ui;
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
@@ -95,12 +96,12 @@ class AttachmentService {
   }) async {
     try {
       final dir = await getAttachmentDirectory();
-      final timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final ext = path.extension(sourceFile.path).toLowerCase();
       final finalExt = ext.isEmpty ? '.jpg' : ext;
-      final fileName = 'tx_${transactionId}_${timestamp}_$index$finalExt';
-      final destPath = '${dir.path}/$fileName';
 
+      // 按内容 sha256 命名:多笔/多次记账用到同一张图时复用同一物理文件,
+      // 不再每笔复制一份(配合删除处的引用计数,避免误删共享文件)。
+      final String fileName;
       final File savedFile;
       int? width;
       int? height;
@@ -109,16 +110,32 @@ class AttachmentService {
         // 跳过压缩,sync copy。iOS background launch 状态下唯一可靠的写法。
         // 同时跳过 _getImageInfo:它走 ui.instantiateImageCodec 也是 platform
         // channel,后台冻结时也卡。width/height 留 null 不影响主功能。
-        sourceFile.copySync(destPath);
+        final bytes = sourceFile.readAsBytesSync();
+        fileName = 'sha_${sha256.convert(bytes)}$finalExt';
+        final destPath = '${dir.path}/$fileName';
         savedFile = File(destPath);
+        if (!savedFile.existsSync()) {
+          sourceFile.copySync(destPath);
+        }
         fileSize = savedFile.lengthSync();
       } else {
-        final compressedFile = await _compressImage(sourceFile, destPath);
+        // 先压缩到临时文件,再按压缩后内容 sha256 命名(同图去重)
+        final timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        final tempPath = '${dir.path}/_tmp_${timestamp}_$index$finalExt';
+        final compressedFile = await _compressImage(sourceFile, tempPath);
         if (compressedFile == null) {
           logger.error('AttachmentService', '图片压缩失败');
           return null;
         }
-        savedFile = compressedFile;
+        final bytes = await compressedFile.readAsBytes();
+        fileName = 'sha_${sha256.convert(bytes)}$finalExt';
+        final destPath = '${dir.path}/$fileName';
+        if (await File(destPath).exists()) {
+          await compressedFile.delete();
+        } else {
+          await compressedFile.rename(destPath);
+        }
+        savedFile = File(destPath);
         final imageInfo = await _getImageInfo(savedFile.path);
         width = imageInfo?.width;
         height = imageInfo?.height;
@@ -173,23 +190,37 @@ class AttachmentService {
       final attachment = await repo.getAttachmentById(attachmentId);
 
       if (attachment != null) {
-        // 删除原图文件
-        final dir = await getAttachmentDirectory();
-        final file = File('${dir.path}/${attachment.fileName}');
-        if (await file.exists()) {
-          await file.delete();
-          logger.debug('AttachmentService', '已删除原图: ${attachment.fileName}');
-        }
-
-        // 删除缩略图
-        await _deleteThumbnail(attachment.fileName);
-
-        // 删除数据库记录
+        // 先删数据库记录,再按引用计数删物理文件(多笔/多次共享同一文件时,
+        // 仅当没有其他行引用该 fileName 才删物理文件)
         await repo.deleteAttachment(attachmentId);
+        await _deletePhysicalFileIfUnreferenced(attachment.fileName);
         logger.info('AttachmentService', '附件删除成功: ${attachment.fileName}');
       }
     } catch (e, stackTrace) {
       logger.error('AttachmentService', '删除附件失败', e, stackTrace);
+    }
+  }
+
+  /// 引用计数删物理文件:仅当没有其他 transaction_attachments 行引用该 fileName
+  /// 时才删物理文件 + 缩略图。多笔/多次共享同一张图时避免误删。
+  Future<void> _deletePhysicalFileIfUnreferenced(String fileName) async {
+    final repo = ref.read(repositoryProvider);
+    final refCount = await repo.countAttachmentsByFileName(fileName);
+    if (refCount > 0) return; // 仍有其他行引用,保留物理文件
+    final dir = await getAttachmentDirectory();
+    final file = File('${dir.path}/$fileName');
+    if (await file.exists()) {
+      await file.delete();
+      logger.debug('AttachmentService', '已删除原图: $fileName');
+    }
+    await _deleteThumbnail(fileName);
+  }
+
+  /// 对一组 fileName 逐个按引用计数删物理文件(清空/删账本后,精准清理该账本
+  /// 关联的附件文件;其他账本/交易仍引用同一 fileName 的不会被删)。
+  Future<void> deletePhysicalFilesIfUnreferenced(Iterable<String> fileNames) async {
+    for (final fileName in fileNames) {
+      await _deletePhysicalFileIfUnreferenced(fileName);
     }
   }
 
@@ -198,21 +229,13 @@ class AttachmentService {
     try {
       final repo = ref.read(repositoryProvider);
       final attachments = await repo.getAttachmentsByTransaction(transactionId);
+      final fileNames = attachments.map((a) => a.fileName).toSet();
 
-      for (final attachment in attachments) {
-        // 删除原图文件
-        final dir = await getAttachmentDirectory();
-        final file = File('${dir.path}/${attachment.fileName}');
-        if (await file.exists()) {
-          await file.delete();
-        }
-
-        // 删除缩略图
-        await _deleteThumbnail(attachment.fileName);
-      }
-
-      // 删除所有数据库记录
+      // 先删数据库记录,再逐个按引用计数删物理文件
       await repo.deleteAttachmentsByTransaction(transactionId);
+      for (final fileName in fileNames) {
+        await _deletePhysicalFileIfUnreferenced(fileName);
+      }
       logger.info('AttachmentService', '已删除交易 $transactionId 的所有附件');
     } catch (e, stackTrace) {
       logger.error('AttachmentService', '删除交易附件失败', e, stackTrace);


### PR DESCRIPTION
围绕「多笔交易共享同一张图片」引出的一系列附件问题:

## 1. 多笔共享不再复制多份物理文件
`saveAttachment` 改按内容 sha256 命名(`sha_<hash>`),多笔/多次用到同一张图复用同一物理文件,不再每笔复制。

## 2. 删除引用计数(防误删)
所有删物理文件路径（单删 / 按交易 / 交易级联 / sync pull）加引用计数：仅当没有其他行再引用该 fileName 才删物理文件,绝不误删共享文件。

## 3. 清空 / 删账本精准清理物理文件
清空账本、删本地账本走批量 SQL 删行,只删 DB 行不删物理文件。改为：删前收集该账本关联的附件 fileName，删后只对这批做引用计数删除。

## 4. 同步页「本地附件数」对齐云端
按内容（cloudSha256/fileName）去重,不再把共享同一张图的 N 笔交易算成 N 个附件。

新增 repo/service：`countAttachmentsByFileName` / `getAttachmentFileNamesByLedger` / `deletePhysicalFilesIfUnreferenced`。

## 验证
- 改动文件 \`flutter analyze\` 0 issue（pre-existing 除外）
- 真机回归：多笔同图只 1 份文件、删除引用计数（删一笔/最后一笔/清空/删账本）、同步上传下载对端删除均正常