### PR TITLE
fix(applink): 修复 deep-link 冷启动首次记账失败 + 参数不全提示

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';
 import 'widgets/biz/login_2fa_challenge_view.dart';
+import 'widgets/ui/toast.dart';
 import 'theme.dart';
 import 'providers.dart';
 import 'providers/font_scale_provider.dart';
@@ -330,10 +331,70 @@ void _setupUrlListener(ProviderContainer container) {
       container.read(pendingAppLinkActionProvider.notifier).state = action;
     };
 
-    // 监听URL（应用在后台时）
+    // 用 Navigator 的 OverlayState 直接弹 toast —— deep-link 在冷启动/任意页面
+    // 处理,没有就近 BuildContext;不能用 globalNavigatorKey.currentContext
+    // (它在 Overlay 之上,Overlay.of 找不到祖先 Overlay)。overlay 没就绪时退
+    // 回日志(用 deep-link 的多是极客,日志中心也能看到)。
+    void showAppLinkToast(String message) {
+      final overlay = globalNavigatorKey.currentState?.overlay;
+      if (overlay != null) {
+        showToastOnOverlay(overlay, message);
+      } else {
+        logger.warning('AppLink', 'overlay 未就绪,toast 改记日志: $message');
+      }
+    }
+
+    // 自动记账成功提示("已记录 xx 元")
+    appLinkService.onShowToast = showAppLinkToast;
+
+    // 冷启动时 uriLinkStream 会在 app 还在 Splash 预加载、provider 尚未就绪时
+    // 立即吐出启动 URL。此时直接 handleUrl 会因 currentLedgerProvider 还在
+    // loading 而误判"无账本"静默失败(issue #162)。因此:未 ready 先暂存,等
+    // appInitState 变 ready(Splash 完成、账本已恢复、navigator 已 attach)后
+    // 再统一处理。
+    final pendingUris = <Uri>[];
+
+    bool isAppReady() =>
+        container.read(appInitStateProvider) == AppInitState.ready;
+
+    Future<void> dispatch(Uri uri) async {
+      try {
+        final result = await appLinkService.handleUrl(uri);
+        // 失败/拦截(参数不全、分类不存在等)→ toast 提醒用户。具体原因
+        // _handleAddTransaction 里已记 warning 日志,这里再弹一层。
+        if (!result.success && result.message != null) {
+          logger.warning('AppLink', '处理URL未成功: $uri -> ${result.message}');
+          showAppLinkToast(result.message!);
+        }
+      } catch (e, st) {
+        logger.error('AppLink', '处理URL异常: $uri', e, st);
+      }
+    }
+
+    void flushPendingUris() {
+      if (pendingUris.isEmpty) return;
+      final uris = List<Uri>.from(pendingUris);
+      pendingUris.clear();
+      logger.info('AppLink', '应用已就绪,处理暂存的 ${uris.length} 个URL');
+      for (final uri in uris) {
+        dispatch(uri);
+      }
+    }
+
+    // app 变 ready 时,flush 冷启动期间暂存的 URL
+    container.listen<AppInitState>(appInitStateProvider, (prev, next) {
+      if (next == AppInitState.ready) flushPendingUris();
+    });
+
+    // 监听URL(冷启动初始链接 + 应用在后台时的后续链接都走这里)
     appLinks.uriLinkStream.listen((uri) {
       logger.info('AppLink', '收到URL: $uri');
-      appLinkService.handleUrl(uri);
+      if (isAppReady()) {
+        dispatch(uri);
+      } else {
+        logger.info('AppLink', '应用未就绪,暂存冷启动URL: $uri');
+        pendingUris.add(uri);
+      }
     }, onError: (err) {
       logger.error('AppLink', 'URL监听错误', err);
     });

--- a/lib/services/platform/app_link_service.dart
+++ b/lib/services/platform/app_link_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../data/repositories/base_repository.dart';
 import '../../providers/database_providers.dart';
