### PR TITLE
feat: 账户与资产管理优化(编辑页重做 + 信用卡展示对齐 + loading 修复)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2599,6 +2599,8 @@
   "appLockTimeout5Min": "After 5 minutes",
   "appLockTimeout15Min": "After 15 minutes",
   "creditCardSettings": "Credit Card Settings",
+  "accountTabValuation": "Valuation",
+  "creditCardDaysRequired": "Please select billing & due dates",
   "creditLimit": "Credit Limit",
   "creditLimitHint": "Enter credit limit",
   "billingDay": "Billing Day",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11214,6 +11214,18 @@ abstract class AppLocalizations {
   /// **'Credit Card Settings'**
   String get creditCardSettings;
 
+  /// No description provided for @accountTabValuation.
+  ///
+  /// In en, this message translates to:
+  /// **'Valuation'**
+  String get accountTabValuation;
+
+  /// No description provided for @creditCardDaysRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please select billing & due dates'**
+  String get creditCardDaysRequired;
+
   /// No description provided for @creditLimit.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5872,6 +5872,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get creditCardSettings => 'Credit Card Settings';
 
   @override
+  String get accountTabValuation => 'Valuation';
+
+  @override
+  String get creditCardDaysRequired => 'Please select billing & due dates';
+
+  @override
   String get creditLimit => 'Credit Limit';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5872,6 +5872,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get creditCardSettings => '信用卡设置';
 
   @override
+  String get accountTabValuation => '估值账户';
+
+  @override
+  String get creditCardDaysRequired => '请选择账单日和还款日';
+
+  @override
   String get creditLimit => '信用额度';
 
   @override
@@ -12394,6 +12400,12 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get creditCardSettings => '信用卡設定';
+
+  @override
+  String get accountTabValuation => '估值帳戶';
+
+  @override
+  String get creditCardDaysRequired => '請選擇帳單日和還款日';
 
   @override
   String get creditLimit => '信用額度';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2559,6 +2559,8 @@
   "appLockTimeout5Min": "5分钟后",
   "appLockTimeout15Min": "15分钟后",
   "creditCardSettings": "信用卡设置",
+  "accountTabValuation": "估值账户",
+  "creditCardDaysRequired": "请选择账单日和还款日",
   "creditLimit": "信用额度",
   "creditLimitHint": "请输入信用额度",
   "billingDay": "账单日",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -2338,6 +2338,8 @@
   "appLockTimeout5Min": "5分鐘後",
   "appLockTimeout15Min": "15分鐘後",
   "creditCardSettings": "信用卡設定",
+  "accountTabValuation": "估值帳戶",
+  "creditCardDaysRequired": "請選擇帳單日和還款日",
   "creditLimit": "信用額度",
   "creditLimitHint": "請輸入信用額度",
   "billingDay": "帳單日",

--- a/lib/pages/account/account_detail_page.dart
+++ b/lib/pages/account/account_detail_page.dart
@@ -186,7 +186,6 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
         (accountId: widget.account.id, type: 'income')));
 
     final account = widget.account;
-    final isDark = BeeTokens.isDark(context);
     final typeColor = getColorForAccountType(account.type, primaryColor);
     final isValuation = isValuationOnlyType(account.type);
 
@@ -238,9 +237,12 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
                   // 估值账户：显示估值卡片
                   _buildValuationCard(context, ref, account, statsAsync, currencyCode, primaryColor, l10n),
                 ] else ...[
-                  // 可交易账户：余额/收入/支出统计卡片
-                  _buildStatsCard(context, ref, account, statsAsync, currencyCode, l10n),
-                  SizedBox(height: 4.0.scaled(context, ref)),
+                  // 信用卡不显示"收入/支出"卡(概念错位),概览卡=欠款/额度/还款即主卡;
+                  // 其它可交易账户仍显示 余额/收入/支出
+                  if (account.type != 'credit_card') ...[
+                    _buildStatsCard(context, ref, account, statsAsync, currencyCode, l10n),
+                    SizedBox(height: 4.0.scaled(context, ref)),
+                  ],
                   // 账户概览卡片（合并 metadata + 类型统计）
                   _buildOverviewCard(
                     context, ref, account, statsAsync,
@@ -249,10 +251,11 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
 
                   SizedBox(height: 8.0.scaled(context, ref)),
 
-                  // 图表区域（支出分布/收入分布 切换）
+                  // 图表区域（支出分布/收入分布 切换;信用卡仅消费分布）
                   _buildDetailChartSection(
                     context, ref, l10n, primaryColor,
                     expenseStatsAsync, incomeStatsAsync, typeColor,
+                    isCreditCard: account.type == 'credit_card',
                   ),
 
                   SizedBox(height: 12.0.scaled(context, ref)),
@@ -611,10 +614,12 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
     Color typeColor,
     AppLocalizations l10n,
   ) {
-    if (account.type == 'credit_card' && account.creditLimit != null) {
-      final creditLimit = account.creditLimit!;
+    if (account.type == 'credit_card') {
+      final creditLimit = account.creditLimit;
       final usedAmount = stats.balance < 0 ? -stats.balance : 0.0;
-      final usageRate = creditLimit > 0 ? (usedAmount / creditLimit).clamp(0.0, 1.0) : 0.0;
+      final usageRate = (creditLimit != null && creditLimit > 0)
+          ? (usedAmount / creditLimit).clamp(0.0, 1.0)
+          : 0.0;
 
       // 计算距还款日天数
       final hasBillingInfo = account.billingDay != null && account.paymentDueDay != null;
@@ -633,28 +638,55 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
       }
 
       return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // 当前欠款(待还) —— 永远显示,不依赖额度
           Row(
             children: [
-              Expanded(child: _OverviewStatCell(label: l10n.creditLimit, value: creditLimit)),
-              Expanded(child: _OverviewStatCell(label: l10n.creditUsed, value: usedAmount)),
-              Expanded(child: _OverviewStatCell(label: l10n.creditAvailable, value: creditLimit - usedAmount)),
+              Text(
+                l10n.creditCardOwed,
+                style: TextStyle(fontSize: 13, color: BeeTokens.textSecondary(context)),
+              ),
+              const Spacer(),
+              AmountText(
+                value: usedAmount,
+                signed: false,
+                showCurrency: false,
+                useCompactFormat: ref.watch(compactAmountProvider),
+                currencyCode: currencyCode,
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: BeeTokens.textPrimary(context),
+                ),
+              ),
             ],
           ),
-          SizedBox(height: 8.0.scaled(context, ref)),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(2),
-            child: LinearProgressIndicator(
-              value: usageRate,
-              backgroundColor: BeeTokens.divider(context),
-              valueColor: AlwaysStoppedAnimation<Color>(
-                usageRate < 0.5 ? BeeTokens.success(context)
-                    : usageRate < 0.8 ? BeeTokens.warning(context)
-                    : BeeTokens.error(context),
-              ),
-              minHeight: 4,
+          // 额度/已用/可用 + 进度条 —— 仅设过额度时
+          if (creditLimit != null) ...[
+            SizedBox(height: 12.0.scaled(context, ref)),
+            Row(
+              children: [
+                Expanded(child: _OverviewStatCell(label: l10n.creditLimit, value: creditLimit)),
+                Expanded(child: _OverviewStatCell(label: l10n.creditUsed, value: usedAmount)),
+                Expanded(child: _OverviewStatCell(label: l10n.creditAvailable, value: creditLimit - usedAmount)),
+              ],
             ),
-          ),
+            SizedBox(height: 8.0.scaled(context, ref)),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: LinearProgressIndicator(
+                value: usageRate,
+                backgroundColor: BeeTokens.divider(context),
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  usageRate < 0.5 ? BeeTokens.success(context)
+                      : usageRate < 0.8 ? BeeTokens.warning(context)
+                      : BeeTokens.error(context),
+                ),
+                minHeight: 4,
+              ),
+            ),
+          ],
           // 账单日/还款日信息
           if (hasBillingInfo || account.paymentDueDay != null) ...[
             SizedBox(height: 10.0.scaled(context, ref)),
@@ -744,8 +776,9 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
     Color primaryColor,
     AsyncValue<List<({int? id, String name, String? icon, double total})>> expenseStatsAsync,
     AsyncValue<List<({int? id, String name, String? icon, double total})>> incomeStatsAsync,
-    Color typeColor,
-  ) {
+    Color typeColor, {
+    required bool isCreditCard,
+  }) {
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 12.0.scaled(context, ref)),
       child: SectionCard(
@@ -760,22 +793,24 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
                 children: [
                   _DetailChartTab(
                     label: l10n.homeExpense,
-                    isSelected: _detailChartTab == 0,
+                    isSelected: isCreditCard || _detailChartTab == 0,
                     primaryColor: primaryColor,
                     onTap: () => setState(() => _detailChartTab = 0),
                   ),
-                  SizedBox(width: 6.0.scaled(context, ref)),
-                  _DetailChartTab(
-                    label: l10n.homeIncome,
-                    isSelected: _detailChartTab == 1,
-                    primaryColor: primaryColor,
-                    onTap: () => setState(() => _detailChartTab = 1),
-                  ),
+                  if (!isCreditCard) ...[
+                    SizedBox(width: 6.0.scaled(context, ref)),
+                    _DetailChartTab(
+                      label: l10n.homeIncome,
+                      isSelected: _detailChartTab == 1,
+                      primaryColor: primaryColor,
+                      onTap: () => setState(() => _detailChartTab = 1),
+                    ),
+                  ],
                 ],
               ),
               SizedBox(height: 12.0.scaled(context, ref)),
               // 图表内容
