### PR TITLE
feat: 记账键盘支持加减乘除(长按/双击切换)

### DIFF
--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -492,16 +492,15 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
           child: InkWell(
             borderRadius: BorderRadius.circular(12),
             onTap: () => applyOp(activeOp),
+            // 双击 / 长按都是「切到另一组运算符并直接应用」(一步用上另一个);
+            // applyOp 内部已带触感/声音。
             onDoubleTap: () {
-              // 双击 = 切到「另一组」运算符并直接应用(一步用上另一个);applyOp 已带触感/声音。
-              final altOp = isMul ? addSubOp : mulDivOp;
               onToggle();
-              applyOp(altOp);
+              applyOp(isMul ? addSubOp : mulDivOp);
             },
             onLongPress: () {
               onToggle();
-              HapticFeedback.mediumImpact();
-              SystemSound.play(SystemSoundType.click);
+              applyOp(isMul ? addSubOp : mulDivOp);
             },
             child: SizedBox(
               height: 60,

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -475,13 +475,13 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     Widget opKey(String addSubOp, String mulDivOp, bool isMul,
         VoidCallback onToggle) {
       final activeOp = isMul ? mulDivOp : addSubOp;
-      // 激活=主文字色(亮=黑/暗=白)且更大;未激活=次级灰色且更小。粗细与旁边
-      // 数字键保持一致(w600),仅靠字号大小 + 颜色分主次。
+      // 激活的运算符与数字键完全一致(字号 18 / w600),保证视觉粗细相同 —— 字号
+      // 更大即使同 weight 笔画也会更粗。未激活更小(14)+ 灰色以分主次。
       TextStyle opStyle(bool active) => text.titleMedium!.copyWith(
             color: active
                 ? BeeTokens.textPrimary(context)
                 : BeeTokens.textTertiary(context),
-            fontSize: active ? 24 : 16,
+            fontSize: active ? 18 : 14,
             fontWeight: FontWeight.w600,
           );
       return Padding(
@@ -508,7 +508,7 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                       text: '/',
                       style: text.titleMedium!.copyWith(
                         color: BeeTokens.textTertiary(context),
-                        fontSize: 16,
+                        fontSize: 14,
                         fontWeight: FontWeight.w400,
                       ),
                     ),

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -475,13 +475,14 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     Widget opKey(String addSubOp, String mulDivOp, bool isMul,
         VoidCallback onToggle) {
       final activeOp = isMul ? mulDivOp : addSubOp;
-      // 激活=主文字色(亮=黑/暗=白)且更大;未激活=次级灰色且更小 —— 大小+颜色双重主次。
+      // 激活=主文字色(亮=黑/暗=白)且更大;未激活=次级灰色且更小。粗细与旁边
+      // 数字键保持一致(w600),仅靠字号大小 + 颜色分主次。
       TextStyle opStyle(bool active) => text.titleMedium!.copyWith(
             color: active
                 ? BeeTokens.textPrimary(context)
                 : BeeTokens.textTertiary(context),
-            fontSize: active ? 22 : 15,
-            fontWeight: active ? FontWeight.w700 : FontWeight.w500,
+            fontSize: active ? 24 : 16,
+            fontWeight: FontWeight.w600,
           );
       return Padding(
         padding: const EdgeInsets.all(6),
@@ -507,7 +508,7 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                       text: '/',
                       style: text.titleMedium!.copyWith(
                         color: BeeTokens.textTertiary(context),
-                        fontSize: 15,
+                        fontSize: 16,
                         fontWeight: FontWeight.w400,
                       ),
                     ),

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -492,6 +492,12 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
           child: InkWell(
             borderRadius: BorderRadius.circular(12),
             onTap: () => applyOp(activeOp),
+            onDoubleTap: () {
+              // 双击 = 切到「另一组」运算符并直接应用(一步用上另一个);applyOp 已带触感/声音。
+              final altOp = isMul ? addSubOp : mulDivOp;
+              onToggle();
+              applyOp(altOp);
+            },
             onLongPress: () {
               onToggle();
               HapticFeedback.mediumImpact();

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -224,6 +224,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
   // 运算缓存：支持简单 + / - 键入累计
   double _acc = 0;
   String? _op; // 最近一次运算符，null 表示尚未进入运算模式
+  // 运算符键模式:false=加减(默认),true=乘除。长按运算符键切换两组。
+  bool _multiplyMode = false;
 
   // 高频备注列表（包含使用次数）
   List<({String note, int count})> _frequentNotes = [];
@@ -353,6 +355,36 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     }
   }
 
+  /// 左到右运算(无运算符优先级,与原 +/- 累加器一致),除零做保护(返回被除数)。
+  double _compute(double a, String op, double b) {
+    switch (op) {
+      case '+':
+        return a + b;
+      case '-':
+        return a - b;
+      case '×':
+        return a * b;
+      case '÷':
+        return b == 0 ? a : a / b;
+      default:
+        return b;
+    }
+  }
+
+  /// 运算符显示字形(减号用真减号 −,而非连字符 -)。
+  String _opGlyph(String op) {
+    switch (op) {
+      case '-':
+        return '−';
+      case '×':
+        return '×';
+      case '÷':
+        return '÷';
+      default:
+        return '+';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final primary = Theme.of(context).colorScheme.primary;
@@ -369,10 +401,9 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
       if (_op == null) {
         // 首次点击运算符，将当前值存入累加器
         _acc = cur;
-      } else if (_op == '+') {
-        _acc += cur;
-      } else if (_op == '-') {
-        _acc -= cur;
+      } else {
+        // 左到右:先把上一个运算符算掉
+        _acc = _compute(_acc, _op!, cur);
       }
       _op = op;
       _amountStr = '0';
@@ -385,12 +416,7 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     void applyEquals() {
       if (_op == null) return; // 没有运算符，不执行
       final cur = parsed();
-      double total = _acc;
-      if (_op == '+') {
-        total += cur;
-      } else if (_op == '-') {
-        total -= cur;
-      }
+      final total = _compute(_acc, _op!, cur);
       // 格式化结果
       final s = total.abs().toStringAsFixed(2);
       final trimmed = s.contains('.')
@@ -422,6 +448,50 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                   color: fg ?? BeeTokens.textPrimary(context),
                   fontSize: 18,
                   fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // 运算符键:同时显示「加减」与「乘除」两组运算符;当前激活的一组用主色高亮、
+    // 另一组用次级色弱化(主次区分,也作为"长按可切到乘除"的提示)。单击应用激活
+    // 运算符,长按切换加减 ↔ 乘除。
+    Widget opKey(String addSubOp, String mulDivOp) {
+      final activeOp = _multiplyMode ? mulDivOp : addSubOp;
+      Widget glyph(String op, bool active) => Text(
+            _opGlyph(op),
+            style: text.titleMedium?.copyWith(
+              color: active ? primary : BeeTokens.textTertiary(context),
+              fontSize: active ? 20 : 13,
+              fontWeight: active ? FontWeight.w700 : FontWeight.w500,
+            ),
+          );
+      return Padding(
+        padding: const EdgeInsets.all(6),
+        child: Material(
+          color: BeeTokens.surfaceKeySecondary(context),
+          borderRadius: BorderRadius.circular(12),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(12),
+            onTap: () => applyOp(activeOp),
+            onLongPress: () {
+              setState(() => _multiplyMode = !_multiplyMode);
+              HapticFeedback.mediumImpact();
+              SystemSound.play(SystemSoundType.click);
+            },
+            child: SizedBox(
+              height: 60,
+              child: Center(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    glyph(addSubOp, !_multiplyMode),
+                    const SizedBox(width: 6),
+                    glyph(mulDivOp, _multiplyMode),
+                  ],
                 ),
               ),
             ),
@@ -479,7 +549,7 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 8),
                         child: Text(
-                          _op == '-' ? '−' : '+',
+                          _opGlyph(_op!),
                           style: text.titleMedium?.copyWith(
                             fontWeight: FontWeight.w600,
                             color: primary,
@@ -514,7 +584,7 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                       Text(
                         (() {
                           final cur = parsed();
-                          final total = _op == '+' ? _acc + cur : _acc - cur;
+                          final total = _compute(_acc, _op!, cur);
                           final s = total.abs().toStringAsFixed(2);
                           final r1 = s.contains('.')
                               ? s.replaceFirst(RegExp(r'0+$'), '')
@@ -684,14 +754,7 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
               Widget doneKey() {
                 // 计算当前总额以判断是否启用完成按钮
                 final cur = parsed();
-                double total;
-                if (_op == '+') {
-                  total = _acc + cur;
-                } else if (_op == '-') {
-                  total = _acc - cur;
-                } else {
-                  total = cur;
-                }
+                final total = _op == null ? cur : _compute(_acc, _op!, cur);
 
                 // 判断是否处于运算模式
                 final isInCalcMode = _op != null;
@@ -785,10 +848,7 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                     SizedBox(
                         width: w,
                         child: keyBtn('6', onTap: () => _append('6'))),
-                    SizedBox(
-                        width: w,
-                        child: keyBtn('+',
-                            bg: BeeTokens.surfaceKeySecondary(context), onTap: () => applyOp('+'))),
+                    SizedBox(width: w, child: opKey('+', '×')),
                   ]),
                   const SizedBox(height: 2),
                   Row(children: [
@@ -801,10 +861,7 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                     SizedBox(
                         width: w,
                         child: keyBtn('3', onTap: () => _append('3'))),
-                    SizedBox(
-                        width: w,
-                        child: keyBtn('-',
-                            bg: BeeTokens.surfaceKeySecondary(context), onTap: () => applyOp('-'))),
+                    SizedBox(width: w, child: opKey('-', '÷')),
                   ]),
                   const SizedBox(height: 2),
                   Row(children: [

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:decimal/decimal.dart';
 import 'package:flutter_cloud_sync/flutter_cloud_sync.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:beecount/widgets/ui/wheel_date_picker.dart';
@@ -224,8 +225,9 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
   // 运算缓存：支持简单 + / - 键入累计
   double _acc = 0;
   String? _op; // 最近一次运算符，null 表示尚未进入运算模式
-  // 运算符键模式:false=加减(默认),true=乘除。长按运算符键切换两组。
-  bool _multiplyMode = false;
+  // 两个运算符键各自独立的模式(false=加/减,true=乘/除),长按各自切换,互不影响。
+  bool _mulKey1 = false; // 键1:+ ↔ ×
+  bool _mulKey2 = false; // 键2:− ↔ ÷
 
   // 高频备注列表（包含使用次数）
   List<({String note, int count})> _frequentNotes = [];
@@ -355,20 +357,31 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     }
   }
 
-  /// 左到右运算(无运算符优先级,与原 +/- 累加器一致),除零做保护(返回被除数)。
+  /// 用 Decimal 精确运算(避免浮点漂移,如 0.1+0.2),左到右无运算符优先级,
+  /// 除零保护;结果四舍五入到最多两位小数(金额精度)。
   double _compute(double a, String op, double b) {
+    final da = Decimal.parse(a.toStringAsFixed(2));
+    final db = Decimal.parse(b.toStringAsFixed(2));
+    final Decimal r;
     switch (op) {
       case '+':
-        return a + b;
+        r = da + db;
+        break;
       case '-':
-        return a - b;
+        r = da - db;
+        break;
       case '×':
-        return a * b;
+        r = da * db;
+        break;
       case '÷':
-        return b == 0 ? a : a / b;
+        if (db == Decimal.zero) return a; // 除零保护:保持被除数不变
+        r = (da.toRational() / db.toRational())
+            .toDecimal(scaleOnInfinitePrecision: 12);
+        break;
       default:
         return b;
     }
+    return r.round(scale: 2).toDouble();
   }
 
   /// 运算符显示字形(减号用真减号 −,而非连字符 -)。
@@ -459,15 +472,16 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     // 运算符键:同时显示「加减」与「乘除」两组运算符;当前激活的一组用主色高亮、
     // 另一组用次级色弱化(主次区分,也作为"长按可切到乘除"的提示)。单击应用激活
     // 运算符,长按切换加减 ↔ 乘除。
-    Widget opKey(String addSubOp, String mulDivOp) {
-      final activeOp = _multiplyMode ? mulDivOp : addSubOp;
-      Widget glyph(String op, bool active) => Text(
-            _opGlyph(op),
-            style: text.titleMedium?.copyWith(
-              color: active ? primary : BeeTokens.textTertiary(context),
-              fontSize: active ? 20 : 13,
-              fontWeight: active ? FontWeight.w700 : FontWeight.w500,
-            ),
+    Widget opKey(String addSubOp, String mulDivOp, bool isMul,
+        VoidCallback onToggle) {
+      final activeOp = isMul ? mulDivOp : addSubOp;
+      // 激活=主文字色(亮=黑/暗=白)且更大;未激活=次级灰色且更小 —— 大小+颜色双重主次。
+      TextStyle opStyle(bool active) => text.titleMedium!.copyWith(
+            color: active
+                ? BeeTokens.textPrimary(context)
+                : BeeTokens.textTertiary(context),
+            fontSize: active ? 22 : 15,
+            fontWeight: active ? FontWeight.w700 : FontWeight.w500,
           );
       return Padding(
         padding: const EdgeInsets.all(6),
@@ -478,20 +492,27 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
             borderRadius: BorderRadius.circular(12),
             onTap: () => applyOp(activeOp),
             onLongPress: () {
-              setState(() => _multiplyMode = !_multiplyMode);
+              onToggle();
               HapticFeedback.mediumImpact();
               SystemSound.play(SystemSoundType.click);
             },
             child: SizedBox(
               height: 60,
+              // 「加减/乘除」中间一个斜杠分隔;单击用激活运算符,长按只切换本键(两键独立)。
               child: Center(
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    glyph(addSubOp, !_multiplyMode),
-                    const SizedBox(width: 6),
-                    glyph(mulDivOp, _multiplyMode),
-                  ],
+                child: Text.rich(
+                  TextSpan(children: [
+                    TextSpan(text: _opGlyph(addSubOp), style: opStyle(!isMul)),
+                    TextSpan(
+                      text: '/',
+                      style: text.titleMedium!.copyWith(
+                        color: BeeTokens.textTertiary(context),
+                        fontSize: 15,
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                    TextSpan(text: _opGlyph(mulDivOp), style: opStyle(isMul)),
+                  ]),
                 ),
               ),
             ),
@@ -848,7 +869,10 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                     SizedBox(
                         width: w,
                         child: keyBtn('6', onTap: () => _append('6'))),
-                    SizedBox(width: w, child: opKey('+', '×')),
+                    SizedBox(
+                        width: w,
+                        child: opKey('+', '×', _mulKey1,
+                            () => setState(() => _mulKey1 = !_mulKey1))),
                   ]),
                   const SizedBox(height: 2),
                   Row(children: [
@@ -861,7 +885,10 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                     SizedBox(
                         width: w,
                         child: keyBtn('3', onTap: () => _append('3'))),
-                    SizedBox(width: w, child: opKey('-', '÷')),
+                    SizedBox(
+                        width: w,
+                        child: opKey('-', '÷', _mulKey2,
+                            () => setState(() => _mulKey2 = !_mulKey2))),
                   ]),
                   const SizedBox(height: 2),
                   Row(children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -289,6 +289,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  decimal:
+    dependency: "direct main"
+    description:
+      name: decimal
+      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.4"
   device_info_plus:
     dependency: transitive
     description:
@@ -1332,6 +1340,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   realtime_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   path_provider: ^2.1.4
   path: ^1.9.0
   intl: ^0.19.0
+  decimal: ^3.0.0
   fl_chart: ^0.68.0
   shared_preferences: ^2.3.2
   connectivity_plus: ^6.1.0


### PR DESCRIPTION
## 做了什么

记账金额键盘(`AmountEditorSheet`)从只支持加减扩展到加减乘除。

### 交互
- 两个运算符键各显示一对:键 A = `+/×`,键 B = `−/÷`。激活的(黑/白主文字色)与未激活的(灰色)以**颜色 + 字号**区分;激活项的字号/粗细与数字键完全一致。
- **单击** = 应用当前激活的运算符。
- **长按 / 双击** = 切到另一组运算符并直接应用(一步用上另一个)。
- 两个键**各自独立**切换,互不影响。

### 计算
- 接入 `decimal` 包做精确十进制运算(避免浮点漂移,如 `0.1+0.2`),左到右无运算符优先级,**除零保护**,结果四舍五入到**最多两位小数**。
- 完成键在运算过程中作 `=`。

### 范围
- 主要改 `lib/widgets/biz/amount_editor_sheet.dart`;新增 `decimal` 依赖;无 l10n、无 DB 迁移。

> 注:单击带约 300ms 判定延迟(双击的固有代价,已知并接受)。

Closes #245