@@ -316,16 +317,49 @@ class AppLinkService {
   /// 处理自动记账（带参数）
   Future<AppLinkResult> _handleAddTransaction(Map<String, String> params) async {
     try {
-      final txParams = AddTransactionParams.fromQueryParams(params);
-
       final repo = _container.read(repositoryProvider);
-      final currentLedger = _container.read(currentLedgerProvider).valueOrNull;
+
+      // 冷启动早期 _currentLedgerPersist 可能还没把上次选中的账本从
+      // SharedPreferences 恢复出来,currentLedgerId 还是默认值 1 —— 先显式
+      // 校准一次,避免 deep-link 把交易记到错误账本。
+      await _restoreCurrentLedgerId();
+
+      // 必须 await .future:冷启动时 currentLedgerProvider 还在 loading,
+      // 用 .valueOrNull 会拿到 null 而误判"无账本"导致静默失败(issue #162)。
+      final currentLedger = await _container.read(currentLedgerProvider.future);
 
       if (currentLedger == null) {
+        logger.warning('AppLink',
+            '自动记账失败:未找到当前账本 (ledgerId=${_container.read(currentLedgerIdProvider)})');
         return AppLinkResult.failure('请先选择账本');
       }
 
       final ledgerId = currentLedger.id;
+      final type = params['type'] ?? 'expense';
+
+      // —— 完整性校验 —— 金额无效 / 缺分类 / 分类不存在 → 不记账,返回具体原因
+      // (由上层用 toast 提醒用户)。转账没有分类概念,只校验金额。
+      final parsedAmount = double.tryParse(params['amount'] ?? '');
+      if (parsedAmount == null || parsedAmount <= 0) {
+        logger.warning('AppLink', '已拦截:金额无效 (amount=${params['amount']})');
+        return AppLinkResult.failure('未记账:请填写有效金额');
+      }
+      if (type != 'transfer') {
+        final categoryName = params['category'];
+        if (categoryName == null || categoryName.isEmpty) {
+          logger.warning('AppLink', '已拦截:缺少分类');
+          return AppLinkResult.failure('未记账:请指定分类');
+        }
+        final matched = await _findCategoryId(
+            repo, categoryName, type == 'income' ? 'income' : 'expense');
+        if (matched == null) {
+          logger.warning('AppLink', '已拦截:分类「$categoryName」不存在');
+          return AppLinkResult.failure('未记账:分类「$categoryName」不存在');
+        }
+      }
+
+      // —— 参数齐全:自动记账(原逻辑)——
+      final txParams = AddTransactionParams.fromQueryParams(params);
 
       // 解析分类
       int? categoryId;
@@ -403,6 +437,24 @@ class AppLinkService {
     } catch (e, st) {
       logger.error('AppLink', '自动记账失败', e, st);
       return AppLinkResult.failure('记账失败: $e');
+    }
+  }
+
+  /// 从持久化恢复上次选中的账本 id。
+  ///
+  /// 冷启动通过 deep-link 触发记账时,Splash 的 `_currentLedgerPersist` 恢复
+  /// 逻辑可能还没跑完(它是 fire-and-forget,不被 await),currentLedgerId 还
+  /// 停在默认值 1。这里显式、幂等地校准一次,确保记到用户真正选中的账本。
+  Future<void> _restoreCurrentLedgerId() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final saved = prefs.getInt('current_ledger_id');
+      if (saved != null &&
+          _container.read(currentLedgerIdProvider) != saved) {
+        _container.read(currentLedgerIdProvider.notifier).state = saved;
+      }
+    } catch (_) {
+      // 恢复失败不致命,退回当前(可能为默认)账本。
     }
   }
 