-              if (_detailChartTab == 0)
+              if (isCreditCard || _detailChartTab == 0)
                 expenseStatsAsync.when(
                   data: (data) {
                     if (data.isEmpty) {

--- a/lib/pages/account/account_edit_page.dart
+++ b/lib/pages/account/account_edit_page.dart
@@ -4,7 +4,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../providers.dart';
 import '../../widgets/ui/ui.dart';
 import '../../widgets/biz/section_card.dart';
-import '../../widgets/biz/app_list_tile.dart';
 import '../../data/db.dart' as db;
 import '../../l10n/app_localizations.dart';
 import '../../services/billing/post_processor.dart';
@@ -45,8 +44,10 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
   bool _saving = false;
   bool _isNameDuplicate = false;
   String? _nameErrorText;
+  // 账户类型 Tab：0 = 日常账户，1 = 估值账户
+  int _typeTab = 0;
 
-  // 可交易账户类型
+  // 日常账户类型（走流水）
   static const List<String> tradableAccountTypes = [
     'cash',
     'bank_card',
@@ -56,7 +57,7 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
     'other',
   ];
 
-  // 估值账户类型
+  // 估值账户类型（只记当前价值 / 欠款，不走流水）
   static const List<String> valuationAccountTypes = [
     'real_estate',
     'vehicle',
@@ -88,6 +89,7 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
     _selectedCurrency = widget.account?.currency ?? 'CNY';
     _billingDay = widget.account?.billingDay;
     _paymentDueDay = widget.account?.paymentDueDay;
+    _typeTab = isValuationOnlyType(_selectedType) ? 1 : 0;
     _loadReminderSettings();
   }
 
@@ -171,10 +173,77 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
     }
   }
 
+  /// 切换账户类型：复用旧逻辑——离开信用卡/银行卡时清空对应字段。
+  void _selectType(String type) {
+    setState(() {
+      final oldType = _selectedType;
+      _selectedType = type;
+      if (oldType == 'credit_card' && type != 'credit_card') {
+        _creditLimitController.clear();
+        _billingDay = null;
+        _paymentDueDay = null;
+        _reminderEnabled = false;
+      }
+      final wasBankOrCredit = oldType == 'bank_card' || oldType == 'credit_card';
+      final isBankOrCredit = type == 'bank_card' || type == 'credit_card';
+      if (wasBankOrCredit && !isBankOrCredit) {
+        _bankNameController.clear();
+        _cardLastFourController.clear();
+      }
+    });
+  }
+
+  TextStyle _sectionTitle(BuildContext context) => TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        color: BeeTokens.textPrimary(context),
+      );
+
+  /// 资产/负债 分段标签
+  Widget _segTab(BuildContext context,
+      {required String label,
+      required bool selected,
+      required Color primaryColor,
+      required VoidCallback onTap}) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          padding: EdgeInsets.symmetric(vertical: 8.0.scaled(context, ref)),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: selected ? BeeTokens.surfaceElevated(context) : Colors.transparent,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+              color: selected ? primaryColor : BeeTokens.textSecondary(context),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final primaryColor = ref.watch(primaryColorProvider);
+
+    // 统一的 filled 圆角输入框装饰（委托顶层实现，便于点击式字段框复用）
+    InputDecoration filledDec(
+            {String? label, String? hint, String? prefix, String? errorText}) =>
+        _filledDecoration(context, primaryColor,
+            label: label, hint: hint, prefix: prefix, errorText: errorText);
+
+    final typesForTab = _typeTab == 0 ? tradableAccountTypes : valuationAccountTypes;
+    final isCreditCard = _selectedType == 'credit_card';
+    final isBankCard = _selectedType == 'bank_card';
 
     return Scaffold(
       backgroundColor: BeeTokens.scaffoldBackground(context),
@@ -192,10 +261,11 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
                   left: 12.0.scaled(context, ref),
                   right: 12.0.scaled(context, ref),
                   top: 8.0.scaled(context, ref),
-                  bottom: 8.0.scaled(context, ref) + MediaQuery.of(context).padding.bottom,
+                  bottom: 8.0.scaled(context, ref) +
+                      MediaQuery.of(context).padding.bottom,
                 ),
                 children: [
-                  // 账户名称
+                  // ===== 账户类型（资产/负债 Tab + 缩小网格）=====
                   SectionCard(
                     margin: EdgeInsets.zero,
                     child: Padding(
@@ -203,50 +273,75 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            l10n.accountNameLabel,
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: BeeTokens.textPrimary(context),
+                          Container(
+                            padding: const EdgeInsets.all(4),
+                            decoration: BoxDecoration(
+                              color: BeeTokens.surfaceInput(context),
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Row(
+                              children: [
+                                _segTab(context,
+                                    label: l10n.accountGroupTradable,
+                                    selected: _typeTab == 0,
+                                    primaryColor: primaryColor,
+                                    onTap: () => setState(() => _typeTab = 0)),
+                                _segTab(context,
+                                    label: l10n.accountTabValuation,
+                                    selected: _typeTab == 1,
+                                    primaryColor: primaryColor,
+                                    onTap: () => setState(() => _typeTab = 1)),
+                              ],
                             ),
                           ),
-                          SizedBox(height: 12.0.scaled(context, ref)),
+                          SizedBox(height: 16.0.scaled(context, ref)),
+                          GridView.count(
+                            crossAxisCount: 4,
+                            shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            mainAxisSpacing: 10.0.scaled(context, ref),
+                            crossAxisSpacing: 10.0.scaled(context, ref),
+                            childAspectRatio: 1.0,
+                            children: typesForTab.map((type) {
+                              final isSelected = _selectedType == type;
+                              // 编辑模式禁止跨“可交易 / 估值”大类切换（语义不同）
+                              final disabled = isEditing &&
+                                  isValuationOnlyType(type) !=
+                                      isValuationOnlyType(widget.account!.type);
+                              return _AccountTypeCard(
+                                type: type,
+                                label: getAccountTypeLabel(context, type),
+                                isSelected: isSelected,
+                                primaryColor: primaryColor,
+                                disabled: disabled,
+                                onTap: disabled ? () {} : () => _selectType(type),
+                              );
+                            }).toList(),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+
+                  SizedBox(height: 8.0.scaled(context, ref)),
+
+                  // ===== 基本（名称 + 币种/余额）=====
+                  SectionCard(
+                    margin: EdgeInsets.zero,
+                    child: Padding(
+                      padding: EdgeInsets.all(16.0.scaled(context, ref)),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
                           TextFormField(
                             controller: _nameController,
-                            decoration: InputDecoration(
-                              hintText: l10n.accountNameHint,
-                              hintStyle: TextStyle(color: Colors.grey[400]),
+                            decoration: filledDec(
+                              label: l10n.accountNameLabel,
+                              hint: l10n.accountNameHint,
                               errorText: _nameErrorText,
-                              errorStyle: const TextStyle(
-                                color: Colors.red,
-                                fontSize: 12,
-                              ),
-                              border: UnderlineInputBorder(
-                                borderSide:
-                                    BorderSide(color: Colors.grey[300]!),
-                              ),
-                              enabledBorder: UnderlineInputBorder(
-                                borderSide: BorderSide(
-                                  color: _isNameDuplicate
-                                      ? Colors.red
-                                      : Colors.grey[300]!,
-                                ),
-                              ),
-                              focusedBorder: UnderlineInputBorder(
-                                borderSide: BorderSide(
-                                  color: _isNameDuplicate ? Colors.red : primaryColor,
-                                  width: 2,
-                                ),
-                              ),
-                              contentPadding: EdgeInsets.symmetric(
-                                vertical: 8.0.scaled(context, ref),
-                              ),
                             ),
                             style: const TextStyle(fontSize: 16),
-                            onChanged: (value) {
-                              _checkNameDuplicate(value);
-                            },
+                            onChanged: (value) => _checkNameDuplicate(value),
                             validator: (value) {
                               if (value == null || value.trim().isEmpty) {
                                 return l10n.accountNameRequired;
@@ -254,217 +349,95 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
                               return null;
                             },
                           ),
-                        ],
-                      ),
-                    ),
-                  ),
-
-                  SizedBox(height: 8.0.scaled(context, ref)),
-
-                  // 账户类型
-                  SectionCard(
-                    margin: EdgeInsets.zero,
-                    child: Padding(
-                      padding: EdgeInsets.all(16.0.scaled(context, ref)),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            l10n.accountGroupTradable,
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: BeeTokens.textPrimary(context),
-                            ),
-                          ),
-                          SizedBox(height: 16.0.scaled(context, ref)),
-                          GridView.count(
-                            crossAxisCount: 3,
-                            shrinkWrap: true,
-                            physics: const NeverScrollableScrollPhysics(),
-                            mainAxisSpacing: 12.0.scaled(context, ref),
-                            crossAxisSpacing: 12.0.scaled(context, ref),
-                            childAspectRatio: 1.2,
-                            children: tradableAccountTypes.map((type) {
-                              final isSelected = _selectedType == type;
-                              // 编辑模式下，如果当前是估值账户则禁止选择可交易类型
-                              final disabled = isEditing && isValuationOnlyType(widget.account!.type);
-                              return _AccountTypeCard(
-                                type: type,
-                                label: getAccountTypeLabel(context, type),
-                                isSelected: isSelected,
-                                primaryColor: primaryColor,
-                                disabled: disabled,
-                                onTap: disabled ? () {} : () {
-                                  setState(() {
-                                    final oldType = _selectedType;
-                                    _selectedType = type;
-                                    // 离开信用卡类型时清空信用卡字段
-                                    if (oldType == 'credit_card' && type != 'credit_card') {
-                                      _creditLimitController.clear();
-                                      _billingDay = null;
-                                      _paymentDueDay = null;
-                                      _reminderEnabled = false;
-                                    }
-                                    // 离开银行卡/信用卡类型时清空元信息字段
-                                    final wasBankOrCredit = oldType == 'bank_card' || oldType == 'credit_card';
-                                    final isBankOrCredit = type == 'bank_card' || type == 'credit_card';
-                                    if (wasBankOrCredit && !isBankOrCredit) {
-                                      _bankNameController.clear();
-                                      _cardLastFourController.clear();
-                                    }
-                                  });
-                                },
-                              );
-                            }).toList(),
-                          ),
-                          SizedBox(height: 20.0.scaled(context, ref)),
-                          Text(
-                            l10n.accountGroupValuation,
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: BeeTokens.textPrimary(context),
-                            ),
-                          ),
-                          SizedBox(height: 16.0.scaled(context, ref)),
-                          GridView.count(
-                            crossAxisCount: 3,
-                            shrinkWrap: true,
-                            physics: const NeverScrollableScrollPhysics(),
-                            mainAxisSpacing: 12.0.scaled(context, ref),
-                            crossAxisSpacing: 12.0.scaled(context, ref),
-                            childAspectRatio: 1.2,
-                            children: valuationAccountTypes.map((type) {
-                              final isSelected = _selectedType == type;
-                              // 编辑模式下，如果当前是可交易账户则禁止选择估值类型
-                              final disabled = isEditing && isTradableType(widget.account!.type);
-                              return _AccountTypeCard(
-                                type: type,
-                                label: getAccountTypeLabel(context, type),
-                                isSelected: isSelected,
-                                primaryColor: primaryColor,
-                                disabled: disabled,
-                                onTap: disabled ? () {} : () {
-                                  setState(() {
-                                    _selectedType = type;
-                                    // 清空不相关字段
-                                    _creditLimitController.clear();
-                                    _billingDay = null;
-                                    _paymentDueDay = null;
-                                    _reminderEnabled = false;
-                                    _bankNameController.clear();
-                                    _cardLastFourController.clear();
-                                  });
-                                },
-                              );
-                            }).toList(),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-
-                  SizedBox(height: 8.0.scaled(context, ref)),
-
-                  // v1.15.0: 币种选择
-                  SectionCard(
-                    margin: EdgeInsets.zero,
-                    child: AppListTile(
-                      leading: Icons.monetization_on_outlined,
-                      title: l10n.ledgersCurrency,
-                      subtitle: displayCurrency(_selectedCurrency, context),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap: () async {
-                        // 检查是否有交易记录
-                        if (isEditing) {
-                          final repo = ref.read(repositoryProvider);
-                          final hasTransactions = await repo.hasTransactions(widget.account!.id);
-                          if (hasTransactions) {
-                            if (!mounted) return;
-                            await AppDialog.info(
-                              context,
-                              title: l10n.commonNotice,
-                              message: l10n.accountCurrencyLocked,
-                            );
-                            return;
-                          }
-                        }
-
-                        if (!mounted) return;
-                        final picked = await _showCurrencyPicker(context, initial: _selectedCurrency);
-                        if (picked != null) {
-                          setState(() => _selectedCurrency = picked);
-                        }
-                      },
-                    ),
-                  ),
-
-                  SizedBox(height: 8.0.scaled(context, ref)),
-
-                  // 初始资金
-                  SectionCard(
-                    margin: EdgeInsets.zero,
-                    child: Padding(
-                      padding: EdgeInsets.all(16.0.scaled(context, ref)),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            _getInitialBalanceLabel(l10n),
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: BeeTokens.textPrimary(context),
-                            ),
-                          ),
                           SizedBox(height: 12.0.scaled(context, ref)),
-                          TextFormField(
-                            controller: _initialBalanceController,
-                            decoration: InputDecoration(
-                              hintText: _getInitialBalanceHint(l10n),
-                              hintStyle: TextStyle(color: Colors.grey[400]),
-                              prefixText: '${getCurrencySymbol(_selectedCurrency)} ',
-                              prefixStyle: TextStyle(
-                                fontSize: 16,
-                                color: BeeTokens.textPrimary(context),
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              SizedBox(
+                                width: 120.0.scaled(context, ref),
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(12),
+                                  onTap: () async {
+                                    // 同账单日：开选择器前先收键盘
+                                    FocusManager.instance.primaryFocus?.unfocus();
+                                    if (isEditing) {
+                                      final repo = ref.read(repositoryProvider);
+                                      final hasTransactions = await repo
+                                          .hasTransactions(widget.account!.id);
+                                      if (hasTransactions) {
+                                        if (!context.mounted) return;
+                                        await AppDialog.info(
+                                          context,
+                                          title: l10n.commonNotice,
+                                          message: l10n.accountCurrencyLocked,
+                                        );
+                                        return;
+                                      }
+                                    }
+                                    if (!context.mounted) return;
+                                    final picked = await _showCurrencyPicker(
+                                        context,
+                                        initial: _selectedCurrency);
+                                    if (picked != null) {
+                                      setState(() => _selectedCurrency = picked);
+                                    }
+                                  },
+                                  child: InputDecorator(
+                                    decoration:
+                                        filledDec(label: l10n.ledgersCurrency),
+                                    child: Row(
+                                      children: [
+                                        Expanded(
+                                          child: Text(
+                                            displayCurrency(
+                                                _selectedCurrency, context),
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: const TextStyle(fontSize: 16),
+                                          ),
+                                        ),
+                                        Icon(Icons.expand_more,
+                                            size: 18.0.scaled(context, ref),
+                                            color:
+                                                BeeTokens.iconTertiary(context)),
+                                      ],
+                                    ),
+                                  ),
+                                ),
                               ),
-                              border: UnderlineInputBorder(
-                                borderSide:
-                                    BorderSide(color: Colors.grey[300]!),
+                              SizedBox(width: 12.0.scaled(context, ref)),
+                              Expanded(
+                                child: TextFormField(
+                                  controller: _initialBalanceController,
+                                  decoration: filledDec(
+                                    label: _getInitialBalanceLabel(l10n),
+                                    hint: _getInitialBalanceHint(l10n),
+                                    prefix:
+                                        '${getCurrencySymbol(_selectedCurrency)} ',
+                                  ),
+                                  style: const TextStyle(fontSize: 16),
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                          decimal: true, signed: true),
+                                  validator: (value) {
+                                    if (value != null && value.trim().isNotEmpty) {
+                                      if (double.tryParse(value.trim()) == null) {
+                                        return '请输入有效的金额';
+                                      }
+                                    }
+                                    return null;
+                                  },
+                                ),
                               ),
-                              enabledBorder: UnderlineInputBorder(
-                                borderSide:
-                                    BorderSide(color: Colors.grey[300]!),
-                              ),
-                              focusedBorder: UnderlineInputBorder(
-                                borderSide:
-                                    BorderSide(color: primaryColor, width: 2),
-                              ),
-                              contentPadding: EdgeInsets.symmetric(
-                                vertical: 8.0.scaled(context, ref),
-                              ),
-                            ),
-                            style: const TextStyle(fontSize: 16),
-                            keyboardType: const TextInputType.numberWithOptions(
-                                decimal: true, signed: true),
-                            validator: (value) {
-                              if (value != null && value.trim().isNotEmpty) {
-                                final parsed = double.tryParse(value.trim());
-                                if (parsed == null) {
-                                  return '请输入有效的金额';
-                                }
-                              }
-                              return null;
-                            },
+                            ],
                           ),
                         ],
                       ),
                     ),
                   ),
 
