### PR TITLE
fix(ai): 兼容字符串金额与中文时间,修复部分模型记账中断

### DIFF
--- a/lib/ai/core/bill_info.dart
+++ b/lib/ai/core/bill_info.dart
@@ -103,15 +103,18 @@ class BillInfo {
   /// 从 AI 返回的 JSON 对象构造。
   ///
   /// 容错:
+  /// - `amount` / `confidence` 兼容字符串数值(部分模型吐 `"-800.00"`,
+  ///   甚至带千分位 `"1,234.50"`),无法解析时按缺失处理
   /// - `note` 兼容老字段名 `merchant`
   /// - `from_account` / `to_account` 兼容 camelCase
   /// - `tag` / `tags` 兼容单字符串和字符串数组
   /// - `time` 字符串内嵌空格会自动 strip 再 parse(应对 AI 偶发吐
-  ///   `"2222 2-1-26T18:08:00"` 这类格式),仍不可解析时返回 null,
+  ///   `"2222 2-1-26T18:08:00"` 这类格式),并支持中文格式
+  ///   `"2026年5月29日 23:35:16"`;仍不可解析时返回 null,
   ///   由 [JsonResponseParser._sanitize] 兜底成当前时间。
   factory BillInfo.fromJson(Map<String, dynamic> json) {
     return BillInfo(
-      amount: (json['amount'] as num?)?.toDouble(),
+      amount: _parseDouble(json['amount']),
       time: _parseTime(json['time']),
       note: json['note'] as String? ?? json['merchant'] as String?,
       category: json['category'] as String?,
@@ -122,7 +125,7 @@ class BillInfo {
       toAccount: json['to_account'] as String? ?? json['toAccount'] as String?,
       tags: _parseTags(json['tags'] ?? json['tag']),
       ledgerId: json['ledgerId'] as int?,
-      confidence: (json['confidence'] as num?)?.toDouble() ?? 0.8,
+      confidence: _parseDouble(json['confidence']) ?? 0.8,
     );
   }
 
@@ -140,6 +143,20 @@ class BillInfo {
         'confidence': confidence,
       };
 
+  /// 解析数值字段,兼容 `num` 与字符串(部分模型把 amount 输出成 `"-800.00"`,
+  /// 甚至带千分位 `"1,234.50"`)。无法解析返回 null,交由上层兜底/丢弃。
+  static double? _parseDouble(dynamic value) {
+    if (value == null) return null;
+    if (value is num) return value.toDouble();
+    if (value is String) {
+      // 去掉千分位逗号(半/全角)与空白;负号、小数点保留交给 tryParse。
+      final cleaned = value.replaceAll(RegExp(r'[,，\s]'), '');
+      if (cleaned.isEmpty) return null;
+      return double.tryParse(cleaned);
+    }
+    return null;
+  }
+
   static DateTime? _parseTime(dynamic value) {
     if (value is! String) return null;
     final raw = value.trim();
@@ -147,7 +164,19 @@ class BillInfo {
     final direct = DateTime.tryParse(raw);
     if (direct != null) return direct;
     // AI 偶发会在 ISO8601 里夹空格(如 `"2222 2-1-26T18:08:00"`),strip 重试
-    return DateTime.tryParse(raw.replaceAll(RegExp(r'\s+'), ''));
+    final stripped = DateTime.tryParse(raw.replaceAll(RegExp(r'\s+'), ''));
+    if (stripped != null) return stripped;
+    // 本地化 / 中文格式(如 `"2026年5月29日 23:35:16"`):正则提取年月日时分秒。
+    final m = RegExp(
+      r'(\d{4})\s*[年./-]\s*(\d{1,2})\s*[月./-]\s*(\d{1,2})\s*日?'
+      r'(?:[\sT]+(\d{1,2})\s*[:时点]\s*(\d{1,2})(?:\s*[:分]\s*(\d{1,2}))?)?',
+    ).firstMatch(raw);
+    if (m == null) return null;
+    int g(int i) => int.tryParse(m.group(i) ?? '') ?? 0;
+    final month = g(2);
+    final day = g(3);
+    if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+    return DateTime(g(1), month, day, g(4), g(5), g(6));
   }
 
   static BillType? _parseBillType(dynamic value) {

--- a/test/ai/core/bill_info_test.dart
+++ b/test/ai/core/bill_info_test.dart
@@ -108,6 +108,47 @@ void main() {
       final bill = BillInfo.fromJson({'amount': -30, 'merchant': '星巴克'});
       expect(bill.note, '星巴克');
     });
+
+    test('amount 字符串数值 → 正确解析(issue #297)', () {
+      // AI(如 qwen-vl-ocr)把金额输出成字符串 "-800.00",旧实现 `as num?`
+      // 强转抛 CastError,整笔被 JsonResponseParser 跳过、记账失败。
+      final bill = BillInfo.fromJson({
+        'amount': '-800.00',
+        'time': '2026-05-29T23:35:16',
+      });
+      expect(bill.amount, -800.0);
+    });
+
+    test('amount 带千分位字符串 → 去逗号解析', () {
+      expect(BillInfo.fromJson({'amount': '1,234.50'}).amount, 1234.5);
+    });
+
+    test('amount 数字仍正常 / 空串 / 非数值 → null', () {
+      expect(BillInfo.fromJson({'amount': -30.5}).amount, -30.5);
+      expect(BillInfo.fromJson({'amount': ''}).amount, isNull);
+      expect(BillInfo.fromJson({'amount': '无'}).amount, isNull);
+    });
+
+    test('confidence 字符串数值兼容,缺失回落 0.8', () {
+      expect(
+        BillInfo.fromJson({'amount': -1, 'confidence': '0.9'}).confidence,
+        0.9,
+      );
+      expect(BillInfo.fromJson({'amount': -1}).confidence, 0.8);
+    });
+
+    test('time 中文格式解析(issue #297)', () {
+      final bill = BillInfo.fromJson({
+        'amount': -800,
+        'time': '2026年5月29日 23:35:16',
+      });
+      expect(bill.time, DateTime(2026, 5, 29, 23, 35, 16));
+    });
+
+    test('time 中文格式仅日期(无时分秒)', () {
+      final bill = BillInfo.fromJson({'amount': -1, 'time': '2026年5月29日'});
+      expect(bill.time, DateTime(2026, 5, 29));
+    });
   });
 
   group('BillInfo.copyWith', () {

--- a/test/ai/core/json_response_parser_test.dart
+++ b/test/ai/core/json_response_parser_test.dart
@@ -149,5 +149,28 @@ void main() {
       expect(bills[1].type, BillType.income);
       expect(bills[2].type, BillType.transfer);
     });
+
+    test('字符串金额 + 中文时间不再被跳过(回归 issue #297)', () {
+      // issue #297 原始响应:qwen-vl-ocr 把 amount 输出成字符串、time 用中文,
+      // 还带 ```json 包裹。旧实现 amount `as num?` 强转抛 CastError → 整笔被
+      // 跳过、记账失败。
+      const raw = '```json\n'
+          '[\n'
+          '    {\n'
+          '        "amount": "-800.00",\n'
+          '        "time": "2026年5月29日 23:35:16",\n'
+          '        "note": "转账-xxxxx",\n'
+          '        "category": "转账",\n'
+          '        "type": "expense",\n'
+          '        "tag": []\n'
+          '    }\n'
+          ']\n'
+          '```';
+      final bills = parser.parse(raw);
+      expect(bills, hasLength(1));
+      expect(bills.first.amount, -800.0);
+      expect(bills.first.time, DateTime(2026, 5, 29, 23, 35, 16));
+      expect(bills.first.category, '转账');
+    });
   });
 }


### PR DESCRIPTION
## 问题
issue #297:部分视觉模型(如 qwen-vl-ocr-latest)截图记账时,AI 返回的 `amount` 是字符串 `"-800.00"`(而非数字),解析时 `as num?` 强转抛 `type 'String' is not a subtype of type 'num?'`,整笔被 `JsonResponseParser` 跳过 → 记账失败。

## 根因
`BillInfo.fromJson`(`lib/ai/core/bill_info.dart`):
- `amount` / `confidence` 用 `(json['x'] as num?)` 强转,字符串数值直接 CastError
- `time` 用 `DateTime.tryParse`,中文格式 `"2026年5月29日 23:35:16"` 解析不了 → 兜底成当前时间(时间记错)

## 修复
- 新增 `_parseDouble`:兼容 `num` 与字符串数值(含千分位 `"1,234.50"`),`amount` / `confidence` 都走它
- `_parseTime` 增加中文 / 本地化日期格式解析(年月日时分秒)

## 测试
- `bill_info_test.dart`:字符串金额 / 千分位 / 空串 / confidence / 中文时间
- `json_response_parser_test.dart`:用 issue #297 原始响应做端到端回归
- `flutter test` 全绿(+37)

Closes #297