### PR TITLE
fix(recurring): 周期账单禁止历史开始日期,避免回溯生成脏数据

### DIFF
--- a/lib/pages/transaction/recurring_transaction_edit_page.dart
+++ b/lib/pages/transaction/recurring_transaction_edit_page.dart
@@ -601,10 +601,18 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
   }
 
   Future<void> _selectDate(BuildContext context, bool isStartDate) async {
+    final now = DateTime.now();
+    final todayStart = DateTime(now.year, now.month, now.day);
+    // 开始日期最早只能是今天:禁止历史开始日期,避免回溯生成脏数据(issue #135);
+    // 结束日期不早于开始日期。
+    final minDate = isStartDate ? todayStart : _startDate;
+    var initial = isStartDate ? _startDate : (_endDate ?? _startDate);
+    if (initial.isBefore(minDate)) initial = minDate;
+
     final date = await showWheelDatePicker(
       context,
-      initial: isStartDate ? _startDate : (_endDate ?? DateTime.now()),
-      minDate: DateTime(2000),
+      initial: initial,
+      minDate: minDate,
       maxDate: DateTime(2100),
     );
 

--- a/lib/services/data/recurring_transaction_service.dart
+++ b/lib/services/data/recurring_transaction_service.dart
@@ -84,8 +84,14 @@ class RecurringTransactionService {
       return null;
     }
 
-    // 基准日期：最后生成日期 或 开始日期
-    final baseDate = lastGenerated ?? recurring.startDate;
+    // 基准日期：最后生成日期 或 开始日期。
+    // 防止历史开始日期回溯补生成脏数据(issue #135):从未生成过(lastGenerated
+    // 为 null)的周期账单,基准不早于今天零点,只面向未来生成,不补创建之前的历史。
+    final todayStart = DateTime(now.year, now.month, now.day);
+    final rawBase = lastGenerated ?? recurring.startDate;
+    final baseDate = lastGenerated == null && rawBase.isBefore(todayStart)
+        ? todayStart
+        : rawBase;
 
     DateTime nextDate;
     switch (frequency) {

--- a/test/services/data/recurring_transaction_service_test.dart
+++ b/test/services/data/recurring_transaction_service_test.dart
@@ -1,0 +1,70 @@
+// RecurringTransactionService 生成逻辑回归测试。
+//
+// 锁死 issue #135:历史开始日期不再回溯补生成脏数据。
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+import 'package:beecount/services/data/recurring_transaction_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late BeeDatabase db;
+  late LocalRepository repo;
+  late int ledgerId;
+
+  setUp(() async {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+    ledgerId = await repo.createLedger(name: 'test', currency: 'CNY');
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('历史开始日期 + 从未生成 → 不回溯补历史账单(issue #135)', () async {
+    // daily 周期账单,开始日期在 30 天前,lastGeneratedDate 为 null。
+    // 修复前:会从 startDate 一路补到今天(约 30 笔脏数据);
+    // 修复后:基准锁定今天零点,daily 第一笔落在明天(未来),本次不生成。
+    await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now().subtract(const Duration(days: 30)),
+    );
+
+    final service = RecurringTransactionService(repo);
+    final generated = await service.generatePendingTransactions();
+
+    expect(generated, isEmpty);
+  });
+
+  test('已生成过(lastGeneratedDate 非空)→ 正常 catch-up 不受影响', () async {
+    // 开始 30 天前、昨天生成过一笔的 daily 账单:应正常补出"今天"这一笔,
+    // 证明历史保护只拦"从未生成"的回溯,不误伤正常的错过补齐。
+    final id = await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now().subtract(const Duration(days: 30)),
+    );
+    final now = DateTime.now();
+    final yesterday = DateTime(now.year, now.month, now.day)
+        .subtract(const Duration(days: 1));
+    await repo.updateLastGeneratedDate(id, yesterday);
+
+    final service = RecurringTransactionService(repo);
+    final generated = await service.generatePendingTransactions();
+
+    // 昨天 → 今天一笔(daily);明天还没到,停在这。
+    expect(generated, hasLength(1));
+  });
+}


### PR DESCRIPTION
## 问题
issue #135:周期账单创建/修改可选历史开始日期。开始时间为历史日期时,生成逻辑会从该日期一路 catch-up 补齐到今天 → 凭空生成大量历史脏数据(如仅改个备注后多出 12 条)。

## 根因
- `recurring_transaction_edit_page.dart`:开始日期选择器 `minDate: DateTime(2000)`,允许选历史
- `recurring_transaction_service.dart`:`calculateNextDate` 基准 = `lastGenerated ?? startDate`,首次生成(lastGenerated 为 null)时从历史 startDate 无下限回溯

## 修复
1. **UI**:开始日期选择器 `minDate` 限为今天,禁止历史(结束日期不早于开始日期);初始值越界时 clamp 回 minDate
2. **生成逻辑兜底**:从未生成过(lastGenerated 为 null)的账单,基准不早于今天零点 → 只面向未来生成,不补创建之前的历史(也覆盖存量历史 startDate 数据)

## 测试
新增 `test/services/data/recurring_transaction_service_test.dart`:
- 历史开始日期 + 从未生成 → 不回溯(0 笔)
- lastGenerated 非空 → 正常 catch-up 不受影响(补当天 1 笔)

`flutter test` 通过。

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Bug Fixes**
  * 修复周期账单的日期处理逻辑，禁止设置历史开始日期，防止产生重复的账单记录
  * 优化周期账单的生成基准日期计算，避免从历史日期回溯补生成

* **Tests**
  * 新增回归测试用例，验证周期账单在不同场景下的正确生成行为

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TNT-Likely/BeeCount/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->