-                  // 信用卡设置（仅信用卡类型显示）
-                  if (_selectedType == 'credit_card') ...[
+                  // ===== 信用卡信息（仅 credit_card）=====
+                  if (isCreditCard) ...[
                     SizedBox(height: 8.0.scaled(context, ref)),
                     SectionCard(
                       margin: EdgeInsets.zero,
@@ -473,71 +446,86 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
-                              l10n.creditCardSettings,
-                              style: TextStyle(
-                                fontSize: 14,
-                                fontWeight: FontWeight.w600,
-                                color: BeeTokens.textPrimary(context),
-                              ),
-                            ),
+                            Text(l10n.creditCardSettings, style: _sectionTitle(context)),
                             SizedBox(height: 12.0.scaled(context, ref)),
-                            // 信用额度
+                            // 信用额度（必填）
                             TextFormField(
                               controller: _creditLimitController,
-                              decoration: InputDecoration(
-                                labelText: l10n.creditLimit,
-                                hintText: l10n.creditLimitHint,
-                                hintStyle: TextStyle(color: Colors.grey[400]),
-                                prefixText: '${getCurrencySymbol(_selectedCurrency)} ',
-                                prefixStyle: TextStyle(
-                                  fontSize: 16,
-                                  color: BeeTokens.textPrimary(context),
-                                ),
-                                border: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.grey[300]!),
-                                ),
-                                enabledBorder: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.grey[300]!),
-                                ),
-                                focusedBorder: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: primaryColor, width: 2),
-                                ),
-                                contentPadding: EdgeInsets.symmetric(
-                                  vertical: 8.0.scaled(context, ref),
-                                ),
+                              decoration: filledDec(
+                                label: '${l10n.creditLimit} *',
+                                hint: l10n.creditLimitHint,
+                                prefix: '${getCurrencySymbol(_selectedCurrency)} ',
                               ),
                               style: const TextStyle(fontSize: 16),
