### PR TITLE
fix(ai): 推理模型锁 temperature 时自适应摘参数重试 (kimi-k2.5)

### DIFF
--- a/lib/ai/providers/ai_provider_factory.dart
+++ b/lib/ai/providers/ai_provider_factory.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_ai_kit/flutter_ai_kit.dart';
 import 'package:flutter_ai_kit_zhipu/flutter_ai_kit_zhipu.dart';
 
@@ -446,6 +447,56 @@ class AIProviderFactory {
   // OpenAI 兼容实现
   // ============================================================
 
+  // 结构上必须保留的键;其余键(temperature 等)被上游拒绝时可摘掉重发。
+  static const _requiredChatKeys = {'model', 'messages', 'stream'};
+  static const _maxParamStrips = 3;
+
+  /// 上游因「参数不合法」报 4xx 时,返回它点名的那个可丢键(候选只来自我们发出去的键)。
+  ///
+  /// 推理模型(Moonshot kimi-k2.5 / OpenAI o1·o3 / DeepSeek-R1)把 temperature 锁死成 1,
+  /// 发其他值返回 400「invalid temperature: only 1 is allowed for this model」即走这里。
+  /// 不写死参数名/模型名,而是看错误文案点了我们发出去的哪个键。
+  @visibleForTesting
+  static String? rejectedChatParam(
+    Map<String, dynamic> payload,
+    int? statusCode,
+    String errorBody,
+  ) {
+    if (statusCode == null || statusCode < 400) return null;
+    final low = errorBody.toLowerCase();
+    for (final key in payload.keys) {
+      if (!_requiredChatKeys.contains(key) && low.contains(key.toLowerCase())) {
+        return key;
+      }
+    }
+    return null;
+  }
+
+  /// POST /chat/completions;被某个可选参数拒就摘掉重发,最多 [_maxParamStrips] 次。
+  ///
+  /// 普通模型:参数都合法 → 一次成功,行为不变(只有 4xx 才会进摘参数逻辑)。
+  /// 推理模型:temperature 等被锁 → 摘掉 → 用模型默认值,通过。
+  static Future<Response<dynamic>> _postChatCompletions(
+    Dio dio,
+    Map<String, dynamic> body,
+  ) async {
+    var payload = Map<String, dynamic>.of(body);
+    for (var attempt = 0;; attempt++) {
+      try {
+        return await dio.post('/chat/completions', data: payload);
+      } on DioException catch (e) {
+        final param = rejectedChatParam(
+          payload,
+          e.response?.statusCode,
+          e.response?.data?.toString() ?? '',
+        );
+        if (param == null || attempt >= _maxParamStrips) rethrow;
+        logger.warning('AIFactory', '上游拒绝参数 $param,去掉重发');
+        payload = Map<String, dynamic>.of(payload)..remove(param);
+      }
+    }
+  }
+
   static Future<String> _chatOpenAI(
     AIServiceProviderConfig config,
     String prompt,
@@ -463,14 +514,11 @@ class AIProviderFactory {
     logger.debug('AIFactory', '请求: ${config.baseUrl}/chat/completions');
 
     try {
-      final response = await dio.post(
-        '/chat/completions',
-        data: {
-          'model': config.textModel,
-          'messages': messages,
-          'temperature': temperature,
-        },
-      );
+      final response = await _postChatCompletions(dio, {
+        'model': config.textModel,
+        'messages': messages,
+        'temperature': temperature,
+      });
 
       final data = response.data as Map<String, dynamic>;
       final choices = data['choices'] as List;

--- a/test/ai/providers/ai_provider_factory_test.dart
+++ b/test/ai/providers/ai_provider_factory_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:beecount/ai/providers/ai_provider_factory.dart';
+
+/// issue #312:推理模型(kimi-k2.5 / o1 / o3 / R1)锁 temperature=1,被拒时自适应摘参数。
+///
+/// 这里直接单测决策逻辑 `rejectedChatParam`(纯函数,无需 mock HTTP):
+/// 给定上游错误响应 + 我们发出去的 payload,判断该摘哪个键。
+void main() {
+  group('AIProviderFactory.rejectedChatParam', () {
+    const moonshotTempErr =
+        '{"error":{"message":"invalid temperature: only 1 is allowed for this model","type":"invalid_request_error"}}';
+
+    test('Moonshot kimi-k2.5 锁温度 → 返回 temperature', () {
+      final param = AIProviderFactory.rejectedChatParam(
+        {'model': 'kimi-k2.5', 'messages': <dynamic>[], 'temperature': 0.3},
+        400,
+        moonshotTempErr,
+      );
+      expect(param, 'temperature');
+    });
+
+    test('OpenAI o1 风格文案也命中 temperature', () {
+      final param = AIProviderFactory.rejectedChatParam(
+        {'model': 'o1', 'messages': <dynamic>[], 'temperature': 0.2},
+        400,
+        "Unsupported value: 'temperature' does not support 0.2 with this model. "
+            'Only the default (1) value is supported.',
+      );
+      expect(param, 'temperature');
+    });
+
+    test('成功状态 → null(摘参数逻辑不触发)', () {
+      expect(
+        AIProviderFactory.rejectedChatParam({'temperature': 0.2}, 200, ''),
+        isNull,
+      );
+    });
+
+    test('status 为 null(网络异常等)→ null', () {
+      expect(
+        AIProviderFactory.rejectedChatParam({'temperature': 0.2}, null, ''),
+        isNull,
+      );
+    });
+
+    test('非参数错误(限流)→ null,交给上层照常报错', () {
+      expect(
+        AIProviderFactory.rejectedChatParam(
+          {'model': 'x', 'messages': <dynamic>[], 'temperature': 0.2},
+          429,
+          '{"error":"rate limited"}',
+        ),
+        isNull,
+      );
+    });
+
+    test('"model not found" 含 model,但 model 是必须键 → 不摘', () {
+      expect(
+        AIProviderFactory.rejectedChatParam(
+          {'model': 'missing', 'messages': <dynamic>[]},
+          404,
+          '{"error":"model not found"}',
+        ),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 背景

修复 #312 —— 用户添加 Moonshot `kimi-k2.5` 报「temperature 错误」无法添加。

`kimi-k2.5`(以及 OpenAI o1/o3、DeepSeek-R1 等**推理模型**)把 `temperature` **锁死成只能 = 1**,发其他值直接 400:

```
400: {"error":{"message":"invalid temperature: only 1 is allowed for this model","type":"invalid_request_error"}}
```

而 `_chatOpenAI` 硬编码了非 1 的温度(验证 `0.7` / 真实提取 `0.3`),无处可改 → 这类模型**添加验证 + 真实记账全失败**。

> 这不是「不支持高温」——`temperature=1` 是推理模型的形式约束,不是创造性档位。本 PR **不新增任何用户可见的温度旋钮**,记账仍走低温。

## 方案:听上游报错动态适配(不写死参数名/模型名)

上游因某参数报 4xx 时它会点名(错误文案里出现该参数),照它说的把那个参数摘掉重发:

- 抽出纯函数 `rejectedChatParam`(`@visibleForTesting`)—— 给定上游错误 + 我们发出的 payload,判断该摘哪个可丢键(候选只来自我们发出去的键,永不摘 `model`/`messages`)。
- `_postChatCompletions` 包装 `dio.post`:被拒就摘掉重发,最多 3 次。
- `_chatOpenAI` 走包装,**一处同时覆盖**验证(`validateTextCapability` → 0.7)和真实提取(`extractFromText` → 0.3)。

## 为什么对老用户零影响

摘参数逻辑**只在收到 4xx 时才触发**。普通模型(GLM / GPT / DeepSeek-V3 …)的成功调用是「POST 一次 → 拿到 <400 → 直接返回」,根本不进摘参数那段,温度仍是原值,行为不变。

## 测试

`test/ai/providers/ai_provider_factory_test.dart` 直接单测 `rejectedChatParam`(纯函数,无需 mock HTTP):Moonshot / o1 文案命中 temperature、必须键(model)不摘、非参数错误(限流)返回 null、成功/网络异常返回 null。本地 `flutter test test/ai test/services/ai` 全绿。

## 范围

本 PR 修 **mobile(Flutter)** 端。**server**(Web + 云端记账)同款硬编码已在 `TNT-Likely/BeeCount-Cloud#38` 用同一机制修复。两端合并后 #312 即可关闭。

Refs #312