--- a/lib/widgets/ui/toast.dart
+++ b/lib/widgets/ui/toast.dart
@@ -4,8 +4,21 @@ import '../../styles/tokens.dart';
 /// 轻量 Toast（基础 UI 工具）：覆盖层展示，不占据布局，不顶起 FAB
 void showToast(BuildContext context, String message,
     {Duration duration = const Duration(seconds: 2)}) {
-  final overlay = Overlay.of(context, rootOverlay: true);
-  final isDark = BeeTokens.isDark(context);
+  showToastOnOverlay(
+    Overlay.of(context, rootOverlay: true),
+    message,
+    duration: duration,
+    isDark: BeeTokens.isDark(context),
+  );
+}
+
+/// 用指定的 OverlayState 直接弹 Toast —— 给没有就近 BuildContext 的全局场景
+/// (如 deep-link 处理:`globalNavigatorKey.currentState?.overlay`)。普通页面
+/// 请用 [showToast]。注意不能用 navigator 的 context 走 [showToast],因为它在
+/// Overlay 之上,`Overlay.of` 找不到祖先 Overlay 会抛 "No Overlay widget found"。
+void showToastOnOverlay(OverlayState overlay, String message,
+    {Duration duration = const Duration(seconds: 2), bool? isDark}) {
+  final dark = isDark ?? BeeTokens.isDark(overlay.context);
 
   final entry = OverlayEntry(
     builder: (ctx) => Positioned.fill(
@@ -23,7 +36,7 @@ void showToast(BuildContext context, String message,
                   color: Colors.black.withValues(alpha: 0.85),
                   borderRadius: BorderRadius.circular(12),
                   // 暗黑模式下添加白色阴影，提升可见度
-                  boxShadow: isDark ? [
+                  boxShadow: dark ? [
                     BoxShadow(
                       color: Colors.white.withValues(alpha: 0.2),
                       blurRadius: 8,


### PR DESCRIPTION
## 问题

issue #162:`beecount://` 快捷指令 / URL 冷启动唤起 app 时**首次不记账**,需再触发一次才正常。部分设备复现、部分正常,安卓 iOS 均有。

## 根因

冷启动时 `uriLinkStream` 在 Splash 预加载阶段就吐出初始 URL,此时 `currentLedgerProvider`(FutureProvider)仍在 loading。`_handleAddTransaction` 用 `.valueOrNull` 同步读到 `null`,误判「请先选择账本」走 failure 静默退出 —— 既没记账,`handleUrl` 的返回值又被丢弃,连提示都没有。热启动时该 provider 早已就绪,所以「再触发一次就好」。

**非 iOS 特有**,是 Dart 层 provider 时序问题(原生 scheme 配置正常)。

## 修复

- **暂存到 ready**:冷启动 URL 未就绪先暂存,待 `appInitState == ready`(Splash 完成、账本恢复、navigator attach)后统一处理
- **await future**:`.valueOrNull` → `await currentLedgerProvider.future`
- **校准账本**:记账前从持久化校准 `currentLedgerId`,避免冷启动早期记到默认账本 1
- **不再静默**:金额无效 / 分类不存在等改 toast 提醒(走 navigator overlay,顺带修了之前 `No Overlay widget found`;成功的「已记录 xx 元」也一并修好)

## 不影响

- 安卓图片分享(MethodChannel)、iOS 快捷指令截图记账(AppIntent EventChannel):独立通道,未改动
- `beecount://new`、桌面小组件、voice/image/camera/ai-chat:行为不变

## 测试

真机 / 模拟器**完全杀进程**后用命令唤起,看应用内日志中心确认首次即记账成功:

```
# iOS 模拟器
xcrun simctl openurl booted "beecount://add?amount=100&type=expense&category=餐饮"
# Android
adb shell am start -a android.intent.action.VIEW -d "beecount://add?amount=100&type=expense&category=餐饮"
```

Closes #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 深层链接现在可在应用启动过程中更可靠地显示提示消息

* **错误修复**
  * 改进冷启动时账本的初始化和恢复逻辑
  * 增强自动记账的参数校验，提前捕获无效的金额和分类信息
  * 优化深层链接场景下的提示弹窗显示机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->