-                              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                              keyboardType: const TextInputType.numberWithOptions(
+                                  decimal: true),
                               validator: (value) {
-                                if (value != null && value.trim().isNotEmpty) {
-                                  final parsed = double.tryParse(value.trim());
-                                  if (parsed == null || parsed < 0) {
-                                    return '请输入有效的额度';
-                                  }
+                                final t = value?.trim() ?? '';
+                                final parsed = double.tryParse(t);
+                                if (t.isEmpty || parsed == null || parsed <= 0) {
+                                  return l10n.creditLimitHint;
                                 }
                                 return null;
                               },
                             ),
-                            SizedBox(height: 16.0.scaled(context, ref)),
-                            // 账单日
-                            _DayPickerTile(
-                              label: l10n.billingDay,
-                              value: _billingDay,
-                              primaryColor: primaryColor,
-                              onChanged: (day) => setState(() => _billingDay = day),
-                            ),
-                            SizedBox(height: 8.0.scaled(context, ref)),
-                            // 还款日
-                            _DayPickerTile(
-                              label: l10n.paymentDueDay,
-                              value: _paymentDueDay,
-                              primaryColor: primaryColor,
-                              onChanged: (day) => setState(() => _paymentDueDay = day),
+                            SizedBox(height: 12.0.scaled(context, ref)),
+                            // 账单日 / 还款日（双列，必填）
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: _DayPickerTile(
+                                    label: '${l10n.billingDay} *',
+                                    value: _billingDay,
+                                    primaryColor: primaryColor,
+                                    onChanged: (day) =>
+                                        setState(() => _billingDay = day),
+                                  ),
+                                ),
+                                SizedBox(width: 12.0.scaled(context, ref)),
+                                Expanded(
+                                  child: _DayPickerTile(
+                                    label: '${l10n.paymentDueDay} *',
+                                    value: _paymentDueDay,
+                                    primaryColor: primaryColor,
+                                    onChanged: (day) =>
+                                        setState(() => _paymentDueDay = day),
+                                  ),
+                                ),
+                              ],
                             ),
                             SizedBox(height: 12.0.scaled(context, ref)),
-                            // 还款提醒
+                            // 开户行 / 卡号后四（双列）
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: _bankNameController,
+                                    decoration: filledDec(
+                                      label: l10n.accountBankName,
+                                      hint: l10n.accountBankNameHint,
+                                    ),
+                                    style: const TextStyle(fontSize: 16),
+                                  ),
+                                ),
+                                SizedBox(width: 12.0.scaled(context, ref)),
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: _cardLastFourController,
+                                    decoration: filledDec(
+                                      label: l10n.accountCardLastFour,
+                                      hint: l10n.accountCardLastFourHint,
+                                    ).copyWith(counterText: ''),
+                                    style: const TextStyle(fontSize: 16),
+                                    maxLength: 4,
+                                    keyboardType: TextInputType.number,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            SizedBox(height: 4.0.scaled(context, ref)),
                             Divider(color: BeeTokens.divider(context)),
+                            // 还款提醒
                             SwitchListTile(
                               dense: true,
                               contentPadding: EdgeInsets.zero,
@@ -557,7 +545,8 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
                               ),
                               value: _reminderEnabled,
                               activeColor: primaryColor,
-                              onChanged: (value) => setState(() => _reminderEnabled = value),
+                              onChanged: (value) =>
+                                  setState(() => _reminderEnabled = value),
                             ),
                             if (_reminderEnabled) ...[
                               SizedBox(height: 4.0.scaled(context, ref)),
@@ -566,15 +555,22 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
                                 children: [1, 3, 5, 7].map((days) {
                                   final isSelected = _reminderDaysBefore == days;
                                   return ChoiceChip(
-                                    label: Text(l10n.creditCardReminderDaysBefore(days)),
+                                    label: Text(
+                                        l10n.creditCardReminderDaysBefore(days)),
                                     selected: isSelected,
-                                    selectedColor: primaryColor.withValues(alpha: 0.15),
+                                    selectedColor:
+                                        primaryColor.withValues(alpha: 0.15),
                                     labelStyle: TextStyle(
                                       fontSize: 12,
-                                      color: isSelected ? primaryColor : BeeTokens.textSecondary(context),
-                                      fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                                      color: isSelected
+                                          ? primaryColor
+                                          : BeeTokens.textSecondary(context),
+                                      fontWeight: isSelected
+                                          ? FontWeight.w600
+                                          : FontWeight.normal,
                                     ),
-                                    onSelected: (_) => setState(() => _reminderDaysBefore = days),
+                                    onSelected: (_) => setState(
+                                        () => _reminderDaysBefore = days),
                                   );
                                 }).toList(),
                               ),
@@ -585,8 +581,8 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
                     ),
                   ],
 
-                  // 元信息（银行卡/信用卡：开户行+卡号后四位；所有类型：备注）
-                  if (_selectedType == 'bank_card' || _selectedType == 'credit_card') ...[
+                  // ===== 卡信息（仅 bank_card）=====
+                  if (isBankCard) ...[
                     SizedBox(height: 8.0.scaled(context, ref)),
                     SectionCard(
                       margin: EdgeInsets.zero,
@@ -595,121 +591,60 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
-                              l10n.accountMetaInfo,
-                              style: TextStyle(
-                                fontSize: 14,
-                                fontWeight: FontWeight.w600,
-                                color: BeeTokens.textPrimary(context),
-                              ),
-                            ),
+                            Text(l10n.accountMetaInfo, style: _sectionTitle(context)),
                             SizedBox(height: 12.0.scaled(context, ref)),
-                            TextFormField(
-                              controller: _bankNameController,
-                              decoration: InputDecoration(
-                                labelText: l10n.accountBankName,
-                                hintText: l10n.accountBankNameHint,
-                                hintStyle: TextStyle(color: Colors.grey[400]),
-                                border: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.grey[300]!),
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: _bankNameController,
+                                    decoration: filledDec(
+                                      label: l10n.accountBankName,
+                                      hint: l10n.accountBankNameHint,
+                                    ),
+                                    style: const TextStyle(fontSize: 16),
+                                  ),
                                 ),
-                                enabledBorder: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.grey[300]!),
+                                SizedBox(width: 12.0.scaled(context, ref)),
+                                Expanded(
+                                  child: TextFormField(
+                                    controller: _cardLastFourController,
+                                    decoration: filledDec(
+                                      label: l10n.accountCardLastFour,
+                                      hint: l10n.accountCardLastFourHint,
+                                    ).copyWith(counterText: ''),
+                                    style: const TextStyle(fontSize: 16),
+                                    maxLength: 4,
+                                    keyboardType: TextInputType.number,
+                                  ),
                                 ),
-                                focusedBorder: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: primaryColor, width: 2),
-                                ),
-                                contentPadding: EdgeInsets.symmetric(
-                                  vertical: 8.0.scaled(context, ref),
-                                ),
-                              ),
-                              style: const TextStyle(fontSize: 16),
-                            ),
-                            SizedBox(height: 12.0.scaled(context, ref)),
-                            TextFormField(
-                              controller: _cardLastFourController,
-                              decoration: InputDecoration(
-                                labelText: l10n.accountCardLastFour,
-                                hintText: l10n.accountCardLastFourHint,
-                                hintStyle: TextStyle(color: Colors.grey[400]),
-                                border: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.grey[300]!),
-                                ),
-                                enabledBorder: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.grey[300]!),
-                                ),
-                                focusedBorder: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: primaryColor, width: 2),
-                                ),
-                                contentPadding: EdgeInsets.symmetric(
-                                  vertical: 8.0.scaled(context, ref),
-                                ),
-                              ),
-                              style: const TextStyle(fontSize: 16),
-                              maxLength: 4,
-                              keyboardType: TextInputType.number,
-                            ),
-                            SizedBox(height: 8.0.scaled(context, ref)),
-                            TextFormField(
-                              controller: _noteController,
-                              decoration: InputDecoration(
-                                labelText: l10n.accountNote,
-                                hintText: l10n.accountNoteHint,
-                                hintStyle: TextStyle(color: Colors.grey[400]),
-                                border: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.grey[300]!),
-                                ),
-                                enabledBorder: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: Colors.grey[300]!),
-                                ),
-                                focusedBorder: UnderlineInputBorder(
-                                  borderSide: BorderSide(color: primaryColor, width: 2),
-                                ),
-                                contentPadding: EdgeInsets.symmetric(
-                                  vertical: 8.0.scaled(context, ref),
-                                ),
-                              ),
-                              style: const TextStyle(fontSize: 16),
-                              maxLines: 3,
-                              minLines: 1,
+                              ],
                             ),
                           ],
                         ),
                       ),
                     ),
-                  ] else ...[
-                    // 非银行卡/信用卡类型：仅备注
-                    SizedBox(height: 8.0.scaled(context, ref)),
-                    SectionCard(
-                      margin: EdgeInsets.zero,
-                      child: Padding(
-                        padding: EdgeInsets.all(16.0.scaled(context, ref)),
-                        child: TextFormField(
-                          controller: _noteController,
-                          decoration: InputDecoration(
-                            labelText: l10n.accountNote,
-                            hintText: l10n.accountNoteHint,
-                            hintStyle: TextStyle(color: Colors.grey[400]),
-                            border: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.grey[300]!),
-                            ),
-                            enabledBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.grey[300]!),
-                            ),
-                            focusedBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: primaryColor, width: 2),
-                            ),
-                            contentPadding: EdgeInsets.symmetric(
-                              vertical: 8.0.scaled(context, ref),
-                            ),
-                          ),
-                          style: const TextStyle(fontSize: 16),
-                          maxLines: 3,
-                          minLines: 1,
+                  ],
+
+                  // ===== 备注（所有类型）=====
+                  SizedBox(height: 8.0.scaled(context, ref)),
+                  SectionCard(
+                    margin: EdgeInsets.zero,
+                    child: Padding(
+                      padding: EdgeInsets.all(16.0.scaled(context, ref)),
+                      child: TextFormField(
+                        controller: _noteController,
+                        decoration: filledDec(
+                          label: l10n.accountNote,
+                          hint: l10n.accountNoteHint,
                         ),
+                        style: const TextStyle(fontSize: 16),
+                        maxLines: 3,
+                        minLines: 1,
                       ),
                     ),
-                  ],
+                  ),
 
                   SizedBox(height: 24.0.scaled(context, ref)),
 
@@ -783,6 +718,13 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
 
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
+
+    // 信用卡：账单日 / 还款日必填（额度由表单 validator 拦截）
+    if (_selectedType == 'credit_card' &&
+        (_billingDay == null || _paymentDueDay == null)) {
+      showToast(context, AppLocalizations.of(context).creditCardDaysRequired);
+      return;
+    }
 
     setState(() => _saving = true);
 
@@ -1073,7 +1015,39 @@ class _AccountEditPageState extends ConsumerState<AccountEditPage> {
   }
 }
 
-/// 日期选择行（1-28）
+/// 统一的 filled 圆角输入框装饰（TextField 与点击式字段框共用，保证等高同款）
+InputDecoration _filledDecoration(
+  BuildContext context,
+  Color primary, {
+  String? label,
+  String? hint,
+  String? prefix,
+  String? errorText,
+}) {
+  OutlineInputBorder b(Color c, double w) => OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: w == 0 ? BorderSide.none : BorderSide(color: c, width: w),
+      );
+  return InputDecoration(
+    labelText: label,
+    hintText: hint,
+    hintStyle: TextStyle(color: BeeTokens.textTertiary(context)),
+    prefixText: prefix,
+    errorText: errorText,
+    filled: true,
+    fillColor: BeeTokens.surfaceInput(context),
+    isDense: true,
+    floatingLabelBehavior: FloatingLabelBehavior.auto,
+    contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+    border: b(Colors.transparent, 0),
+    enabledBorder: b(Colors.transparent, 0),
+    focusedBorder: b(primary, 1.5),
+    errorBorder: b(Colors.red, 1),
+    focusedErrorBorder: b(Colors.red, 1.5),
+  );
+}
+
+/// 日期选择行（1-28）— filled 输入框样式，可双列并排
 class _DayPickerTile extends ConsumerWidget {
   final String label;
   final int? value;
@@ -1090,43 +1064,42 @@ class _DayPickerTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
+    final hasValue = value != null;
     return InkWell(
       onTap: () => _showDayPicker(context, l10n),
-      child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 8.0.scaled(context, ref)),
+      borderRadius: BorderRadius.circular(12),
+      child: InputDecorator(
+        decoration: _filledDecoration(context, primaryColor, label: label),
         child: Row(
           children: [
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 14,
-                color: BeeTokens.textPrimary(context),
+            Expanded(
+              child: Text(
+                hasValue ? l10n.dayOfMonth(value!) : l10n.selectDay,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 16,
+                  color: hasValue
+                      ? BeeTokens.textPrimary(context)
+                      : BeeTokens.textTertiary(context),
+                ),
               ),
             ),
-            const Spacer(),
-            Text(
-              value != null ? l10n.dayOfMonth(value!) : l10n.selectDay,
-              style: TextStyle(
-                fontSize: 14,
-                color: value != null
-                    ? BeeTokens.textPrimary(context)
-                    : BeeTokens.textTertiary(context),
-              ),
-            ),
-            SizedBox(width: 4.0.scaled(context, ref)),
-            Icon(
-              Icons.chevron_right,
-              size: 18.0.scaled(context, ref),
-              color: BeeTokens.iconTertiary(context),
-            ),
+            Icon(Icons.expand_more,
+                size: 18.0.scaled(context, ref),
+                color: BeeTokens.iconTertiary(context)),
           ],
         ),
       ),
     );
   }
 
-  void _showDayPicker(BuildContext context, AppLocalizations l10n) {
-    showModalBottomSheet(
+  void _showDayPicker(BuildContext context, AppLocalizations l10n) async {
+    // 先收起键盘并等其收完，避免输入框焦点残留导致选完日期后键盘又弹回来
+    FocusManager.instance.primaryFocus?.unfocus();
+    await Future.delayed(const Duration(milliseconds: 100));
+    if (!context.mounted) return;
+    await showModalBottomSheet(
       context: context,
       backgroundColor: BeeTokens.surfaceElevated(context),
       shape: const RoundedRectangleBorder(
@@ -1217,41 +1190,54 @@ class _AccountTypeCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final effectiveOpacity = disabled ? 0.4 : 1.0;
-    return Opacity(
-      opacity: effectiveOpacity,
-      child: InkWell(
-        onTap: disabled ? null : onTap,
-        borderRadius: BorderRadius.circular(8.0.scaled(context, ref)),
-        child: Container(
-          decoration: BoxDecoration(
-            color:
-                isSelected ? primaryColor.withValues(alpha: 0.12) : BeeTokens.surfaceElevated(context),
-            border: Border.all(
-              color: isSelected ? primaryColor : BeeTokens.border(context),
-              width: isSelected ? 2 : 1,
-            ),
-            borderRadius: BorderRadius.circular(8.0.scaled(context, ref)),
+    // 禁用态：灰底 + 浅边 + 灰字 + 图标淡化，明确区别于可选/选中
+    final Color bg = disabled
+        ? BeeTokens.surfaceInput(context)
+        : (isSelected
+            ? primaryColor.withValues(alpha: 0.12)
+            : BeeTokens.surfaceElevated(context));
+    final Color borderColor = disabled
+        ? BeeTokens.divider(context)
+        : (isSelected ? primaryColor : BeeTokens.border(context));
+    final Color fg = disabled
+        ? BeeTokens.textTertiary(context)
+        : (isSelected ? primaryColor : BeeTokens.textSecondary(context));
+    return InkWell(
+      onTap: disabled ? null : onTap,
+      borderRadius: BorderRadius.circular(8.0.scaled(context, ref)),
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 2.0.scaled(context, ref)),
+        decoration: BoxDecoration(
+          color: bg,
+          border: Border.all(
+            color: borderColor,
+            width: isSelected ? 2 : 1,
           ),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              AccountTypeIcon(
+          borderRadius: BorderRadius.circular(8.0.scaled(context, ref)),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Opacity(
+              opacity: disabled ? 0.35 : 1.0,
+              child: AccountTypeIcon(
                 type: type,
-                size: 28.0.scaled(context, ref),
+                size: 24.0.scaled(context, ref),
               ),
-              SizedBox(height: 8.0.scaled(context, ref)),
-              Text(
-                label,
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
-                  color: isSelected ? primaryColor : BeeTokens.textSecondary(context),
-                ),
-                textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 6.0.scaled(context, ref)),
+            Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                color: fg,
               ),
-            ],
-          ),
+              textAlign: TextAlign.center,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/account/accounts_page.dart
+++ b/lib/pages/account/accounts_page.dart
@@ -85,7 +85,6 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
     final primaryColor = ref.watch(primaryColorProvider);
     final allStatsAsync = ref.watch(allAccountStatsProvider);
     final netWorthByCurrencyAsync = ref.watch(netWorthBreakdownByCurrencyProvider);
-    final isDark = BeeTokens.isDark(context);
 
     // 资产构成数据
     final compositionAsync = ref.watch(assetCompositionProvider);
@@ -1062,7 +1061,7 @@ class _AccountCard extends ConsumerWidget {
                     ),
                     SizedBox(height: 10.0.scaled(context, ref)),
                     // 信用卡：进度条 + 额度信息
-                    if (account.type == 'credit_card' && account.creditLimit != null && stats != null)
+                    if (account.type == 'credit_card' && stats != null)
                       _buildCreditCardStats(context, ref, l10n, isDark)
                     // 估值账户：仅显示当前估值
                     else if (isValuationOnlyType(account.type) && stats != null)
@@ -1205,12 +1204,27 @@ class _AccountCard extends ConsumerWidget {
   }
 
   Widget _buildCreditCardStats(BuildContext context, WidgetRef ref, AppLocalizations l10n, bool isDark) {
-    final creditLimit = account.creditLimit!;
     final used = stats!.balance < 0 ? -stats!.balance : 0.0;
-    final usageRate = creditLimit > 0 ? (used / creditLimit).clamp(0.0, 1.0) : 0.0;
     final textColor = isDark ? Colors.white.withValues(alpha: 0.9) : Colors.white;
     final labelColor = isDark ? Colors.white.withValues(alpha: 0.6) : Colors.white.withValues(alpha: 0.8);
 
+    // 信用卡按 type 判定;无额度时仅显示当前欠款,不再 fallthrough 到收入/支出卡
+    final creditLimit = account.creditLimit;
+    if (creditLimit == null) {
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: _CardStat(
+          label: l10n.creditCardOwed,
+          value: used,
+          textColor: textColor,
+          labelColor: labelColor,
+          ref: ref,
+          currencyCode: account.currency,
+        ),
+      );
+    }
+
+    final usageRate = creditLimit > 0 ? (used / creditLimit).clamp(0.0, 1.0) : 0.0;
     return Column(
       children: [
         // 进度条

--- a/lib/pages/account/accounts_page.dart
+++ b/lib/pages/account/accounts_page.dart
@@ -184,7 +184,7 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
                         iconColor: BeeTokens.incomeColor(context, ref),
                         typeOrder: assetTypeOrder,
                         groups: groups,
-                        allStats: allStatsAsync.asData?.value,
+                        allStats: allStatsAsync.valueOrNull,
                         primaryColor: primaryColor,
                         ledgerId: ledgerId,
                       ),
@@ -198,7 +198,7 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
                         iconColor: BeeTokens.expenseColor(context, ref),
                         typeOrder: liabilityTypeOrder,
                         groups: groups,
-                        allStats: allStatsAsync.asData?.value,
+                        allStats: allStatsAsync.valueOrNull,
                         primaryColor: primaryColor,
                         ledgerId: ledgerId,
                       ),
@@ -212,7 +212,7 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
                           type: type,
                           accounts: groupList,
                           primaryColor: primaryColor,
-                          allStats: allStatsAsync.asData?.value,
+                          allStats: allStatsAsync.valueOrNull,
                           onReorder: (oldIndex, newIndex) =>
                               _onReorder(type, groupList, oldIndex, newIndex),
                           onTap: (account) =>
@@ -244,9 +244,8 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
     AsyncValue<List<({String type, double totalBalance})>> compositionAsync,
     Color primaryColor,
   ) {
-    final isSingleCurrency = netWorthAsync.asData?.value != null
-        ? netWorthAsync.asData!.value.length <= 1
-        : true;
+    // reload 时 asData 会短暂变 null 致布局闪动,用 valueOrNull 保留上次结果
+    final isSingleCurrency = (netWorthAsync.valueOrNull?.length ?? 1) <= 1;
 
     return SectionCard(
       margin: EdgeInsets.zero,


### PR DESCRIPTION
## 改动

- **账户新增/编辑页重做**:账户类型分「日常 / 估值」双 Tab + 缩小网格;字段统一 filled 圆角框、成对字段双列(币种/余额、账单日/还款日、开户行/卡号);信用卡 **额度 / 账单日 / 还款日必填**;禁用类型明确灰态;修复选账单日弹窗后键盘残留弹回。
- **信用卡资产展示对齐主流**:按 `type` 判定(不再依赖是否设额度),显示「当前欠款 + 额度/已用/可用」;去掉信用卡的「收入/支出」(概念错位),详情图表仅消费;还款(转账)入口对所有信用卡可见;计入总负债不变。
- **体验**:账户编辑返回资产页时金额不再闪 loading(刷新保留旧值)。

## 范围
仅手机端,无 DB 迁移。web 端展示对齐、信用卡账单周期/平账/账户封存等见 `.docs` backlog,不在本 PR。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发行说明

* **新功能**
  * 添加估值账户标签和多语言支持（英文、简体中文、繁体中文）
  * 新增信用卡账单日和还款日选择功能，包含必填字段验证

* **样式**
  * 重构账户编辑页面表单UI，采用统一填充型圆角装饰设计

* **改进**
  * 优化数据加载状态处理，减少账户列表刷新时的界面闪动
  * 改进信用卡统计展示逻辑，支持无额度情况下的欠款展示

<!-- end of auto-generated comment: release notes by coderabbit.ai -->