### PR TITLE
feat(android): 安卓端增加摇一摇自动记账功能

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,13 +26,20 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <!-- Required for foreground service notifications -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- Required for foreground service with specialUse type on Android 14+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <!-- Required for apps targeting Android 14+ -->
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <!-- Required for requesting battery optimization exemption -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <!-- Required for biometric authentication -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
-    
+    <!-- Required for heads-up notification (fullScreenIntent) on Android 12+ -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+
+    <!-- AccessibilityService 权限由系统通过 <service android:permission="..."> 授予，
+         不需要也不应该声明为 <uses-permission>（它是 signature 级权限，只能系统赋予） -->
+
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"
@@ -104,7 +111,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
-                <action android:name="android.intent.action.PACKAGE_REPLACED" />
                 <data android:scheme="package" />
             </intent-filter>
             <intent-filter>
@@ -130,6 +136,48 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/beecount_widget_info" />
+        </receiver>
+
+        <!-- 摇一摇自动记账无障碍服务 -->
+        <service
+            android:name=".BillingAccessibilityService"
+            android:exported="true"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:label="@string/accessibility_service_label"
+            android:description="@string/accessibility_service_description"
+            android:foregroundServiceType="specialUse">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
+
+        <!-- 保活前台服务 -->
+        <service
+            android:name=".KeepAliveService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+        </service>
+
+        <!-- 保活心跳检测 JobService -->
+        <service
+            android:name=".KeepAliveJobService"
+            android:enabled="true"
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE">
+        </service>
+
+        <!-- 开机自启接收器 -->
+        <receiver
+            android:name=".BootReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
         </receiver>
 
     </application>

--- a/android/app/src/main/kotlin/com/tntlikely/beecount/BillingAccessibilityService.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/beecount/BillingAccessibilityService.kt
@@ -1,0 +1,690 @@
+package com.tntlikely.beecount
+
+import android.accessibilityservice.AccessibilityService
+import android.app.KeyguardManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.PowerManager
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.view.accessibility.AccessibilityEvent
+import androidx.core.app.NotificationCompat
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Bridge to share FlutterEngine between MainActivity and BillingAccessibilityService.
+ *
+ * ### 架构
+ * 不再创建独立的后台 Engine。改为由 [MainActivity.provideFlutterEngine] 缓存
+ * 一个全局唯一的 FlutterEngine，该 Engine 在 Activity 销毁后**仍存活**，
+ * 保证 App 切后台后 Dart 代码仍能实时接收摇一摇截图结果。
+ *
+ * ### 初始化流程
+ * 1. [MainActivity.provideFlutterEngine] 首次调用时创建 Engine 并缓存
+ * 2. [AccessibilityBridge.setEngine] 被 [MainActivity.configureFlutterEngine] 调用
+ * 3. Engine 存活于整个进程生命周期，Activity 销毁不释放
+ * 4. [BillingAccessibilityService] 摇一摇触发时通过 [sendCaptureResult] 发送
+ */
+object AccessibilityBridge {
+    const val CHANNEL = "com.tntlikely.beecount/accessibility_billing"
+    private const val TAG = "AccessibilityBridge"
+
+    /** 全局唯一的 FlutterEngine（Activity 销毁后仍存活） */
+    private var flutterEngine: FlutterEngine? = null
+
+    /** Engine 是否已就绪（Dart isolate 必须存活） */
+    fun hasEngine(): Boolean {
+        val engine = flutterEngine
+        return engine != null && engine.dartExecutor.isExecutingDart
+    }
+
+    /** 降级队列：Engine 尚未就绪时暂存结果 */
+    private val pendingResults = mutableListOf<String>()
+
+    // ─── 初始化 ───
+
+    /**
+     * 设置全局 FlutterEngine 引用，并在首次接入时注册 [SHAKE_CONTROL_CHANNEL] handler。
+     *
+     * 由 [MainActivity.configureFlutterEngine] 每次 Activity 创建时调用，
+     * 但 Engine 本身是同一个（由 [MainActivity.provideFlutterEngine] 缓存），
+     * 所以 Dart 隔离区始终存活。
+     *
+     * handler 在首次注册后永久有效（Engine 不销毁就不丢），
+     * 解决 Activity 销毁后 [MainActivity.configureFlutterEngine] 无法重新注册
+     * 导致的 MissingPluginException。
+     */
+    fun setEngine(engine: FlutterEngine) {
+        // 检查引用是否不同（首次注册 or Engine 重建后），确保 handler 绑定到当前 Engine
+        val isNewEngine = (flutterEngine !== engine)
+        if (isNewEngine) {
+            android.util.Log.d(TAG, "🚀 ===== 全局 FlutterEngine 就绪 =====")
+            registerShakeControlHandler(engine)
+        }
+        flutterEngine = engine
+        LoggerPlugin.info(TAG, "FlutterEngine 已注册")
+        // 有 Engine 了，刷新排队结果
+        flushPending()
+    }
+
+    /** 摇一摇自动记账控制通道 */
+    private const val SHAKE_CONTROL_CHANNEL = "com.tntlikely.beecount/shake_billing_control"
+
+    /**
+     * 注册 [SHAKE_CONTROL_CHANNEL] 的 MethodCallHandler。
+     * 所有方法仅调用 [BillingAccessibilityService] 的静态方法，
+     * 不依赖 Activity，故可绑定到 Engine 生命周期。
+     */
+    private fun registerShakeControlHandler(engine: FlutterEngine) {
+        MethodChannel(engine.dartExecutor.binaryMessenger, SHAKE_CONTROL_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "enableShake" -> {
+                        BillingAccessibilityService.setShakeDetectionEnabled(true)
+                        result.success(true)
+                    }
+                    "disableShake" -> {
+                        BillingAccessibilityService.setShakeDetectionEnabled(false)
+                        result.success(true)
+                    }
+                    "showResultNotification" -> {
+                        val title = call.argument<String>("title") ?: ""
+                        val body = call.argument<String>("body") ?: ""
+                        BillingAccessibilityService.showResultNotification(title, body)
+                        result.success(true)
+                    }
+                    // Dart 处理完成（成功/超时/失败），取消原生超时并显示结果通知
+                    "captureResult" -> {
+                        val path = call.argument<String>("path") ?: ""
+                        val title = call.argument<String>("title") ?: ""
+                        val body = call.argument<String>("body") ?: ""
+                        BillingAccessibilityService.onCaptureResult(path, title, body)
+                        result.success(true)
+                    }
+                    // Dart 侧关键阶段日志，直达原生 Logcat，闪退后仍可查看
+                    "logStage" -> {
+                        val stage = call.argument<String>("stage") ?: "?"
+                        android.util.Log.d(TAG, "🐛 [DartStage] $stage")
+                        result.success(true)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    // ─── 发送截图结果 ───
+
+    /**
+     * 发送无障碍截屏结果到 Flutter。
+     *
+     * [result] 为 PNG 文件路径（API 31+）或 "text:..." 前缀文本（API 30-）。
+     * 如果 Engine 尚未就绪（极少情况），结果排队等待下一轮 flush。
+     */
+    fun sendCaptureResult(result: String) {
+        val engine = flutterEngine
+        if (engine != null) {
+            LoggerPlugin.info(TAG, "截屏结果发送到 Flutter: ${result.take(60)}")
+            sendNow(engine, result)
+        } else {
+            LoggerPlugin.warning(TAG, "Engine 未就绪，截屏结果入队等待")
+            synchronized(pendingResults) {
+                pendingResults.add(result)
+            }
+        }
+    }
+
+    /**
+     * 发送无障碍服务被中断的通知到 Flutter。
+     *
+     * 被 [BillingAccessibilityService.onInterrupt] 调用，
+     * Flutter 侧收到后可在 UI 上提示用户检查无障碍状态。
+     */
+    fun sendServiceInterrupted() {
+        val engine = flutterEngine
+        if (engine != null) {
+            try {
+                MethodChannel(engine.dartExecutor.binaryMessenger, CHANNEL)
+                    .invokeMethod("onAccessibilityServiceInterrupted", null)
+                LoggerPlugin.warning(TAG, "无障碍服务中断已通知 Flutter")
+            } catch (e: Exception) {
+                LoggerPlugin.error(TAG, "发送中断通知失败: ${e.message}")
+            }
+        }
+    }
+
+    /** 立即通过 MethodChannel 发送一条结果 */
+    private fun sendNow(engine: FlutterEngine, data: String) {
+        val ok = java.util.concurrent.atomic.AtomicBoolean(true)
+        try {
+            MethodChannel(engine.dartExecutor.binaryMessenger, CHANNEL)
+                .invokeMethod("onAccessibilityCapture", data, object : MethodChannel.Result {
+                    override fun success(result: Any?) {
+                        LoggerPlugin.info(TAG, "MethodChannel 发送成功: ${data.take(60)}")
+                    }
+                    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                        LoggerPlugin.error(TAG, "MethodChannel 返回错误: $errorCode $errorMessage")
+                        ok.set(false)
+                    }
+                    override fun notImplemented() {
+                        // JNI detached 时 FlutterJNI.dispatchPlatformMessage 会 reply(null)，
+                        // IncomingResultHandler 将其转为 notImplemented() 回调
+                        LoggerPlugin.warning(TAG, "MethodChannel 未实现（JNI 可能已断开），重新入队")
+                        ok.set(false)
+                    }
+                })
+            if (!ok.get()) {
+                synchronized(pendingResults) {
+                    pendingResults.add(data)
+                }
+            }
+        } catch (e: Exception) {
+            LoggerPlugin.error(TAG, "MethodChannel 异常: ${e.message}")
+            synchronized(pendingResults) {
+                pendingResults.add(data)
+            }
+        }
+    }
+
+    /** Engine 就绪后刷新排队的结果 */
+    private fun flushPending() {
+        val engine = flutterEngine ?: return
+        synchronized(pendingResults) {
+            if (pendingResults.isEmpty()) return
+            val batch = pendingResults.toList()
+            pendingResults.clear()
+            LoggerPlugin.info(TAG, "刷新排队结果: ${batch.size} 条")
+            batch.forEach { sendNow(engine, it) }
+        }
+    }
+}
+
+/**
+ * 摇一摇自动记账无障碍服务。
+ *
+ * 通过 [ShakeDetector] 监听加速度传感器，摇动手机时利用
+ * [ScreenshotController] 截取当前屏幕（API 31+ takeScreenshot）
+ * 或提取节点文本（API 30-），通过 [AccessibilityBridge] 将结果
+ * 发送到 Flutter 端调用 [AutoBillingService] 进行 AI 记账。
+ *
+ * ### 生命周期
+ * 1. `onServiceConnected()` — 注册传感器监听
+ * 2. 摇动手机 → `ShakeDetector` 触发 → `ScreenshotController.captureForAI`
+ * 3. `onDestroy()` — 注销传感器，释放资源
+ */
+class BillingAccessibilityService : AccessibilityService() {
+
+    companion object {
+        private const val TAG = "BillingAccessibility"
+
+        /** 进度通知 ID */
+        private const val PROGRESS_NOTIFICATION_ID = 9101
+        /** 结果通知 ID */
+        private const val RESULT_NOTIFICATION_ID = 9102
+        /** 复用结果通知的 channel，该 channel 已在设备上配置好横幅权限 */
+        private const val PROGRESS_CHANNEL_ID = "shake_result"
+        private const val RESULT_RETRACTED_CHANNEL_ID = "shake_result_retracted"
+
+        /** 无障碍服务是否正在运行（供 MainActivity 状态查询 + KeepAliveJobService 心跳） */
+        @Volatile
+        var isRunning = false
+            private set
+
+        /** 当前运行的无障碍服务实例，供静态方法控制 ShakeDetector */
+        @Volatile
+        var instance: BillingAccessibilityService? = null
+            private set
+
+        /**
+         * 缓存 Application Context，用于 AccessibilityService 被销毁后
+         * 仍能发送通知（用户从最近任务清除 App 后服务可能被系统销毁）。
+         * [onServiceConnected] 时写入，避免裸 Activity/Service context。
+         */
+        @Volatile
+        private var appContext: Context? = null
+
+        /**
+         * 当前正在处理中的截图路径（用于原生超时兜底）。
+         * Dart 端处理完成后通过 [onCaptureResult] 清空此值，
+         * 如果 15s 内未清空，原生直接弹出超时通知。
+         */
+        @Volatile
+        private var pendingCapturePath: String? = null
+
+        /**
+         * 启用/禁用摇一摇检测。
+         * 由 MainActivity 的 MethodChannel 调用，无需持有服务实例。
+         */
+        fun setShakeDetectionEnabled(enabled: Boolean) {
+            val service = instance ?: return
+            if (enabled) {
+                service.shakeDetector?.start()
+                LoggerPlugin.info(TAG, "ShakeDetector 已启用")
+            } else {
+                service.shakeDetector?.stop()
+                LoggerPlugin.info(TAG, "ShakeDetector 已禁用")
+            }
+        }
+
+        /**
+         * 打开系统最近任务列表（无障碍全局动作）。
+         * 用户在最近任务中手动锁定应用，防止被一键清理。
+         */
+        fun openRecentTasks(): Boolean {
+            return instance?.performGlobalAction(
+                android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_RECENTS
+            ) ?: false
+        }
+
+        /**
+         * 截屏处理完成时由 Flutter 侧回调（通过 MethodChannel [captureResult]）。
+         *
+         * 1. 取消原生 15s 超时定时器（防止超时通知覆盖结果通知）
+         * 2. 调用 [showResultNotification] 显示结果通知
+         */
+        fun onCaptureResult(path: String, title: String, body: String) {
+            android.util.Log.d(TAG, "📩 onCaptureResult: path=$path title=$title | instance=$instance appContext=$appContext")
+            if (path == pendingCapturePath) {
+                android.util.Log.d(TAG, "✓ 匹配 pendingCapturePath，取消原生超时")
+                LoggerPlugin.info(TAG, "Dart 处理完成，取消原生超时")
+                pendingCapturePath = null
+            } else {
+                android.util.Log.w(TAG, "⚠️ path 不匹配 pendingCapturePath（path=$path pending=$pendingCapturePath）")
+            }
+            showResultNotification(title, body)
+        }
+
+        /**
+         * 截屏发送到 Dart 后启动原生 15s 超时兜底。
+         *
+         * 如果 15s 内 [onCaptureResult] 未被调用（Dart Isolate 挂起/崩溃），
+         * 直接弹出超时通知，确保用户不会一直看到「正在识别」进度通知。
+         * Dart 后续处理完成时仍可通过 [onCaptureResult] 替换为结果通知。
+         *
+         * ⚡ 使用 [android.util.Log] 直出 logcat，App 被划掉后仍可
+         * 通过 `adb logcat -s BillingAccessibility` 抓取。
+         */
+        @JvmStatic
+        fun startCaptureTimeout(path: String) {
+            pendingCapturePath = path
+            android.util.Log.d(TAG, "⭐ 原生 15s 超时已启动: $path")
+            LoggerPlugin.info(TAG, "原生 15s 超时已启动: $path")
+            android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                if (pendingCapturePath == path) {
+                    android.util.Log.w(TAG, "⚠️ 原生超时触发：Dart 15s 内未返回 | instance=$instance appContext=$appContext")
+                    LoggerPlugin.warning(TAG, "原生超时触发：Dart 15s 内未返回")
+                    showTimeoutNotification()
+                } else {
+                    android.util.Log.d(TAG, "✓ 超时取消（pendingCapturePath 已被 onCaptureResult 清空）")
+                }
+            }, 15_000)
+        }
+
+        /** 显示超时通知（原生侧直接弹出，不依赖 Flutter Engine） */
+        private fun showTimeoutNotification() {
+            val ctx = (instance ?: appContext) ?: run {
+                android.util.Log.e(TAG, "❌ showTimeoutNotification: 无可用 Context（instance=null && appContext=null）")
+                return
+            }
+            try {
+                instance?.ensureProgressChannelHigh()
+                val notification = NotificationCompat.Builder(ctx, PROGRESS_CHANNEL_ID)
+                    .setContentTitle("蜜蜂记账")
+                    .setContentText("⏳ 识别耗时较长，请稍等！")
+                    .setSmallIcon(android.R.drawable.ic_popup_reminder)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setCategory(NotificationCompat.CATEGORY_ALARM)
+                    .setAutoCancel(true)
+                    .build()
+                val manager = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                manager.cancel(PROGRESS_NOTIFICATION_ID)
+                manager.notify(RESULT_NOTIFICATION_ID, notification)
+                android.util.Log.d(TAG, "✅ 超时通知已发送 (ctx=${if (instance != null) "instance" else "appContext"})")
+                LoggerPlugin.info(TAG, "超时通知已发送")
+            } catch (e: Exception) {
+                android.util.Log.e(TAG, "❌ 超时通知发送失败: ${e.message}")
+                LoggerPlugin.error(TAG, "超时通知发送失败: ${e.message}")
+            }
+        }
+
+        /**
+         * 显示摇一摇结果通知（原生侧投递，绕过 Flutter Engine）。
+         * 由 Flutter 侧 AI 处理完成后通过 MethodChannel 调用。
+         * 使用与进度通知相同的 [PROGRESS_CHANNEL_ID]（shake_result），
+         * 该 channel 已在设备上配置好横幅权限以支持 heads-up 弹出。
+         *
+         * **兼容 App 被从最近任务清除后的场景**：此时服务实例可能已被销毁
+         * （[instance] == null），用缓存的 [appContext] 兜底发通知。
+         *
+         * ⚡ 使用 [android.util.Log] 直出 logcat，App 被划掉后仍可
+         * 通过 `adb logcat -s BillingAccessibility` 抓取。
+         */
+        fun showResultNotification(title: String, body: String) {
+            val ctx = (instance ?: appContext) ?: run {
+                android.util.Log.e(TAG, "❌ showResultNotification: 无可用 Context（instance=null && appContext=null）")
+                LoggerPlugin.error(TAG, "showResultNotification: 无可用 Context")
+                return
+            }
+            android.util.Log.d(TAG, "📢 showResultNotification: title=$title ctx=${if (instance != null) "instance" else "appContext"}")
+            try {
+                // instance 存在时才保证 channel，否则 channel 已由 MainActivity 创建
+                instance?.ensureProgressChannelHigh()
+
+                val launchIntent = Intent(ctx, com.tntlikely.beecount.MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
+                val fullScreenIntent = android.app.PendingIntent.getActivity(
+                    ctx, 0, launchIntent,
+                    android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
+                )
+                val contentIntent = android.app.PendingIntent.getActivity(
+                    ctx, 1, launchIntent,
+                    android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
+                )
+
+                val headsUpNotification = NotificationCompat.Builder(ctx, PROGRESS_CHANNEL_ID)
+                    .setContentTitle(title)
+                    .setContentText(body)
+                    .setSmallIcon(android.R.drawable.ic_popup_reminder)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setCategory(NotificationCompat.CATEGORY_ALARM)
+                    .setContentIntent(contentIntent)
+                    .setFullScreenIntent(fullScreenIntent, true)
+                    .setAutoCancel(true)
+                    .build()
+
+                val manager = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                // 先取消旧的进度通知（ID 9101），避免同一 channel 两个通知竞争 heads-up 配额
+                manager.cancel(PROGRESS_NOTIFICATION_ID)
+                // 显示 heads-up 横幅
+                manager.notify(RESULT_NOTIFICATION_ID, headsUpNotification)
+                android.util.Log.d(TAG, "✅ 结果通知已发送: title=$title")
+                LoggerPlugin.info(TAG, "结果通知已发送: title=$title")
+
+                // 3s 后收回通知栏：取消 heads-up 通知，用低优先级渠道重新显示（不再弹横幅）
+                android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                    try {
+                        manager.cancel(RESULT_NOTIFICATION_ID)
+
+                        // 确保收回收渠道已创建（DEFAULT 重要性，不弹 Heads-up）
+                        ensureResultRetractedChannel(ctx)
+
+                        val retractedNotification = NotificationCompat.Builder(ctx, RESULT_RETRACTED_CHANNEL_ID)
+                            .setContentTitle(title)
+                            .setContentText(body)
+                            .setSmallIcon(android.R.drawable.ic_popup_reminder)
+                            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                            .setCategory(NotificationCompat.CATEGORY_STATUS)
+                            .setContentIntent(contentIntent)
+                            .setAutoCancel(true)
+                            .build()
+                        manager.notify(RESULT_NOTIFICATION_ID, retractedNotification)
+                        android.util.Log.d(TAG, "↘️ 结果通知已收回通知栏")
+                    } catch (e: Exception) {
+                        android.util.Log.e(TAG, "❌ 结果通知收回失败: ${e.message}")
+                    }
+                }, 3000)
+            } catch (e: Exception) {
+                android.util.Log.e(TAG, "❌ 结果通知发送失败: ${e.message}")
+                LoggerPlugin.error(TAG, "结果通知发送失败: ${e.message}")
+            }
+        }
+
+        /** 确保收回收渠道 [RESULT_RETRACTED_CHANNEL_ID] 已创建（DEFAULT 重要性，不弹 heads-up） */
+        private fun ensureResultRetractedChannel(ctx: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            try {
+                val manager = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                if (manager.getNotificationChannel(RESULT_RETRACTED_CHANNEL_ID) == null) {
+                    val channel = android.app.NotificationChannel(
+                        RESULT_RETRACTED_CHANNEL_ID,
+                        "摇一摇记账结果（已收回）",
+                        NotificationManager.IMPORTANCE_DEFAULT
+                    ).apply {
+                        description = "摇一摇自动记账结果（已从横幅收回）"
+                        enableVibration(false)
+                        setBypassDnd(true)
+                        lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+                    }
+                    manager.createNotificationChannel(channel)
+                    android.util.Log.d(TAG, "📢 已创建收回收知渠道: $RESULT_RETRACTED_CHANNEL_ID")
+                }
+            } catch (_: Exception) {}
+        }
+    }
+
+    private var shakeDetector: ShakeDetector? = null
+    private var screenshotController: ScreenshotController? = null
+
+    /** 截屏进行中标志，防止连续摇动触发多次并发截屏 */
+    @Volatile
+    private var isCapturing = false
+
+    private val _captureHandler = Handler(Looper.getMainLooper())
+
+    override fun onCreate() {
+        super.onCreate()
+        createProgressChannel()
+    }
+
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        isRunning = true
+        instance = this
+        // 缓存 Application Context，用于服务销毁后仍能发通知
+        appContext = applicationContext
+
+        // 不创建独立前台通知。KeepAliveService 的前台服务已为整个进程
+        // 提供前台优先级，BillingAccessibilityService 在同一进程中可直接
+        // 访问加速度传感器（Android 9+ 前台进程限制放宽）。
+
+        LoggerPlugin.info(TAG, "onServiceConnected — 启动 ShakeDetector + ScreenshotController")
+
+        screenshotController = ScreenshotController(this)
+
+        shakeDetector = ShakeDetector(this) {
+            // 锁屏时不响应摇一摇（屏幕熄灭 / 锁屏界面）
+            if (shouldIgnoreShake()) {
+                LoggerPlugin.info(TAG, "锁屏状态，忽略摇一摇触发")
+                return@ShakeDetector
+            }
+
+            // 防止并发截图：前一次截图尚未完成时忽略新触发
+            if (isCapturing) {
+                return@ShakeDetector
+            }
+            isCapturing = true
+            // 截屏看门狗：15 秒后自动复位，防止截屏回调失联导致永久卡死
+            val watchdog = Runnable {
+                if (isCapturing) {
+                    isCapturing = false
+                }
+            }
+            _captureHandler.postDelayed(watchdog, 15000)
+
+            // 进度通知提示用户摇一摇已触发
+            showProgressBanner()
+            // 震动反馈
+            vibratePhone()
+
+            val watchdogRef = watchdog
+            LoggerPlugin.info(TAG, "摇一摇触发，开始截屏...")
+            screenshotController?.captureForAI { result ->
+                _captureHandler.removeCallbacks(watchdogRef)
+                isCapturing = false
+                if (result != null) {
+                    LoggerPlugin.info(TAG, "截屏成功: ${result.take(60)}")
+                    // 🔴 确保 Dart Isolate 活着再发截屏结果
+                    KeepAliveService.ensureFlutterEngine(this@BillingAccessibilityService)
+                    // 发送截图到 Dart 处理
+                    AccessibilityBridge.sendCaptureResult(result)
+                    // 🔴 原生 15s 超时兜底（Dart 挂了/卡住时仍能弹超时通知）
+                    startCaptureTimeout(result)
+                } else {
+                    LoggerPlugin.error(TAG, "截屏失败（takeScreenshot + 文本提取均无结果）")
+                }
+            }
+        }
+        shakeDetector?.start()
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        // 不需要处理 UI 事件，仅使用加速度传感器触发
+    }
+
+    override fun onInterrupt() {
+        isRunning = false
+        LoggerPlugin.warning(TAG, "无障碍服务被系统中断")
+        // 通知 Flutter 侧，UI 可提示用户检查无障碍状态
+        try {
+            AccessibilityBridge.sendServiceInterrupted()
+        } catch (e: Exception) {
+            LoggerPlugin.error(TAG, "发送中断通知失败: ${e.message}")
+        }
+    }
+
+    override fun onDestroy() {
+        isRunning = false
+        instance = null
+        LoggerPlugin.info(TAG, "服务销毁 — 停止 ShakeDetector")
+        _captureHandler.removeCallbacksAndMessages(null)
+        shakeDetector?.stop()
+        shakeDetector = null
+        screenshotController = null
+        super.onDestroy()
+    }
+
+    /** 弹出摇一摇进度 heads-up 通知（直到结果通知替换才消失） */
+    private fun showProgressBanner() {
+        try {
+            // 每次发送前确保 channel 为 HIGH（国产 ROM 更新后可能重置渠道重要性）
+            ensureProgressChannelHigh()
+
+            // fullScreenIntent 强制国产 ROM 弹出 heads-up 横幅
+            val launchIntent = Intent(this, com.tntlikely.beecount.MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            val fullScreenIntent = android.app.PendingIntent.getActivity(
+                this, 0, launchIntent,
+                android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
+            )
+
+            val notification = NotificationCompat.Builder(this, PROGRESS_CHANNEL_ID)
+                .setContentTitle("蜜蜂记账")
+                .setContentText("正在识别账单，请稍候…")
+                .setSmallIcon(android.R.drawable.ic_popup_reminder)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setCategory(NotificationCompat.CATEGORY_ALARM)
+                .setFullScreenIntent(fullScreenIntent, true)
+                .setAutoCancel(true)
+                .build()
+
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.notify(PROGRESS_NOTIFICATION_ID, notification)
+            LoggerPlugin.info(TAG, "进度通知已发送")
+        } catch (e: Exception) {
+            LoggerPlugin.error(TAG, "进度通知发送失败: ${e.message}")
+        }
+    }
+
+    /**
+     * 确保 [PROGRESS_CHANNEL_ID] 的 importance 为 HIGH。
+     * 国产 ROM 更新 APK 后可能重置渠道，导致 heads-up 失效。
+     */
+    private fun ensureProgressChannelHigh() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        try {
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val existing = manager.getNotificationChannel(PROGRESS_CHANNEL_ID)
+            if (existing == null || existing.importance < NotificationManager.IMPORTANCE_HIGH) {
+                if (existing != null) {
+                    manager.deleteNotificationChannel(PROGRESS_CHANNEL_ID)
+                }
+                val channel = android.app.NotificationChannel(
+                    PROGRESS_CHANNEL_ID,
+                    "摇一摇记账结果",
+                    NotificationManager.IMPORTANCE_HIGH
+                ).apply {
+                    description = "摇一摇自动记账通知"
+                    enableVibration(false)
+                    setBypassDnd(true)
+                    lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+                }
+                manager.createNotificationChannel(channel)
+            }
+        } catch (_: Exception) {}
+    }
+
+    /**
+     * 确保进度通知使用的 channel 已就绪。
+     * 复用 [PROGRESS_CHANNEL_ID]（即 shake_result channel），
+     * 该 channel 已在 [MainActivity.initBillingNotificationChannels] 中以
+     * IMPORTANCE_HIGH + bypassDnd + VISIBILITY_PUBLIC 创建，
+     * 用户若已为其开启横幅权限则可正常弹出 heads-up。
+     */
+    private fun createProgressChannel() {
+        // channel 由 MainActivity 统一创建，此处仅确保其存在
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (manager.getNotificationChannel(PROGRESS_CHANNEL_ID) == null) {
+                val channel = NotificationChannel(
+                    PROGRESS_CHANNEL_ID,
+                    "摇一摇记账结果",
+                    NotificationManager.IMPORTANCE_HIGH
+                ).apply {
+                    description = "摇一摇自动记账通知"
+                    // 不用渠道震动：由 vibratePhone() 统一控制震动反馈，避免重复
+                    enableVibration(false)
+                    setBypassDnd(true)
+                    lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+                }
+                manager.createNotificationChannel(channel)
+            }
+        }
+    }
+
+    /** 震动反馈，提示用户摇一摇已触发 */
+    private fun vibratePhone(durationMs: Long = 200L) {
+        try {
+            val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val manager = getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+                manager.defaultVibrator
+            } else {
+                @Suppress("DEPRECATION")
+                getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                vibrator.vibrate(
+                    VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE)
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator.vibrate(durationMs)
+            }
+            android.util.Log.d(TAG, "📳 震动反馈 ${durationMs}ms")
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "❌ 震动失败: ${e.message}")
+        }
+    }
+
+    /** 检测是否应忽略摇一摇触发（锁屏 / 屏幕熄灭） */
+    private fun shouldIgnoreShake(): Boolean {
+        // 屏幕熄灭（口袋/包里）
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        if (!pm.isInteractive) return true
+
+        // 屏幕亮但处于锁屏界面
+        val km = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return km.isDeviceLocked
+        }
+        return km.isKeyguardLocked
+    }
+
+}

--- a/android/app/src/main/kotlin/com/tntlikely/beecount/BootReceiver.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/beecount/BootReceiver.kt
@@ -1,0 +1,38 @@
+package com.tntlikely.beecount
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * 开机自启接收器。
+ *
+ * ### 五层保活 — L5 进程守护层
+ * 设备启动后自动启动保活前台服务，确保摇一摇自动记账功能在重启后仍能正常运行。
+ * 仅在用户开启了摇一摇自动记账时启动保活，避免不必要的后台进程。
+ */
+class BootReceiver : BroadcastReceiver() {
+
+    companion object {
+        private const val TAG = "BootReceiver"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            // 检查摇一摇自动记账是否已开启，未开启则不启动保活
+            val prefs = context.getSharedPreferences("flutter.shared_preferences", Context.MODE_PRIVATE)
+            val shakeEnabled = prefs.getBoolean("shake_billing_enabled", false)
+
+            if (!shakeEnabled) {
+                android.util.Log.d(TAG, "⏭️ 摇一摇未启用，跳过 BOOT_COMPLETED 保活")
+                return
+            }
+
+            android.util.Log.d(TAG, "🚀 BOOT_COMPLETED — 启动保活服务（摇一摇已启用）")
+            val serviceIntent = Intent(context, KeepAliveService::class.java).apply {
+                action = KeepAliveService.ACTION_START
+            }
+            context.startForegroundService(serviceIntent)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/tntlikely/beecount/KeepAliveJobService.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/beecount/KeepAliveJobService.kt
@@ -1,0 +1,63 @@
+package com.tntlikely.beecount
+
+import android.app.job.JobParameters
+import android.app.job.JobService
+import android.content.Intent
+
+/**
+ * JobScheduler 心跳检测 JobService。
+ *
+ * ### 五层保活 — L5 进程守护层
+ * 每 15 分钟由 [KeepAliveService] 调度执行一次，检测保活服务是否存活。
+ * 如果服务异常死亡，尝试重新拉起；如果无障碍服务死亡（用户手动关闭），
+ * 则不做恢复（需要用户主动重新开启）。
+ */
+class KeepAliveJobService : JobService() {
+
+    companion object {
+        private const val TAG = "KeepAliveJobService"
+    }
+
+    override fun onStartJob(params: JobParameters?): Boolean {
+        android.util.Log.d(TAG, "❤️‍🔥 心跳检测执行中...")
+
+        val keepAliveAlive = KeepAliveService.isRunning
+        val accessibilityAlive = BillingAccessibilityService.isRunning
+
+        android.util.Log.d(TAG, "   KeepAliveService: ${if (keepAliveAlive) "存活" else "已死"}")
+        android.util.Log.d(TAG, "   BillingAccessibilityService: ${if (accessibilityAlive) "存活" else "已死"}")
+
+        if (!keepAliveAlive) {
+            // 尝试重新拉起保活服务
+            android.util.Log.w(TAG, "⚠️ KeepAliveService 异常死亡，尝试重新拉起...")
+            try {
+                val intent = Intent(this, KeepAliveService::class.java).apply {
+                    action = KeepAliveService.ACTION_START
+                }
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                    startForegroundService(intent)
+                } else {
+                    startService(intent)
+                }
+                android.util.Log.d(TAG, "✅ 重新拉起成功")
+            } catch (e: Exception) {
+                android.util.Log.e(TAG, "❌ 重新拉起失败: ${e.message}")
+            }
+        }
+
+        if (!accessibilityAlive) {
+            android.util.Log.w(TAG, "⚠️ BillingAccessibilityService 未运行（等待系统自动重连）")
+            // Engine 由摇一摇回调按需创建，不在此提前创建
+        }
+
+        // 通知 JobScheduler 工作完成
+        jobFinished(params, false)
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters?): Boolean {
+        android.util.Log.d(TAG, "⏹️ 心跳检测被系统取消")
+        // 返回 true 表示需要重试
+        return true
+    }
+}

--- a/android/app/src/main/kotlin/com/tntlikely/beecount/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/beecount/KeepAliveService.kt
@@ -1,0 +1,398 @@
+package com.tntlikely.beecount
+
+import android.app.AlarmManager
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.app.job.JobInfo
+import android.app.job.JobScheduler
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import android.os.SystemClock
+import androidx.core.app.NotificationCompat
+import io.flutter.FlutterInjector
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.dart.DartExecutor
+
+/**
+ * 保活前台服务。
+ *
+ * 通过前台服务保持应用进程在后台存活，确保截图监听和摇一摇自动记账
+ * 功能在后台也能正常运行。显示一个低优先级通知，不发出声音或震动。
+ *
+ * ### 五层保活 — L3 前台服务层 + L5 进程守护层
+ * - L3: startForeground + onTaskRemoved 自拉活 + WakeLock
+ * - L5: JobScheduler 3min + AlarmManager 1min 双心跳检测
+ *
+ * ### 防清除策略
+ * - onTaskRemoved: 用户从最近任务滑掉时立即自拉活
+ * - AlarmManager 心跳: 国产 ROM 上比 JobScheduler 更可靠
+ * - START_STICKY: 系统杀死后尝试重建
+ */
+class KeepAliveService : Service() {
+
+    companion object {
+        private const val TAG = "KeepAliveService"
+
+        const val CHANNEL_ID = "keep_alive"
+        const val NOTIFICATION_ID = 9001
+        const val JOB_ID = 9001
+        const val ALARM_REQUEST_CODE = 9002
+
+        const val ACTION_START = "com.tntlikely.beecount.action.START_KEEP_ALIVE"
+        const val ACTION_STOP = "com.tntlikely.beecount.action.STOP_KEEP_ALIVE"
+        const val ACTION_HEARTBEAT = "com.tntlikely.beecount.action.HEARTBEAT"
+
+        /**
+         * JobScheduler 心跳间隔（毫秒）。
+         * 注意: Android 7+ (API 24+) 上 setPeriodic 最小强制 15 分钟，设更小也会被抬升到 15min。
+         * JobScheduler 作为 AlarmManager 心跳的补充（Doze 模式下 AlarmManager 受限时仍可触发）。
+         */
+        private const val HEARTBEAT_INTERVAL_MS = 15 * 60 * 1000L  // 15 分钟（API 24+ 最小值）
+
+        /** AlarmManager 心跳间隔（毫秒），国产 ROM 上比 JobScheduler 更可靠 */
+        private const val ALARM_HEARTBEAT_INTERVAL_MS = 1 * 60 * 1000L  // 1 分钟
+
+        /** 服务是否正在运行（供 MainActivity 状态查询） */
+        @Volatile
+        var isRunning = false
+            private set
+
+        /**
+         * 后台专用的 FlutterEngine。
+         *
+         * 与 [MainActivity.cachedEngine] 完全独立，互不干扰。
+         * 此 Engine 用 applicationContext 创建，不绑定 Activity 生命周期，
+         * 专门用于后台截屏的 AI 处理。Activity 打开时 [MainActivity] 会
+         * 创建自己的 Engine 渲染 UI，两者 Dart Isolate 完全隔离。
+         */
+        @Volatile
+        private var backgroundEngine: FlutterEngine? = null
+
+        /**
+         * 确保后台 FlutterEngine 可用。
+         *
+         * 截屏触发后、发送结果到 Dart 前调用此方法，确保 Engine 的 Dart isolate
+         * 正在运行。如果 Engine 已死或未创建，重新创建并注册到 [AccessibilityBridge]。
+         *
+         * **重要：始终使用 applicationContext 而非 Service/JobService context。**
+         * Flutter 插件注册时如果拿到 Service context，后续 Activity attach 时
+         * 会因为 context 类型不匹配而崩溃。applicationContext 是安全的基上下文。
+         */
+        @JvmStatic
+        fun ensureFlutterEngine(context: Context) {
+            // 不检查 AccessibilityBridge.hasEngine()：Activity 引擎可能在划掉后台后
+            // FlutterJNI 已断开（detachFromNative），但 hasEngine() 仍返回 true，
+            // 导致 backgroundEngine 永远不会被创建，MethodChannel 调用静默失败。
+            // 始终走 backgroundEngine 路径，它是用 applicationContext 创建的独立引擎，
+            // 不绑定 Activity 生命周期，JNI 始终存活。
+
+            // 检查自有背景 Engine 是否存活
+            if (backgroundEngine?.dartExecutor?.isExecutingDart == true) {
+                LoggerPlugin.info(TAG, "使用后台缓存的 Engine")
+                AccessibilityBridge.setEngine(backgroundEngine!!)
+                return
+            }
+
+            // 自有 Engine 已死亡，销毁它
+            backgroundEngine?.let {
+                LoggerPlugin.warning(TAG, "后台 Engine 已死亡，销毁重建")
+                try { it.destroy() } catch (_: Exception) {}
+                backgroundEngine = null
+            }
+
+            try {
+                // ⚠️ 关键：必须使用 applicationContext，而非原始 context（可能是 Service）！
+                // Service context 会导致 Flutter 插件注册时拿到 Service 的引用，
+                // 下次 Activity attach 时插件强转为 Activity 会崩溃。applicationContext 是安全的基上下文。
+                val appContext = context.applicationContext
+                LoggerPlugin.info(TAG, "创建 FlutterEngine（applicationContext）")
+                val engine = FlutterEngine(appContext)
+
+                engine.dartExecutor.executeDartEntrypoint(
+                    DartExecutor.DartEntrypoint(
+                        FlutterInjector.instance().flutterLoader().findAppBundlePath(),
+                        "main"
+                    )
+                )
+
+                backgroundEngine = engine
+                AccessibilityBridge.setEngine(engine)
+                LoggerPlugin.info(TAG, "后台 FlutterEngine 已创建并注册（applicationContext）")
+            } catch (e: Exception) {
+                LoggerPlugin.error(TAG, "FlutterEngine 初始化失败: ${e.message}")
+            }
+        }
+    }
+
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        LoggerPlugin.info(TAG, "保活服务创建")
+        createNotificationChannel()
+        scheduleHeartbeat()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                LoggerPlugin.info(TAG, "收到停止指令")
+                isRunning = false
+                cancelHeartbeat()
+                cancelAlarmHeartbeat()
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                releaseWakeLock()
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            ACTION_HEARTBEAT -> {
+                LoggerPlugin.info(TAG, "AlarmManager 心跳 — 保活服务运行中")
+                // Engine 由摇一摇回调按需创建，心跳只负责保活 Service 本身
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                    reacquireForeground()
+                }
+                return START_STICKY
+            }
+            else -> {
+                if (!isRunning) {
+                    LoggerPlugin.info(TAG, "保活服务启动")
+                }
+                isRunning = true
+                startForegroundWithNotification()
+                acquireWakeLock()
+                scheduleHeartbeat()
+                scheduleAlarmHeartbeat()
+                // Engine 由摇一摇回调按需创建，不在此提前创建。
+                // 避免与 MainActivity 的 Engine 同时存在导致 OOM。
+            }
+        }
+        return START_STICKY
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        LoggerPlugin.warning(TAG, "App 被从最近任务移除，尝试自拉活...")
+        isRunning = false
+
+        // 方式 1: 通过 AlarmManager 延迟 2 秒重启（绕过大多数 ROM 的清理限制）
+        val restartIntent = Intent(this, KeepAliveService::class.java).apply {
+            action = ACTION_START
+        }
+        val pendingIntent = PendingIntent.getService(
+            this,
+            ALARM_REQUEST_CODE + 1,
+            restartIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                SystemClock.elapsedRealtime() + 2000,
+                pendingIntent
+            )
+        } else {
+            alarmManager.setExact(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                SystemClock.elapsedRealtime() + 2000,
+                pendingIntent
+            )
+        }
+
+        // 方式 2: 直接尝试重启
+        try {
+            val restartDirect = Intent(this, KeepAliveService::class.java).apply {
+                action = ACTION_START
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForegroundService(restartDirect)
+            } else {
+                startService(restartDirect)
+            }
+            LoggerPlugin.info(TAG, "自拉活指令已发出")
+        } catch (e: Exception) {
+            LoggerPlugin.error(TAG, "直接自拉活失败，等待 AlarmManager 兜底: ${e.message}")
+        }
+
+        super.onTaskRemoved(rootIntent)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        LoggerPlugin.info(TAG, "保活服务销毁")
+        isRunning = false
+        cancelHeartbeat()
+        cancelAlarmHeartbeat()
+        releaseWakeLock()
+        super.onDestroy()
+    }
+
+    // ────────────────── 前台通知 ──────────────────
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "保活服务",
+            NotificationManager.IMPORTANCE_MIN
+        ).apply {
+            description = "保持 BeeCount 在后台运行，确保摇一摇自动记账稳定工作"
+            setShowBadge(false)
+            lockscreenVisibility = NotificationCompat.VISIBILITY_SECRET
+        }
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun createNotification(): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("BeeCount 正在后台运行")
+            .setContentText("保活服务 · 摇一摇自动记账 · 截图识别")
+            .setSmallIcon(android.R.drawable.ic_menu_compass)
+            .setPriority(NotificationCompat.PRIORITY_MIN)
+            .setOngoing(true)
+            .setSilent(true)
+            .build()
+    }
+
+    private fun startForegroundWithNotification() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { // API 34+
+            startForeground(
+                NOTIFICATION_ID,
+                createNotification(),
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, createNotification())
+        }
+    }
+
+    /**
+     * 如果前台通知被系统移除（部分 ROM 清理行为），重新进入前台。
+     */
+    private fun reacquireForeground() {
+        try {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            startForegroundWithNotification()
+        } catch (_: Exception) {
+            // 忽略，下次心跳再试
+        }
+    }
+
+    // ────────────────── WakeLock ──────────────────
+
+    private fun acquireWakeLock() {
+        try {
+            val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+            wakeLock = powerManager.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                "BeeCount:KeepAliveWakeLock"
+            ).apply {
+                acquire(10 * 60 * 1000L) // 最多持有 10 分钟，防止耗电
+            }
+        } catch (_: Exception) {
+            // 部分 ROM 限制 WakeLock
+        }
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.let {
+            if (it.isHeld) {
+                try {
+                    it.release()
+                } catch (_: Exception) {}
+            }
+        }
+        wakeLock = null
+    }
+
+    // ────────────────── JobScheduler 心跳（L5） ──────────────────
+
+    private fun scheduleHeartbeat() {
+        try {
+            val scheduler = getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+            val jobInfo = JobInfo.Builder(JOB_ID, ComponentName(this, KeepAliveJobService::class.java))
+                .setPeriodic(HEARTBEAT_INTERVAL_MS)
+                .setPersisted(true)  // 设备重启后保留
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_NONE)
+                .setRequiresCharging(false)
+                .setRequiresDeviceIdle(false)
+                .build()
+            val result = scheduler.schedule(jobInfo)
+            LoggerPlugin.info(TAG, "JobScheduler 心跳已调度（${HEARTBEAT_INTERVAL_MS / 60000}min），结果=$result")
+        } catch (e: Exception) {
+            LoggerPlugin.error(TAG, "JobScheduler 调度失败: ${e.message}")
+        }
+    }
+
+    private fun cancelHeartbeat() {
+        try {
+            val scheduler = getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+            scheduler.cancel(JOB_ID)
+            LoggerPlugin.info(TAG, "JobScheduler 心跳已取消")
+        } catch (_: Exception) {}
+    }
+
+    // ────────────────── AlarmManager 心跳（L5 补充，国产 ROM 更可靠） ──────────────────
+
+    /**
+     * 使用 AlarmManager 作为额外心跳。
+     * JobScheduler 在部分国产 ROM 上延迟严重（甚至数小时不触发），
+     * AlarmManager（setExactAndAllowWhileIdle）更可靠。
+     */
+    private fun scheduleAlarmHeartbeat() {
+        try {
+            val intent = Intent(this, KeepAliveService::class.java).apply {
+                action = ACTION_HEARTBEAT
+            }
+            val pendingIntent = PendingIntent.getService(
+                this,
+                ALARM_REQUEST_CODE,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    SystemClock.elapsedRealtime() + ALARM_HEARTBEAT_INTERVAL_MS,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.setExact(
+                    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                    SystemClock.elapsedRealtime() + ALARM_HEARTBEAT_INTERVAL_MS,
+                    pendingIntent
+                )
+            }
+            LoggerPlugin.info(TAG, "AlarmManager 心跳已调度（${ALARM_HEARTBEAT_INTERVAL_MS / 60000}min）")
+        } catch (e: Exception) {
+            LoggerPlugin.error(TAG, "AlarmManager 调度失败: ${e.message}")
+        }
+    }
+
+    private fun cancelAlarmHeartbeat() {
+        try {
+            val intent = Intent(this, KeepAliveService::class.java).apply {
+                action = ACTION_HEARTBEAT
+            }
+            val pendingIntent = PendingIntent.getService(
+                this,
+                ALARM_REQUEST_CODE,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_NO_CREATE
+            )
+            pendingIntent?.let {
+                val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                alarmManager.cancel(it)
+            }
+            LoggerPlugin.info(TAG, "AlarmManager 心跳已取消")
+        } catch (_: Exception) {}
+    }
+}

--- a/android/app/src/main/kotlin/com/tntlikely/beecount/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/beecount/MainActivity.kt
@@ -1,29 +1,49 @@
 package com.tntlikely.beecount
 
 import android.app.AlarmManager
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageInstaller
 import android.net.Uri
 import android.os.Build
 import android.os.PowerManager
 import android.provider.Settings
 import androidx.core.content.FileProvider
 import java.io.File
-import java.io.FileInputStream
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterFragmentActivity() {
+
+    companion object {
+        private const val TAG = "MainActivity"
+
+        /** 缓存的 FlutterEngine，在 Activity 销毁后仍存活。
+         * 通过 [provideFlutterEngine] 返回给 Fragment 宿主，
+         * [shouldDestroyEngineWithHost]=false 禁止宿主销毁它。
+         *
+         * internal 可见性，允许 [KeepAliveService] 在进程重启后初始化。
+         */
+        @JvmField
+        internal var cachedEngine: FlutterEngine? = null
+
+        /**
+         * Engine 是否已被 Fragment 配置并使用过。
+         * Fragment 重建时 [configureFlutterEngine] 会被第二次调用，
+         * 此时老 Fragment detach 可能已断开 FlutterJNI，但 Dart isolate 还活着。
+         * 此标志让 [provideFlutterEngine] 检测到复用场景并重建 Engine。
+         */
+        private var engineHasBeenUsed = false
+    }
+
     private val CHANNEL = "notification_channel"
     private val INSTALL_CHANNEL = "com.tntlikely.beecount/install"
     private val SCREENSHOT_CHANNEL = "com.tntlikely.beecount/screenshot"
     private val LOGGER_CHANNEL = "com.beecount.logger"
     private val SHARE_CHANNEL = "com.tntlikely.beecount/share"
+    private val KEEP_ALIVE_CHANNEL = "com.tntlikely.beecount/keep_alive"
 
     private var screenshotObserver: ScreenshotObserver? = null
 
@@ -38,6 +58,92 @@ class MainActivity: FlutterFragmentActivity() {
         setIntent(intent) // 重要：更新当前intent
         handleNotificationIntent(intent)
         handleSharedImage(intent)
+    }
+
+    /**
+     * 提供缓存的 FlutterEngine，避免 Activity 销毁后 Dart 隔离区随之消亡。
+     *
+     * 首次调用时创建 Engine，后续一直返回同一个实例。
+     * [FlutterActivityAndFragmentDelegate] 在 Activity 重建时仍会
+     * 调用此方法获取同一个 Engine，并重新 [configureFlutterEngine]。
+     *
+     * 配合 [shouldDestroyEngineWithHost]=false 让 Engine 存活于整个进程。
+     */
+    override fun provideFlutterEngine(context: Context): FlutterEngine? {
+        val existing = cachedEngine
+        if (existing != null) {
+            if (existing.dartExecutor.isExecutingDart) {
+                // 检查 Engine 是否已被之前的 Fragment 配置并使用过。
+                // Activity/Fragment 重建（如主题切换或第二次启动 Intent）会二次调用
+                // provideFlutterEngine，老 Fragment detach 可能断开了 FlutterJNI，
+                // 但 Dart isolate 还活着。此时复用老 Engine 会在渲染时崩溃。
+                if (!engineHasBeenUsed) {
+                    return existing
+                }
+                android.util.Log.w(TAG, "⚠️ Engine 已被使用过，销毁并重建避免 JNI 断开")
+                LoggerPlugin.warning(TAG, "Engine 已被使用过，销毁并重建避免 JNI 断开")
+            } else {
+                android.util.Log.w(TAG, "⚠️ Dart isolate 已死亡，销毁并重建 FlutterEngine")
+                LoggerPlugin.warning(TAG, "Dart isolate 已死亡，销毁并重建 FlutterEngine")
+            }
+            try {
+                existing.destroy()
+            } catch (_: Exception) {}
+        }
+        engineHasBeenUsed = false
+        // 在创建 Engine 前检查 SharedPreferences 文件健康，防止 OOM
+        checkFlutterSharedPreferencesHealth()
+
+        android.util.Log.e(TAG, "🚀 创建全局缓存的 FlutterEngine")
+        cachedEngine = FlutterEngine(context)
+        return cachedEngine
+    }
+
+    /** 禁止 Fragment 宿主在 Activity 销毁时一并销毁 Engine */
+    override fun shouldDestroyEngineWithHost(): Boolean = false
+
+    /**
+     * 检查并修复 SharedPreferences 文件大小异常。
+     *
+     * 在 Flutter Engine 初始化前检查 [FlutterSharedPreferences.xml] 和
+     * [flutter.shared_preferences.xml] 文件大小。如果超过 1MB，
+     * 说明存储了异常数据（如早期崩溃导致大量路径/损坏累积），
+     * 直接删除文件。Flutter 插件/BootReceiver 读取时会自动创建新的空文件。
+     *
+     * 此操作仅丢失应用设置（主题、摇晃开关等），不涉及 SQLite 中的交易、账户等财务数据。
+     */
+    private fun checkFlutterSharedPreferencesHealth() {
+        try {
+            val sharedPrefsDir = File(filesDir.parentFile, "shared_prefs")
+            if (!sharedPrefsDir.exists()) return
+
+            val targets = listOf(
+                "FlutterSharedPreferences" to "LegacySharedPreferencesPlugin",
+                "flutter.shared_preferences" to "BootReceiver"
+            )
+
+            for ((name, description) in targets) {
+                val file = File(sharedPrefsDir, "$name.xml")
+                if (!file.exists()) continue
+
+                val size = file.length()
+                if (size > 1024 * 1024) { // > 1MB, 正常 SharedPreferences 不应这么大
+                    android.util.Log.w(TAG,
+                        "⚠️ $name.xml 异常过大 (${size / 1024 / 1024}MB) — " +
+                        "由 $description 读取，已删除")
+                    LoggerPlugin.warning(TAG,
+                        "SharedPreferences $name.xml 过大 (${size / 1024 / 1024}MB)，已删除修复")
+
+                    file.delete()
+
+                    // 同时清理备份文件
+                    val bakFile = File(sharedPrefsDir, "$name.xml.bak")
+                    if (bakFile.exists()) bakFile.delete()
+                }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "SharedPreferences 健康检查失败: ${e.message}")
+        }
     }
 
     private fun handleSharedImage(intent: Intent?) {
@@ -133,6 +239,13 @@ class MainActivity: FlutterFragmentActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
+        // 标记 Engine 已被 Fragment 配置和使用过。
+        // 如果 Activity/Fragment 重建导致二次调用，provideFlutterEngine 会据此重建 Engine。
+        engineHasBeenUsed = true
+
+        // 预创建摇一摇相关的通知渠道，确保首次显示通知时 importance 正确
+        initBillingNotificationChannels()
+
         android.util.Log.e("MainActivity", "==========================================")
         android.util.Log.e("MainActivity", "configureFlutterEngine 被调用！！！")
         android.util.Log.e("MainActivity", "==========================================")
@@ -165,6 +278,13 @@ class MainActivity: FlutterFragmentActivity() {
                     stopScreenshotObserver()
                     result.success(true)
                 }
+                "openAccessibilitySettings" -> {
+                    openAccessibilitySettings()
+                    result.success(true)
+                }
+                "isAccessibilityServiceEnabled" -> {
+                    result.success(isAccessibilityServiceEnabled())
+                }
                 else -> result.notImplemented()
             }
         }
@@ -184,6 +304,10 @@ class MainActivity: FlutterFragmentActivity() {
                 else -> result.notImplemented()
             }
         }
+
+        // 将全局 FlutterEngine 注册到 AccessibilityBridge
+        // Engine 由 provideFlutterEngine 缓存，Activity 销毁后仍存活
+        AccessibilityBridge.setEngine(flutterEngine)
 
         // 通知相关的MethodChannel
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
@@ -217,11 +341,13 @@ class MainActivity: FlutterFragmentActivity() {
                     result.success(getBatteryOptimizationInfo())
                 }
                 "openNotificationChannelSettings" -> {
-                    openNotificationChannelSettings()
+                    val channelId = call.argument<String>("channelId") ?: "accounting_reminder"
+                    openNotificationChannelSettings(channelId)
                     result.success(true)
                 }
                 "getNotificationChannelInfo" -> {
-                    result.success(getNotificationChannelInfo())
+                    val channelId = call.argument<String>("channelId") ?: "accounting_reminder"
+                    result.success(getNotificationChannelInfo(channelId))
                 }
                 "testDirectNotification" -> {
                     val title = call.argument<String>("title") ?: "直接测试通知"
@@ -233,6 +359,148 @@ class MainActivity: FlutterFragmentActivity() {
                 }
                 else -> result.notImplemented()
             }
+        }
+
+        // 保活前台服务的MethodChannel
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, KEEP_ALIVE_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "startKeepAlive" -> {
+                    try {
+                        val intent = Intent(this, KeepAliveService::class.java).apply {
+                            action = KeepAliveService.ACTION_START
+                        }
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            startForegroundService(intent)
+                        } else {
+                            startService(intent)
+                        }
+                        android.util.Log.d("MainActivity", "✅ 保活服务已启动")
+                        LoggerPlugin.info("MainActivity", "保活服务已启动")
+                        result.success(true)
+                    } catch (e: Exception) {
+                        android.util.Log.e("MainActivity", "启动保活服务失败: $e")
+                        result.error("START_FAILED", e.message ?: "启动保活服务失败", null)
+                    }
+                }
+                "stopKeepAlive" -> {
+                    try {
+                        val intent = Intent(this, KeepAliveService::class.java).apply {
+                            action = KeepAliveService.ACTION_STOP
+                        }
+                        startService(intent)
+                        android.util.Log.d("MainActivity", "✅ 保活服务已停止")
+                        LoggerPlugin.info("MainActivity", "保活服务已停止")
+                        result.success(true)
+                    } catch (e: Exception) {
+                        android.util.Log.e("MainActivity", "停止保活服务失败: $e")
+                        result.error("STOP_FAILED", e.message ?: "停止保活服务失败", null)
+                    }
+                }
+                "isKeepAliveRunning" -> {
+                    val running = KeepAliveService.isRunning || BillingAccessibilityService.isRunning
+                    result.success(running)
+                }
+                "isIgnoringBatteryOptimizations" -> {
+                    result.success(isIgnoringBatteryOptimizations())
+                }
+                "openBatteryOptimizationSettings" -> {
+                    try {
+                        val intent = Intent(android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                        startActivity(intent)
+                        result.success(true)
+                    } catch (e: Exception) {
+                        result.error("INTENT_FAILED", e.message, null)
+                    }
+                }
+                "cancelProgressNotification" -> {
+                    try {
+                        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                        manager.cancel(9101)
+                        android.util.Log.d("MainActivity", "✅ 进度通知已取消 (ID=9101)")
+                        result.success(true)
+                    } catch (e: Exception) {
+                        android.util.Log.e("MainActivity", "❌ 取消进度通知失败: ${e.message}")
+                        result.error("CANCEL_FAILED", e.message, null)
+                    }
+                }
+                "openAutoStartSettings" -> {
+                    try {
+                        val result2 = openAutoStartSettings()
+                        result.success(result2)
+                    } catch (e: Exception) {
+                        result.error("INTENT_FAILED", e.message, null)
+                    }
+                }
+                "requestIgnoreBatteryOptimizations" -> {
+                    requestIgnoreBatteryOptimizations()
+                    result.success(true)
+                }
+                "getKeepAliveStatus" -> {
+                    val map = mapOf(
+                        "keepAliveServiceRunning" to KeepAliveService.isRunning,
+                        "accessibilityServiceRunning" to BillingAccessibilityService.isRunning,
+                        "isIgnoringBatteryOptimizations" to isIgnoringBatteryOptimizations()
+                    )
+                    result.success(map)
+                }
+                "getNotificationChannelInfo" -> {
+                    val channelId = call.argument<String>("channelId") ?: "shake_result"
+                    result.success(getNotificationChannelInfo(channelId))
+                }
+                "openNotificationChannelSettings" -> {
+                    val channelId = call.argument<String>("channelId") ?: "shake_result"
+                    openNotificationChannelSettings(channelId)
+                    result.success(true)
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // 摇一摇自动记账控制方法绑定到 Engine 生命周期，不因 Activity 销毁而丢失
+    }
+
+    /**
+     * 预创建摇一摇记账相关的通知渠道，确保 importance 正确。
+     * 如果渠道已存在但 importance 不是 HIGH，则删除重建（仅在 DEBUG 构建或渠道重要性不达标时触发）。
+     */
+    private fun initBillingNotificationChannels() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // 需要确保 importance >= HIGH 的渠道列表
+        data class ChannelDef(val id: String, val name: String, val desc: String)
+        val channels = listOf(
+            ChannelDef("shake_result", "摇一摇记账结果", "摇一摇自动记账最终结果通知"),
+            ChannelDef("screenshot_ocr", "截图识别", "截图自动识别通知"),
+        )
+
+        for (ch in channels) {
+            val existing = manager.getNotificationChannel(ch.id)
+            if (existing != null && existing.importance >= NotificationManager.IMPORTANCE_HIGH) {
+                // 已有渠道且 importance 达标 — 跳过
+                android.util.Log.d(TAG, "通知渠道 '${ch.id}' 已存在且 importance 达标 (${existing.importance})")
+                continue
+            }
+            if (existing != null) {
+                // 渠道 importance 太低 — 删除重建（会丢失用户对该渠道的个性化设置）
+                android.util.Log.w(TAG, "通知渠道 '${ch.id}' importance 过低 (${existing.importance})，删除重建")
+                manager.deleteNotificationChannel(ch.id)
+            }
+            val channel = android.app.NotificationChannel(
+                ch.id,
+                ch.name,
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = ch.desc
+                enableVibration(true)
+                enableLights(true)
+                setShowBadge(true)
+                lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+                // 允许绕过勿扰模式（提升国产 ROM 弹出横幅几率）
+                setBypassDnd(true)
+            }
+            manager.createNotificationChannel(channel)
+            android.util.Log.d(TAG, "✅ 已创建通知渠道 '${ch.id}' (IMPORTANCE_HIGH)")
         }
     }
 
@@ -360,6 +628,75 @@ class MainActivity: FlutterFragmentActivity() {
         startActivity(intent)
     }
 
+
+    /**
+     * 打开各 ROM 自启动管理页面。
+     * 根据设备制造商跳转到对应的自启动设置页，不支持的 ROM 返回 false。
+     */
+    private fun openAutoStartSettings(): Boolean {
+        val manufacturer = Build.MANUFACTURER.lowercase()
+
+        // 荣耀/华为：有多条路径，逐一尝试
+        if (manufacturer.contains("huawei") || manufacturer.contains("honor")) {
+            val honorPkg = "com.hihonor.systemmanager"
+            val honorCls = "$honorPkg.optimize.process.ProtectActivity"
+            val huaweiPkg = "com.huawei.systemmanager"
+            val huaweiCls = "$huaweiPkg.optimize.process.ProtectActivity"
+            // 按优先级尝试各路径
+            val candidates = listOf(
+                Intent().apply { component = android.content.ComponentName(honorPkg, honorCls) },
+                Intent().apply { component = android.content.ComponentName(huaweiPkg, huaweiCls) },
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.parse("package:$packageName")
+                },
+            )
+            for (intent in candidates) {
+                try {
+                    startActivity(intent)
+                    return true
+                } catch (_: Exception) { }
+            }
+            return false
+        }
+
+        val intent = when {
+            manufacturer.contains("xiaomi") || manufacturer.contains("redmi") -> {
+                Intent().apply {
+                    component = android.content.ComponentName(
+                        "com.miui.securitycenter",
+                        "com.miui.permcenter.autostart.AutoStartManagementActivity"
+                    )
+                }
+            }
+            manufacturer.contains("oppo") || manufacturer.contains("oneplus") -> {
+                Intent().apply {
+                    component = android.content.ComponentName(
+                        "com.oppo.safe",
+                        "com.oppo.safe.permission.startup.StartupAppListActivity"
+                    )
+                }
+            }
+            manufacturer.contains("meizu") -> {
+                Intent().apply {
+                    component = android.content.ComponentName(
+                        "com.meizu.safe",
+                        "com.meizu.safe.permission.SmartPermissionActivity"
+                    )
+                }
+            }
+            else -> null
+        }
+        if (intent != null) {
+            try {
+                startActivity(intent)
+                return true
+            } catch (e: Exception) {
+                android.util.Log.e(TAG, "打开自启动设置失败: ${e.message}")
+            }
+        }
+        return false
+    }
+
     private fun getBatteryOptimizationInfo(): Map<String, Any> {
         val isIgnoring = isIgnoringBatteryOptimizations()
         val canRequest = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
@@ -374,31 +711,31 @@ class MainActivity: FlutterFragmentActivity() {
         )
     }
 
-    private fun openNotificationChannelSettings() {
+    private fun openNotificationChannelSettings(channelId: String = "accounting_reminder") {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
                     putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
-                    putExtra(Settings.EXTRA_CHANNEL_ID, "accounting_reminder")
+                    putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
                 }
                 startActivity(intent)
-                android.util.Log.d("MainActivity", "打开通知渠道设置页面")
+                android.util.Log.d(TAG, "打开通知渠道设置页面: $channelId")
             } else {
                 // Android 8.0以下版本打开应用通知设置
                 openAppSettings()
             }
         } catch (e: Exception) {
-            android.util.Log.e("MainActivity", "打开通知渠道设置失败: $e")
+            android.util.Log.e(TAG, "打开通知渠道设置失败: $e")
             // fallback到应用设置
             openAppSettings()
         }
     }
 
-    private fun getNotificationChannelInfo(): Map<String, Any> {
+    private fun getNotificationChannelInfo(channelId: String = "accounting_reminder"): Map<String, Any> {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-                val channel = notificationManager.getNotificationChannel("accounting_reminder")
+                val channel = notificationManager.getNotificationChannel(channelId)
 
                 if (channel != null) {
                     val importanceLevel = when (channel.importance) {
@@ -481,6 +818,28 @@ class MainActivity: FlutterFragmentActivity() {
         }
     }
 
+    private fun openAccessibilitySettings() {
+        try {
+            val intent = Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS)
+            startActivity(intent)
+        } catch (e: Exception) {
+            android.util.Log.e("MainActivity", "无法打开无障碍设置: $e")
+            openAppSettings()
+        }
+    }
+
+    private fun isAccessibilityServiceEnabled(): Boolean {
+        return try {
+            val enabledServices = android.provider.Settings.Secure.getString(
+                contentResolver,
+                android.provider.Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+            )
+            enabledServices?.contains(packageName + "/" + BillingAccessibilityService::class.java.name) == true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
     private fun startScreenshotObserver(flutterEngine: FlutterEngine) {
         try {
             android.util.Log.d("MainActivity", "========== 开始启动截图监听服务 ==========")
@@ -550,6 +909,8 @@ class MainActivity: FlutterFragmentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         stopScreenshotObserver()
+        // 不释放 Bridge 中的 Engine 引用——Engine 由 provideFlutterEngine 缓存，
+        // 跨 Activity 生命周期存活，Dart 隔离区继续处理 MethodChannel 消息。
     }
 
     private fun installApkWithIntent(filePath: String): Boolean {

--- a/android/app/src/main/kotlin/com/tntlikely/beecount/ScreenshotController.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/beecount/ScreenshotController.kt
@@ -1,0 +1,125 @@
+package com.tntlikely.beecount
+
+import android.accessibilityservice.AccessibilityService
+import android.graphics.Bitmap
+import android.graphics.PixelFormat
+import android.graphics.Picture
+import android.os.Build
+import android.view.Display
+import android.view.accessibility.AccessibilityNodeInfo
+import androidx.annotation.RequiresApi
+import java.io.File
+
+private const val TAG = "ScreenshotController"
+
+/**
+ * 截图控制器。
+ *
+ * 核心截图能力，封装 API 31+ 的 `takeScreenshot()`，并提供 API 30- 降级方案。
+ *
+ * - API 31+：takeScreenshot() → PNG 文件路径
+ * - API 30-：提取节点文本 → "text:" + 文本内容（Flutter 侧据此分流）
+ */
+class ScreenshotController(private val service: AccessibilityService) {
+
+    private val cacheDir: File
+        get() = File(service.cacheDir, "screenshots").also { it.mkdirs() }
+
+    /**
+     * 截取或提取当前屏幕信息。
+     *
+     * @param onResult 回调：PNG 文件路径 或 "text:" + 提取的节点文本
+     */
+    fun captureForAI(onResult: (String?) -> Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            captureByApiWithFallback(onResult)
+        } else {
+            captureByNodeText(onResult)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun captureByApiWithFallback(onResult: (String?) -> Unit) {
+        LoggerPlugin.info(TAG, "调用 takeScreenshot()")
+        service.takeScreenshot(
+            Display.DEFAULT_DISPLAY,
+            service.mainExecutor,
+            object : AccessibilityService.TakeScreenshotCallback {
+                override fun onSuccess(result: AccessibilityService.ScreenshotResult) {
+                    val buffer = result.hardwareBuffer ?: run {
+                        LoggerPlugin.warning(TAG, "takeScreenshot hardwareBuffer 为 null，降级到文本提取")
+                        captureByNodeText(onResult)
+                        return@onSuccess
+                    }
+                    val bitmap = Bitmap.wrapHardwareBuffer(buffer, null) ?: run {
+                        LoggerPlugin.warning(TAG, "wrapHardwareBuffer 失败，降级到文本提取")
+                        buffer.close()
+                        captureByNodeText(onResult)
+                        return@onSuccess
+                    }
+                    val file = File(cacheDir, "auto_bill_${System.currentTimeMillis()}.png")
+                    try {
+                        file.outputStream().use { out ->
+                            bitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
+                        }
+                        LoggerPlugin.info(TAG, "截屏成功，保存到 ${file.absolutePath} (${file.length()} bytes)")
+                        onResult(file.absolutePath)
+                    } catch (e: Exception) {
+                        LoggerPlugin.error(TAG, "保存截屏图片失败: ${e.message}，降级到文本提取")
+                        captureByNodeText(onResult)
+                    } finally {
+                        buffer.close()
+                    }
+                }
+
+                override fun onFailure(errorCode: Int) {
+                    LoggerPlugin.warning(TAG, "takeScreenshot 失败(errorCode=$errorCode)，降级到文本提取")
+                    captureByNodeText(onResult)
+                }
+            }
+        )
+    }
+
+    /**
+     * API 30- 降级方案：提取当前窗口的 Accessibility 节点文本。
+     *
+     * 输出格式为 "text:" + 提取的文本，Flutter 侧根据前缀走
+     * AiBookkeeper.fromText()（文字 AI 记账）。
+     */
+    private fun captureByNodeText(onResult: (String?) -> Unit) {
+        val root = service.rootInActiveWindow ?: run {
+            LoggerPlugin.error(TAG, "文本提取失败: rootInActiveWindow 为 null")
+            onResult(null)
+            return
+        }
+        val text = extractAllText(root)
+        if (text.isBlank()) {
+            LoggerPlugin.warning(TAG, "文本提取失败: 节点文本为空")
+            onResult(null)
+            return
+        }
+        LoggerPlugin.info(TAG, "文本提取成功: ${text.length} 字符")
+        onResult("text:$text")
+    }
+
+    /** 递归提取节点中的全部文本 */
+    private fun extractAllText(node: AccessibilityNodeInfo?): String {
+        if (node == null) return ""
+        val sb = StringBuilder()
+        if (!node.text.isNullOrBlank()) {
+            sb.appendLine(node.text)
+        }
+        for (i in 0 until node.childCount) {
+            sb.append(extractAllText(node.getChild(i)))
+        }
+        return sb.toString()
+    }
+
+    /** 清理缓存目录中的所有截图文件 */
+    fun cleanup() {
+        val dir = cacheDir
+        if (dir.exists()) {
+            dir.listFiles()?.forEach { it.delete() }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/tntlikely/beecount/ShakeDetector.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/beecount/ShakeDetector.kt
@@ -1,0 +1,226 @@
+package com.tntlikely.beecount
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import kotlin.math.sqrt
+
+/**
+ * 摇一摇检测器 — 抗误触算法。
+ *
+ * 核心思路：除了峰值计数，还检查**峰值节奏**，拒绝走路、放包等非有意动作。
+ *
+ * 误触场景分析：
+ * - 走路：幅度 6-10g，步频 ~120步/分 → 峰值间隔 ~500ms，间隔过大
+ * - 放包/拿手机：幅度 15-20g，但只有 1-2 个脉冲，没有持续振荡
+ * - 有意摇动：幅度 10-18g，5-8 个峰值，间隔 100-250ms，持续 0.8-1.5s
+ *
+ * 算法要点：
+ * 1. 阈值 12.0：排除走路等低幅动作
+ * 2. 最少 5 个峰值：排除单次脉冲（放包/磕碰）
+ * 3. 峰值间隔 ≤ 350ms：排除慢节奏运动（走路）
+ * 4. 紧凑窗口 1.2s：只统计密集的摇晃能量
+ * 5. 防抖 3s：避免连续触发
+ */
+class ShakeDetector(
+    private val context: Context,
+    private val onShake: () -> Unit
+) : SensorEventListener {
+
+    private val sensorManager: SensorManager =
+        context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+    companion object {
+        private const val TAG = "ShakeDetector"
+
+        /** Jerk 幅度阈值，超过此值视为峰值候选 */
+        private const val SHAKE_THRESHOLD = 12.0f
+
+        /** 防抖间隔（毫秒），两次摇一摇之间至少间隔 3 秒 */
+        private const val COOLDOWN_MS = 3000L
+
+        /** 峰值统计窗口（毫秒），在此时间内统计峰值数量 */
+        private const val PEAK_WINDOW_MS = 1200L
+
+        /** 触发所需的最小峰值数量 */
+        private const val MIN_PEAKS = 5
+
+        /** 连续峰值最大间隔（毫秒），超过此值认为节奏中断、清空窗口 */
+        private const val MAX_PEAK_INTERVAL_MS = 350L
+
+        /** 高通滤波器系数，越大重力过滤越彻底 */
+        private const val ALPHA = 0.8f
+    }
+
+    // 高通滤波状态
+    private var hpX = 0f
+    private var hpY = 0f
+    private var hpZ = 0f
+    private var lastRawX = 0f
+    private var lastRawY = 0f
+    private var lastRawZ = 0f
+    private var hasInitialValues = false
+
+    // 峰值检测状态
+    private var isAboveThreshold = false
+    private val peakTimes = mutableListOf<Long>()
+    private var lastShakeTime = 0L
+    private var lastLogTime = 0L
+    private var sensorEventCount = 0
+    /** 用于间隔检查的上一个峰值时间 */
+    private var lastPeakTime = 0L
+
+    /** 开始监听加速度传感器 */
+    fun start() {
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        if (sensor == null) {
+            LoggerPlugin.error(TAG, "设备不支持加速度传感器")
+            return
+        }
+        val registered = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            sensorManager.registerListener(
+                this, sensor,
+                SensorManager.SENSOR_DELAY_UI,
+                Handler(Looper.getMainLooper())
+            )
+        } else {
+            sensorManager.registerListener(
+                this, sensor,
+                SensorManager.SENSOR_DELAY_UI
+            )
+        }
+        if (registered) {
+            LoggerPlugin.info(TAG, "加速度传感器监听已注册")
+        } else {
+            LoggerPlugin.error(TAG, "加速度传感器注册失败！")
+        }
+        sensorEventCount = 0
+        lastLogTime = System.currentTimeMillis()
+    }
+
+    fun isRegistered(): Boolean {
+        return sensorEventCount > 0
+    }
+
+    /** 停止监听 */
+    fun stop() {
+        sensorManager.unregisterListener(this)
+        LoggerPlugin.info(TAG, "加速度传感器监听已注销")
+        resetState()
+    }
+
+    private fun resetState() {
+        hasInitialValues = false
+        hpX = 0f
+        hpY = 0f
+        hpZ = 0f
+        lastRawX = 0f
+        lastRawY = 0f
+        lastRawZ = 0f
+        isAboveThreshold = false
+        lastPeakTime = 0L
+        peakTimes.clear()
+    }
+
+    override fun onSensorChanged(event: SensorEvent) {
+        val now = System.currentTimeMillis()
+        sensorEventCount++
+
+        // 节流日志：每 5 秒输出一次传感器事件接收状态
+        if (now - lastLogTime > 5000) {
+            android.util.Log.d(TAG, "📡 传感器事件: count=$sensorEventCount peaks=${peakTimes.size} 距上次日志=${now - lastLogTime}ms")
+            lastLogTime = now
+        }
+
+        // 防抖（冷却期内丢弃所有事件）
+        if (now - lastShakeTime < COOLDOWN_MS) return
+
+        val rawX = event.values[0]
+        val rawY = event.values[1]
+        val rawZ = event.values[2]
+
+        if (!hasInitialValues) {
+            lastRawX = rawX
+            lastRawY = rawY
+            lastRawZ = rawZ
+            hpX = 0f
+            hpY = 0f
+            hpZ = 0f
+            hasInitialValues = true
+            android.util.Log.d(TAG, "📡 传感器初始化完成，开始接收事件")
+            return
+        }
+
+        // 高通滤波器：hp = alpha * (hp + raw - lastRaw)
+        // 去除重力等低频分量，保留摇晃产生的高频分量
+        hpX = ALPHA * (hpX + rawX - lastRawX)
+        hpY = ALPHA * (hpY + rawY - lastRawY)
+        hpZ = ALPHA * (hpZ + rawZ - lastRawZ)
+
+        lastRawX = rawX
+        lastRawY = rawY
+        lastRawZ = rawZ
+
+        // 计算 jerk 幅度（经过高通滤波后的加速度变化量）
+        val magnitude = sqrt(hpX * hpX + hpY * hpY + hpZ * hpZ)
+
+        // 幅度较大时输出调试日志（节流 2 秒）
+        if (magnitude > 5.0f && now - lastLogTime > 2000) {
+            android.util.Log.d(TAG, "📊 magnitude=%.1f  threshold=%.0f  peaks=%d/%d  count=%d".format(
+                magnitude, SHAKE_THRESHOLD, peakTimes.size, MIN_PEAKS, sensorEventCount))
+        }
+
+        // ---- 节奏检查：清空过期峰值 ----
+        // 先清理超出统计窗口的旧峰值
+        val cutoff = now - PEAK_WINDOW_MS
+        peakTimes.removeAll { it < cutoff }
+        // 如果窗口内还有峰值但最后一个太老，说明节奏中断 → 清空重新计数
+        if (peakTimes.isNotEmpty() && now - peakTimes.last() > MAX_PEAK_INTERVAL_MS) {
+            android.util.Log.d(TAG, "🔄 节奏中断（距上峰值 ${now - peakTimes.last()}ms > ${MAX_PEAK_INTERVAL_MS}ms），清空窗口")
+            peakTimes.clear()
+            isAboveThreshold = false
+            lastPeakTime = 0L
+        }
+
+        // ---- 峰值检测 ----
+        if (magnitude > SHAKE_THRESHOLD && !isAboveThreshold) {
+            // 进入阈值 - 记录新峰值
+            isAboveThreshold = true
+
+            // 检查峰值间隔：如果上一次峰值太近（<50ms）则忽略（防止双峰噪声）
+            val intervalOk = if (lastPeakTime == 0L) true else (now - lastPeakTime >= 50L)
+            if (intervalOk) {
+                peakTimes.add(now)
+                lastPeakTime = now
+                android.util.Log.d(TAG, "⚡ 峰值 #${peakTimes.size}: magnitude=%.1f  peaks=%d/%d".format(
+                    magnitude, peakTimes.size, MIN_PEAKS))
+            } else {
+                android.util.Log.v(TAG, "↺ 忽略过近峰值（距上 ${now - lastPeakTime}ms）")
+            }
+        } else if (magnitude <= SHAKE_THRESHOLD && isAboveThreshold) {
+            // 离开阈值 - 峰值结束
+            isAboveThreshold = false
+        }
+
+        // ---- 触发判定 ----
+        if (peakTimes.size >= MIN_PEAKS) {
+            val firstPeak = peakTimes.first()
+            val duration = now - firstPeak
+            LoggerPlugin.info(TAG, "摇一摇触发！峰值=${peakTimes.size} 历时=${duration}ms")
+            lastShakeTime = now
+            peakTimes.clear()
+            isAboveThreshold = false
+            lastPeakTime = 0L
+            onShake()
+        }
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        // 不需要处理
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">蜜蜂记账</string>
     <string name="widget_description">查看今日和本月的收支情况</string>
 
-    <!-- 无障碍服务相关字符串由 flavor 特定的 strings.xml 定义 -->
-    <!-- dev: android/app/src/dev/res/values/strings.xml -->
-    <!-- prod: android/app/src/prod/res/values/strings.xml -->
+    <!-- 无障碍服务字符串 -->
+    <string name="accessibility_service_label">摇一摇自动记账</string>
+    <string name="accessibility_service_description">摇动手机自动识别当前屏幕内容并记账</string>
 </resources>

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagRequestTouchExplorationMode|flagReportViewIds|flagRetrieveInteractiveWindows"
+    android:canTakeScreenshot="true"
+    android:canRetrieveWindowContent="true"
+    android:notificationTimeout="100" />

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'providers/security_providers.dart';
 import 'services/system/reminder_monitor_service.dart';
 import 'providers/credit_card_reminder_providers.dart';
 import 'services/platform/screenshot_monitor_service.dart';
+import 'services/platform/shake_billing_service.dart';
 import 'services/platform/image_share_handler_service.dart';
 import 'services/platform/app_link_service.dart';
 import 'services/system/logger_service.dart';
@@ -115,6 +116,9 @@ Future<void> main() async {
   // 恢复截图自动识别设置（Android专属），传入container
   await _restoreScreenshotMonitor(container);
 
+  // 恢复摇一摇自动记账状态（Android专属）
+  await _restoreShakeBilling(container);
+
   // 初始化图片分享处理服务（Android专属）
   if (Platform.isAndroid) {
     _setupImageShareHandler(container);
@@ -140,11 +144,23 @@ Future<void> main() async {
   // 执行,失败不致命。
   unawaited(_runOrphanFileGcOnce(container));
 
-  runApp(ProviderScope(
-    parent: container,
-    observers: const [_WidgetUpdateObserver()],
-    child: const MainApp(),
-  ));
+  // 全局错误捕获 — 未捕获的 Flutter/Dart 异常
+  FlutterError.onError = (FlutterErrorDetails details) {
+    logger.error('FlutterError', '未捕获的 Flutter 错误', details.exception.toString(), details.stack);
+  };
+
+  runZonedGuarded(
+    () {
+      runApp(ProviderScope(
+        parent: container,
+        observers: const [_WidgetUpdateObserver()],
+        child: const MainApp(),
+      ));
+    },
+    (Object error, StackTrace stack) {
+      logger.error('ZONE', '未捕获的区域错误', error, stack);
+    },
+  );
 }
 
 /// Provider observer to update widget on app start
@@ -256,7 +272,31 @@ Future<void> _restoreScreenshotMonitor(ProviderContainer container) async {
     }
   } catch (e) {
     print('❌ 恢复截图监听失败: $e');
-    // 不抛出异常，避免影响应用启动
+  }
+
+}
+
+/// 恢复摇一摇自动记账状态（仅Android）
+///
+/// 应用崩溃/重启后 Dart 内存状态丢失，从 SharedPreferences 恢复。
+Future<void> _restoreShakeBilling(ProviderContainer container) async {
+  if (!Platform.isAndroid) return;
+
+  try {
+    print('📳 检查并恢复摇一摇自动记账...');
+    final shakeBilling = ShakeBillingService(container);
+    final shakeEnabled = await shakeBilling.isShakeBillingEnabled();
+
+    if (shakeEnabled) {
+      print('✅ 发现用户已启用摇一摇自动记账');
+      print('🔄 正在重新启用摇一摇检测...');
+      await shakeBilling.enableShakeBilling();
+      print('✅ 摇一摇自动记账已成功恢复');
+    } else {
+      print('ℹ️  用户未启用摇一摇自动记账，跳过恢复');
+    }
+  } catch (e) {
+    print('📳 恢复摇一摇自动记账失败: $e');
   }
 }
 

--- a/lib/pages/automation/shake_billing_page.dart
+++ b/lib/pages/automation/shake_billing_page.dart
@@ -1,0 +1,789 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../widgets/ui/primary_header.dart';
+import '../../widgets/ui/toast.dart';
+
+import '../../providers.dart';
+import '../../services/platform/shake_billing_service.dart';
+import '../../l10n/app_localizations.dart';
+
+/// 摇一摇自动记账设置页面
+class ShakeBillingPage extends ConsumerStatefulWidget {
+  const ShakeBillingPage({super.key});
+
+  @override
+  ConsumerState<ShakeBillingPage> createState() => _ShakeBillingPageState();
+}
+
+class _ShakeBillingPageState extends ConsumerState<ShakeBillingPage> with WidgetsBindingObserver {
+  late final ShakeBillingService _shakeBilling;
+  bool _isShakeBillingEnabled = false;
+  bool _isAccessibilityServiceEnabled = false;
+  bool _isLoading = true;
+  bool _isInitialized = false;
+
+  /// 保活综合状态（由 Kotlin 端返回）
+  Map<String, dynamic> _keepAliveStatus = {};
+
+  /// 摇一摇记账结果通知渠道信息
+  Map<String, dynamic> _shakeResultChannelInfo = {};
+
+  /// 通知渠道是否满足横幅弹窗条件
+  bool get _notifChannelOk =>
+      _shakeResultChannelInfo['isEnabled'] == true &&
+      (_shakeResultChannelInfo['importance'] == 'high' ||
+       _shakeResultChannelInfo['importance'] == 'max');
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_isInitialized) {
+      final container = ProviderScope.containerOf(context);
+      _shakeBilling = ShakeBillingService(container);
+      _loadMonitorStatus();
+      _isInitialized = true;
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      _loadMonitorStatus();
+    }
+  }
+
+  Future<void> _loadMonitorStatus() async {
+    final shakeEnabled = await _shakeBilling.isShakeBillingEnabled();
+
+    bool accessibilityEnabled = false;
+    try {
+      accessibilityEnabled = await _shakeBilling.checkAccessibilityServiceEnabled();
+    } catch (e) {
+      print('检查无障碍服务状态失败: $e');
+    }
+
+    Map<String, dynamic> keepAliveStatus = {};
+    try {
+      keepAliveStatus = await _shakeBilling.getKeepAliveStatus();
+    } catch (e) {
+      print('查询保活状态失败: $e');
+    }
+
+    // 查询摇一摇记账结果通知渠道信息
+    Map<String, dynamic> channelInfo = {};
+    try {
+      channelInfo = await _shakeBilling.getNotificationChannelInfo('shake_result');
+      print('📢 通知渠道 shake_result: $channelInfo');
+    } catch (e) {
+      print('查询通知渠道信息失败: $e');
+    }
+
+    setState(() {
+      _isShakeBillingEnabled = shakeEnabled;
+      _isAccessibilityServiceEnabled = accessibilityEnabled;
+      _keepAliveStatus = keepAliveStatus;
+      _shakeResultChannelInfo = channelInfo;
+      _isLoading = false;
+    });
+  }
+
+  Future<void> _toggleShakeBilling(bool value) async {
+    final l10n = AppLocalizations.of(context);
+
+    try {
+      if (value) {
+        await _shakeBilling.enableShakeBilling();
+        setState(() => _isShakeBillingEnabled = true);
+        if (mounted) showToast(context, l10n.enableSuccess);
+
+        final enabled = await _shakeBilling.checkAccessibilityServiceEnabled();
+        setState(() => _isAccessibilityServiceEnabled = enabled);
+
+        _loadMonitorStatus();
+
+        if (!enabled && mounted) {
+          showToast(context, '请前往系统设置 - 无障碍 - 已安装的应用 - 蜜蜂记账，开启摇一摇自动记账服务', duration: const Duration(seconds: 4));
+        }
+      } else {
+        await _shakeBilling.disableShakeBilling();
+        setState(() => _isShakeBillingEnabled = false);
+        _loadMonitorStatus();
+        if (mounted) showToast(context, l10n.disableSuccess);
+      }
+    } catch (e) {
+      if (mounted) {
+        showToast(context, '${l10n.enableFailed}: $e', duration: const Duration(seconds: 3));
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final primaryColor = ref.watch(primaryColorProvider);
+    final l10n = AppLocalizations.of(context);
+
+    return Scaffold(
+      backgroundColor: theme.colorScheme.surface,
+      body: Column(
+        children: [
+          PrimaryHeader(
+            title: '摇一摇自动记账',
+            showBack: true,
+            leadingIcon: Icons.sensors,
+            leadingPlain: true,
+          ),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                // ── 功能介绍 ──
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(Icons.info_outline, color: primaryColor, size: 24),
+                            const SizedBox(width: 8),
+                            Text(
+                              '功能介绍',
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          '摇动手机，通过无障碍服务截取当前屏幕，自动识别账单信息并完成记账。\n\n'
+                              '• 摇动手机即可触发自动记账\n'
+                              '• 所有版本均可用（包括 Google Play 版）\n'
+                              '• 需开启无障碍服务权限',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                            height: 1.5,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+
+                // ── 摇动示例图 ──
+                _ShakeGuideIllustration(),
+
+                const SizedBox(height: 20),
+
+                // ── 摇一摇自动记账开关 ──
+                Padding(
+                  padding: const EdgeInsets.only(left: 4, bottom: 8),
+                  child: Text(
+                    '摇一摇自动记账',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: primaryColor,
+                    ),
+                  ),
+                ),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 48,
+                          height: 48,
+                          decoration: BoxDecoration(
+                            color: primaryColor.withValues(alpha: 0.1),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Icon(Icons.sensors, color: primaryColor, size: 28),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '摇一摇自动记账',
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                _isShakeBillingEnabled
+                                    ? (_isAccessibilityServiceEnabled ? '已开启' : '已开启（无障碍未授权）')
+                                    : '已关闭',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: _isShakeBillingEnabled
+                                      ? primaryColor
+                                      : theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Switch(
+                          value: _isShakeBillingEnabled,
+                          onChanged: _isLoading ? null : _toggleShakeBilling,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // 无障碍服务引导卡片
+                if (_isShakeBillingEnabled && !_isAccessibilityServiceEnabled) ...[
+                  const SizedBox(height: 12),
+                  Card(
+                    color: Colors.orange.withValues(alpha: 0.08),
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Icon(Icons.accessibility_new, color: Colors.orange, size: 24),
+                              const SizedBox(width: 8),
+                              Text(
+                                '需要无障碍服务权限',
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            '启用摇一摇自动记账需要在系统无障碍设置中开启「蜜蜂记账」服务。\n\n'
+                            '操作步骤：\n'
+                            '1. 点击下方按钮打开无障碍设置\n'
+                            '2. 找到「已安装的应用」或「已安装服务」\n'
+                            '3. 点击「蜜蜂记账」\n'
+                            '4. 打开服务开关并确认启用',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+                              height: 1.5,
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          SizedBox(
+                            width: double.infinity,
+                            child: FilledButton.icon(
+                              onPressed: () async {
+                                await _shakeBilling.openAccessibilitySettings();
+                                await Future.delayed(const Duration(seconds: 1));
+                                if (mounted) {
+                                  final enabled = await _shakeBilling.checkAccessibilityServiceEnabled();
+                                  setState(() => _isAccessibilityServiceEnabled = enabled);
+                                }
+                              },
+                              icon: const Icon(Icons.settings),
+                              label: const Text('打开无障碍设置'),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+
+                const SizedBox(height: 24),
+
+                // ── 后台保活状态 ──
+                Padding(
+                  padding: const EdgeInsets.only(left: 4, bottom: 8),
+                  child: Text(
+                    '后台保活',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: primaryColor,
+                    ),
+                  ),
+                ),
+                if (_isShakeBillingEnabled)
+                  _buildKeepAliveStatusCard(context, primaryColor, l10n)
+                else
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Row(
+                        children: [
+                          Container(
+                            width: 48,
+                            height: 48,
+                            decoration: BoxDecoration(
+                              color: Colors.grey.withValues(alpha: 0.1),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Icon(Icons.shield_outlined, color: Colors.grey, size: 28),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  '保活服务已关闭',
+                                  style: theme.textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  '开启摇一摇自动记账后自动启用保活，无需手动操作',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                                    height: 1.4,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildKeepAliveStatusCard(
+    BuildContext context,
+    Color primaryColor,
+    AppLocalizations l10n,
+  ) {
+    final theme = Theme.of(context);
+    final batteryOpt = _keepAliveStatus['isIgnoringBatteryOptimizations'] == true;
+    final accessibilityRunning = _keepAliveStatus['accessibilityServiceRunning'] == true;
+    final keepAliveRunning = _keepAliveStatus['keepAliveServiceRunning'] == true;
+
+    final importance = _shakeResultChannelInfo['importance'] as String? ?? '';
+    final notifChannelDescription = _notifChannelOk
+        ? '渠道重要性 $importance，可弹出横幅通知'
+        : '重要性 $importance，需设为高才能弹出横幅通知';
+
+    final healthItems = <_HealthItem>[
+      _HealthItem(
+        icon: Icons.accessible,
+        label: '无障碍服务',
+        description: '系统级权限，后台常驻不被系统杀死',
+        ok: accessibilityRunning,
+        okText: '运行中',
+        failText: '未运行',
+      ),
+      _HealthItem(
+        icon: Icons.battery_std,
+        label: '电池优化',
+        description: '豁免后系统不会在后台限制应用活动',
+        ok: batteryOpt,
+        okText: '已豁免',
+        failText: '未优化',
+      ),
+      _HealthItem(
+        icon: Icons.shield,
+        label: '保活前台服务',
+        description: '前台通知保活，关闭摇一摇后自动停止',
+        ok: keepAliveRunning,
+        okText: '运行中',
+        failText: '未运行',
+      ),
+      _HealthItem(
+        icon: Icons.notifications_active,
+        label: '记账结果横幅',
+        description: notifChannelDescription,
+        ok: _notifChannelOk,
+        okText: '已开启',
+        failText: '需设置',
+      ),
+    ];
+
+    final okCount = healthItems.where((e) => e.ok).length;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    color: (okCount == healthItems.length ? Colors.green : Colors.orange).withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Icon(
+                    okCount == healthItems.length ? Icons.shield : Icons.shield_outlined,
+                    color: okCount == healthItems.length ? Colors.green : Colors.orange,
+                    size: 28,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '保活健康度 $okCount/${healthItems.length}',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        okCount == healthItems.length
+                            ? '所有保活机制运行正常'
+                            : '部分保活项未就绪，建议优化',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: okCount == healthItems.length ? Colors.green : Colors.orange,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            // Health status list
+                ...healthItems.map((item) => Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Row(
+                    children: [
+                      Icon(item.icon, size: 20, color: item.ok ? Colors.green : Colors.grey),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(item.label, style: theme.textTheme.bodyMedium),
+                            Text(
+                              item.description,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                                fontSize: 11,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: (item.ok ? Colors.green : Colors.grey).withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          item.ok ? item.okText : item.failText,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: item.ok ? Colors.green : Colors.grey,
+                            fontSize: 11,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                )),
+            // 通知横幅设置引导
+            if (!_notifChannelOk) ...[
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () async {
+                    await _shakeBilling.openNotificationChannelSettings('shake_result');
+                    await Future.delayed(const Duration(seconds: 2));
+                    _loadMonitorStatus();
+                  },
+                  icon: const Icon(Icons.notifications, size: 18),
+                  label: const Text('前往通知设置，开启横幅通知'),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.orange,
+                    side: const BorderSide(color: Colors.orange),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 4),
+              Padding(
+                padding: const EdgeInsets.only(left: 4),
+                child: Text(
+                  '部分手机默认关闭横幅通知，需手动开启。请进入「通知」→「摇一摇记账结果」→ 打开「通知横幅/悬浮通知」',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: Colors.orange[700],
+                    fontSize: 11,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+            // Action buttons for non-optimized items
+            if (!batteryOpt) ...[
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () async {
+                    await _shakeBilling.openBatteryOptimizationSettings();
+                  },
+                  icon: const Icon(Icons.battery_std, size: 18),
+                  label: const Text('前往电池优化设置'),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.orange,
+                    side: const BorderSide(color: Colors.orange),
+                  ),
+                ),
+              ),
+            ],
+            if (!accessibilityRunning) ...[
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () async {
+                    await _shakeBilling.openAccessibilitySettings();
+                  },
+                  icon: const Icon(Icons.accessibility_new, size: 18),
+                  label: const Text('前往无障碍设置'),
+                ),
+              ),
+            ],
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: () async {
+                  final opened = await _shakeBilling.openAutoStartSettings();
+                  if (!opened && context.mounted) {
+                    _showAutoStartGuideDialog(context);
+                  }
+                },
+                icon: const Icon(Icons.power_settings_new, size: 18),
+                label: const Text('自启动管理'),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '无法自动检测自启动状态，不同手机路径不同：设置 → 应用管理 → BeeCount → 自启动',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+                fontSize: 10,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.blue.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.info_outline, color: Colors.blue, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '保活前台服务会在通知栏显示一条静默通知，保持应用在后台不被系统清理。开启摇一摇自动记账后自动启用，关闭后自动停止，无需手动操作。',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: Colors.blue[700],
+                        height: 1.4,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 自启动引导弹窗
+Future<void> _showAutoStartGuideDialog(BuildContext context) async {
+  await showDialog(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('开启自启动'),
+      content: const Text(
+        '当前设备不支持自动跳转，请手动操作：\n\n'
+        '1. 打开手机「设置」\n'
+        '2. 进入「应用管理」或「应用设置」\n'
+        '3. 找到「BeeCount」\n'
+        '4. 开启「自启动」或「允许自启动」权限\n\n'
+        '开启后保活服务更稳定，不会被系统后台清理。',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('知道了'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// 摇动手机示例图 — 带动画提示如何摇手机
+class _ShakeGuideIllustration extends StatefulWidget {
+  @override
+  State<_ShakeGuideIllustration> createState() => _ShakeGuideIllustrationState();
+}
+
+class _ShakeGuideIllustrationState extends State<_ShakeGuideIllustration>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<double> _shakeAnim;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    )..repeat(reverse: true);
+    _shakeAnim = Tween<double>(begin: -16.0, end: 16.0).animate(
+      CurvedAnimation(parent: _ctrl, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final primaryColor = theme.colorScheme.primary;
+
+    // 运动轨迹点 — 显示在手机左右两侧的短线
+    Widget _trailDots({required bool left}) {
+      return AnimatedBuilder(
+        animation: _shakeAnim,
+        builder: (_, __) {
+          final progress = (_shakeAnim.value + 16) / 32; // 0→1
+          final opacity = left ? (1 - progress) : progress;
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(3, (i) {
+              final dotOpacity = ((left ? (2 - i) : i) / 2.0 * opacity)
+                  .clamp(0.0, 0.7);
+              return Container(
+                width: 4,
+                height: 4,
+                margin: const EdgeInsets.symmetric(horizontal: 2),
+                decoration: BoxDecoration(
+                  color: primaryColor.withValues(alpha: dotOpacity),
+                  shape: BoxShape.circle,
+                ),
+              );
+            }),
+          );
+        },
+      );
+    }
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: primaryColor.withValues(alpha: 0.15)),
+      ),
+      color: primaryColor.withValues(alpha: 0.04),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // 动画手机 + 轨迹点
+            SizedBox(
+              height: 80,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  // 左侧轨迹点
+                  Positioned(left: 0, child: _trailDots(left: true)),
+                  // 右侧轨迹点
+                  Positioned(right: 0, child: _trailDots(left: false)),
+                  // 手机图标 — 左右平移 + 轻微摆头模拟手腕弧线
+                  AnimatedBuilder(
+                    animation: _shakeAnim,
+                    builder: (_, __) => Transform.translate(
+                      offset: Offset(_shakeAnim.value, 0),
+                      child: Transform.rotate(
+                        angle: _shakeAnim.value * 0.012,
+                        child: Icon(Icons.phone_android,
+                            color: primaryColor, size: 48),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              '握住手机两侧，以手腕为轴快速摇动 5~6 次',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 保活健康项数据模型
+class _HealthItem {
+  final IconData icon;
+  final String label;
+
+  /// 简短说明（如"前台通知保活，关闭摇一摇后自动停止"）
+  final String description;
+
+  final bool ok;
+  final String okText;
+  final String failText;
+
+  _HealthItem({
+    required this.icon,
+    required this.label,
+    required this.description,
+    required this.ok,
+    required this.okText,
+    required this.failText,
+  });
+}

--- a/lib/pages/main/mine_page.dart
+++ b/lib/pages/main/mine_page.dart
@@ -27,7 +27,6 @@ import '../transaction/recurring_transaction_page.dart';
 import '../settings/reminder_settings_page.dart';
 import '../settings/language_settings_page.dart';
 import '../settings/widget_management_page.dart';
-import '../automation/auto_billing_settings_page.dart';
 import '../ai/ai_settings_page.dart';
 import '../cloud/cloud_sync_page.dart';
 import '../cloud/beecount_cloud_sync_page.dart';

--- a/lib/pages/settings/smart_billing_page.dart
+++ b/lib/pages/settings/smart_billing_page.dart
@@ -9,6 +9,7 @@ import '../../providers/smart_billing_providers.dart';
 import '../../providers/theme_providers.dart';
 import '../ai/ai_settings_page.dart';
 import '../automation/auto_billing_settings_page.dart';
+import '../automation/shake_billing_page.dart';
 import 'shortcuts_guide_page.dart';
 import '../../l10n/app_localizations.dart';
 
@@ -259,6 +260,20 @@ class SmartBillingPage extends ConsumerWidget {
                           onTap: () async {
                             await Navigator.of(context).push(
                               MaterialPageRoute(builder: (_) => const AutoBillingSettingsPage()),
+                            );
+                          },
+                        ),
+                        BeeTokens.cardDivider(context),
+                      ],
+                      // 摇一摇自动记账（Android）
+                      if (Platform.isAndroid && !_isGooglePlayBuild) ...[
+                        AppListTile(
+                          leading: Icons.sensors,
+                          title: '摇一摇自动记账',
+                          subtitle: '摇动手机，无障碍截屏并记账',
+                          onTap: () async {
+                            await Navigator.of(context).push(
+                              MaterialPageRoute(builder: (_) => const ShakeBillingPage()),
                             );
                           },
                         ),

--- a/lib/providers/keep_alive_provider.dart
+++ b/lib/providers/keep_alive_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 保活开关（默认关闭）
+final keepAliveProvider = StateProvider<bool>((ref) => false);
+
+/// 保活开关持久化初始化
+final keepAliveInitProvider = FutureProvider<void>((ref) async {
+  final prefs = await SharedPreferences.getInstance();
+  final saved = prefs.getBool('keep_alive_enabled');
+  if (saved != null) {
+    ref.read(keepAliveProvider.notifier).state = saved;
+  }
+  ref.listen<bool>(keepAliveProvider, (prev, next) async {
+    await prefs.setBool('keep_alive_enabled', next);
+  });
+});

--- a/lib/services/automation/auto_billing_service.dart
+++ b/lib/services/automation/auto_billing_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
+import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -21,19 +22,45 @@ import 'auto_billing_config.dart';
 class AutoBillingService {
   static const _ledgerIdKey = 'current_ledger_id';
   static const _processedScreenshotsKey = 'processed_screenshots';
+  static const _shakeBillingControlChannel =
+      MethodChannel('com.tntlikely.beecount/shake_billing_control');
 
   final ProviderContainer _container;
   final FlutterLocalNotificationsPlugin _notificationsPlugin =
       FlutterLocalNotificationsPlugin();
+
+  /// AI 调用超时后尚未收到延迟响应的截图数
+  int _pendingTimeoutCount = 0;
+
+  /// 记录 Dart 关键阶段（闪退后仍可通过日志查看）
+  void _logStage(String stage) {
+    logger.info('DartStage', stage);
+    print('🐛 [DartStage] $stage');
+  }
 
   // 防重复处理
   final Set<String> _processedPaths = {};
   String? _lastProcessedPath;
   int _lastProcessedTime = 0;
 
+  /// 兜底本地化文案（后台恢复期取不到 PlatformDispatcher.locale 时使用）
+  late final AppLocalizations _defaultL10n = lookupAppLocalizations(
+      const Locale('zh', 'CN'));
+
+  /// 安全获取本地化文案。后台 Activity 重建过渡期可能取不到 locale，兜底用默认值。
+  AppLocalizations _safeL10n() {
+    try {
+      return lookupAppLocalizations(PlatformDispatcher.instance.locale);
+    } catch (_) {
+      return _defaultL10n;
+    }
+  }
+
   AutoBillingService(this._container) {
     _initNotifications();
     _loadProcessedScreenshots();
+    // 恢复 Engine 挂起时未能送达的通知
+    flushPendingNotification();
   }
 
   /// 解析当前账本 ID(Provider → SharedPreferences → 数据库默认)。
@@ -110,11 +137,15 @@ class AutoBillingService {
   /// 核心：处理截图并自动记账
   /// [imagePath] 截图文件路径
   /// [showNotification] 是否显示通知（默认true）
+  /// [showProgressNotifications] 是否显示中间进度通知（默认true）。
+  ///   摇一摇路径传 false，只保留最终结果通知横幅。
   /// 返回：交易记录ID，失败返回null
   Future<int?> processScreenshot(
     String imagePath, {
     bool showNotification = true,
+    bool showProgressNotifications = true,
   }) async {
+    _logStage('process_screenshot_start');
     final totalStartTime = DateTime.now().millisecondsSinceEpoch;
     print('📸 [AutoBilling] 开始处理截图: $imagePath');
     logger.info('AutoBilling', '开始处理截图', imagePath);
@@ -139,11 +170,13 @@ class AutoBillingService {
     _lastProcessedPath = imagePath;
     _lastProcessedTime = now;
 
-    try {
-      const notificationId = 1001;
-      // 最终结果(成功/失败)用独立 ID,避免 iOS 把它当成对 1001 的静默更新
-      const resultNotificationId = 1101;
+    const notificationId = 1001;
+    const resultNotificationId = 1101;
 
+    // 超时后仍需等待 AI 延迟响应，故在 try 外保留引用
+    Future<BookkeepingResult>? pendingAiFuture;
+
+    try {
       // 检查文件是否存在
       final file = File(imagePath);
 
@@ -153,9 +186,9 @@ class AutoBillingService {
         logger.info('AutoBilling', '文件尚未就绪，开始等待',
             '路径=$imagePath, 超时=${AutoBillingConfig.fileWaitTimeout}ms');
 
-        if (showNotification) {
+        if (showNotification && showProgressNotifications) {
           final l10n =
-              lookupAppLocalizations(PlatformDispatcher.instance.locale);
+              _safeL10n();
           await _showNotification(
             id: notificationId,
             title: l10n.autoBillingNotifyDetectedTitle,
@@ -181,11 +214,11 @@ class AutoBillingService {
           logger.error('AutoBilling', '截图文件等待超时',
               '路径=$imagePath, 等待时间=${waitTime}ms, 文件存在=${await file.exists()}');
           if (showNotification) {
-            final l10n =
-                lookupAppLocalizations(PlatformDispatcher.instance.locale);
+            final l10n = _safeL10n();
             await _showFinalNotification(
               progressId: notificationId,
-              finalId: resultNotificationId,
+              finalId: 1101,
+              capturePath: imagePath,
               title: l10n.autoBillingNotifyFileUnavailableTitle,
               body: l10n.autoBillingNotifyFileUnavailableBody,
             );
@@ -204,11 +237,11 @@ class AutoBillingService {
           AICapabilityType.vision)) {
         logger.warning('AutoBilling', 'AI vision 未配置,跳过自动记账');
         if (showNotification) {
-          final l10n = lookupAppLocalizations(
-              PlatformDispatcher.instance.locale);
+          final l10n = _safeL10n();
           await _showFinalNotification(
             progressId: notificationId,
-            finalId: resultNotificationId,
+            finalId: 1101,
+            capturePath: imagePath,
             title: l10n.aiNotConfiguredNotificationTitle,
             body: l10n.aiNotConfiguredNotificationBody,
           );
@@ -216,10 +249,10 @@ class AutoBillingService {
         return null;
       }
 
-      // 更新通知：开始识别
-      if (showNotification) {
+      // 更新通知：开始识别（摇一摇路径不显示进度通知）
+      if (showNotification && showProgressNotifications) {
         final l10n =
-            lookupAppLocalizations(PlatformDispatcher.instance.locale);
+            _safeL10n();
         await _showNotification(
           id: notificationId,
           title: l10n.autoBillingNotifyRecognizingScreenshotTitle,
@@ -232,11 +265,11 @@ class AutoBillingService {
       if (ledgerId == null) {
         logger.error('AutoBilling', '无可用账本');
         if (showNotification) {
-          final l10n =
-              lookupAppLocalizations(PlatformDispatcher.instance.locale);
+          final l10n = _safeL10n();
           await _showFinalNotification(
             progressId: notificationId,
-            finalId: resultNotificationId,
+            finalId: 1101,
+            capturePath: imagePath,
             title: l10n.autoBillingNotifyNoLedgerTitle,
             body: l10n.autoBillingNotifyNoLedgerBody,
           );
@@ -245,46 +278,53 @@ class AutoBillingService {
         return null;
       }
 
+      _logStage('ai_vision_start');
       final aiStartTime = DateTime.now().millisecondsSinceEpoch;
       logger.info('AutoBilling', '开始 AI 视觉识别 + 落库');
 
       final autoAddAttachment =
           _container.read(smartBillingAutoAttachmentProvider);
-      final result = await _container.read(aiBookkeeperProvider).fromImage(
+      final autoAddAttachmentFn = autoAddAttachment
+          ? (txId, _) async {
+              try {
+                final attachmentService =
+                    _container.read(attachmentServiceProvider);
+                await attachmentService.saveAttachment(
+                  transactionId: txId,
+                  sourceFile: file,
+                  index: 0,
+                  urgent: true,
+                );
+                _container
+                    .read(attachmentListRefreshProvider.notifier)
+                    .state++;
+              } catch (e, st) {
+                logger.error('AutoBilling', '保存截图附件失败', e, st);
+              }
+            }
+          : null;
+
+      // 分离 AI Future 引用，超时后仍需等待其延迟响应
+      pendingAiFuture = _container.read(aiBookkeeperProvider).fromImage(
         image: file,
         ledgerId: ledgerId,
         billingTypes: const [
           TagSeedService.billingTypeImage,
           TagSeedService.billingTypeAi,
         ],
-        l10n: lookupAppLocalizations(PlatformDispatcher.instance.locale),
+        l10n: _safeL10n(),
         // 多笔截图(罕见,但 AI 可能识别出一张账单页里的多笔)时,每笔都挂
         // 同一张原图,与相册路径行为对齐。
         //
         // 走 urgent 模式:跳过 FlutterImageCompress(platform channel,后台冻
         // 结时会卡)和 _getImageInfo,用 sync File.copy 几十 ms 内完成。
         // 这样 attachment 在 perform() return 前就写完,不依赖用户开 app。
-        onSaved: autoAddAttachment
-            ? (txId, _) async {
-                try {
-                  final attachmentService =
-                      _container.read(attachmentServiceProvider);
-                  await attachmentService.saveAttachment(
-                    transactionId: txId,
-                    sourceFile: file,
-                    index: 0,
-                    urgent: true,
-                  );
-                  _container
-                      .read(attachmentListRefreshProvider.notifier)
-                      .state++;
-                } catch (e, st) {
-                  logger.error('AutoBilling', '保存截图附件失败', e, st);
-                }
-              }
-            : null,
+        onSaved: autoAddAttachmentFn,
       );
 
+      final result = await pendingAiFuture!.timeout(const Duration(seconds: 15));
+
+      _logStage('ai_vision_complete');
       final aiElapsed = DateTime.now().millisecondsSinceEpoch - aiStartTime;
       logger.info('AutoBilling', 'AI 识别 + 落库完成',
           '耗时=${aiElapsed}ms, 成功=${result.savedCount} 笔, 失败=${result.failedCount}');
@@ -294,11 +334,11 @@ class AutoBillingService {
 
       if (!result.success) {
         if (showNotification) {
-          final l10n =
-              lookupAppLocalizations(PlatformDispatcher.instance.locale);
+          final l10n = _safeL10n();
           await _showFinalNotification(
             progressId: notificationId,
             finalId: resultNotificationId,
+            capturePath: imagePath,
             title: l10n.autoBillingNotifyRecognizeFailedTitle,
             body: l10n.autoBillingNotifyRecognizeFailedBody,
           );
@@ -306,15 +346,18 @@ class AutoBillingService {
         return null;
       }
 
+      _logStage('post_processor_start');
       _container.read(statsRefreshProvider.notifier).state++;
       await PostProcessor.runC(_container, ledgerId: ledgerId, tags: true);
+      _logStage('post_processor_done');
 
       if (showNotification) {
-        final l10n =
-            lookupAppLocalizations(PlatformDispatcher.instance.locale);
+        _logStage('show_final_notification');
+        final l10n = _safeL10n();
         await _showFinalNotification(
           progressId: notificationId,
           finalId: resultNotificationId,
+          capturePath: imagePath,
           title: _successTitle(result, l10n),
           body: _successBody(result, l10n),
         );
@@ -322,13 +365,48 @@ class AutoBillingService {
       logger.info('AutoBilling', '自动记账成功',
           'ids=${result.transactionIds}, 总金额=${result.totalAbsAmount}');
       return result.firstTransactionId;
+    } on TimeoutException {
+      _logStage('ai_vision_timeout');
+      logger.warning('AutoBilling', 'AI 识别超时', '等待延迟响应: $imagePath');
+      if (showNotification) {
+        await _showFinalNotification(
+          progressId: notificationId,
+          finalId: resultNotificationId,
+          capturePath: imagePath,
+          title: '蜜蜂记账',
+          body: '⏳ 识别耗时较长，请稍等！',
+        );
+      }
+      _pendingTimeoutCount++;
+      _handleDelayedResponse(
+        imagePath: imagePath,
+        aiFuture: pendingAiFuture!,
+        finalId: resultNotificationId,
+        showNotification: showNotification,
+      );
+      return null;
     } catch (e, stackTrace) {
+      _logStage('process_screenshot_error');
       print('❌ 处理截图失败: $e');
       logger.error('AutoBilling', '处理截图失败', {
         'path': imagePath,
         'error': e.toString(),
         'stage': '未知阶段',
       }, stackTrace);
+      if (showNotification) {
+        final l10n = _safeL10n();
+        try {
+          await _showFinalNotification(
+            progressId: notificationId,
+            finalId: resultNotificationId,
+            capturePath: imagePath,
+            title: l10n.autoBillingNotifyProcessFailedTitle,
+            body: l10n.autoBillingNotifyProcessFailedBody(e.toString()),
+          );
+        } catch (_) {
+          // 通知失败不影响流程
+        }
+      }
       return null;
     } finally {
       final totalElapsed =
@@ -340,10 +418,13 @@ class AutoBillingService {
   /// 核心：直接处理文本并自动记账(快捷指令推荐方式)
   /// [text] 快捷指令传递的识别文本
   /// [showNotification] 是否显示通知（默认true）
+  /// [showProgressNotifications] 是否显示中间进度通知（默认true）。
+  ///   摇一摇路径传 false，只保留最终结果通知横幅。
   /// 返回：交易记录ID，失败返回null
   Future<int?> processText(
     String text, {
     bool showNotification = true,
+    bool showProgressNotifications = true,
   }) async {
     final totalStartTime = DateTime.now().millisecondsSinceEpoch;
     print('📝 [AutoBilling] 开始处理文本: $text');
@@ -351,7 +432,7 @@ class AutoBillingService {
     try {
       const notificationId = 1002;
       const resultNotificationId = 1102;
-      final l10n = lookupAppLocalizations(PlatformDispatcher.instance.locale);
+      final l10n = _safeL10n();
 
       // 兜底:AI text 未配置 → 系统通知,引导用户去配置
       if (!await AIProviderManager.isCapabilityConfigured(
@@ -367,8 +448,8 @@ class AutoBillingService {
         return null;
       }
 
-      // 显示"正在识别"通知
-      if (showNotification) {
+      // 显示"正在识别"通知（摇一摇路径不显示进度通知）
+      if (showNotification && showProgressNotifications) {
         await _showNotification(
           id: notificationId,
           title: l10n.autoBillingNotifyRecognizingTextTitle,
@@ -428,7 +509,7 @@ class AutoBillingService {
       logger.error('AutoBilling', '文本处理失败', e);
       if (showNotification) {
         final l10n =
-            lookupAppLocalizations(PlatformDispatcher.instance.locale);
+            _safeL10n();
         await _showNotification(
           id: 1002,
           title: l10n.autoBillingNotifyProcessFailedTitle,
@@ -464,6 +545,85 @@ class AutoBillingService {
         : l10n.autoBillingNotifySuccessSingleBodyDefault;
   }
 
+  /// 取消摇一摇进度横幅（Android native 已发，Flutter 负责在结果到来时移除）
+  Future<void> cancelShakeProgressBanner() async {
+    await _notificationsPlugin.cancel(9101);
+  }
+
+  /// 处理 AI 超时后的延迟响应。
+  ///
+  /// [aiFuture] 是 [fromImage] 的原生 Future，即便外层 .timeout() 已触发，
+  /// 它仍在后台运行。等 AI 最终响应后发送结果通知。
+  ///
+  /// 如果有多个待处理的延迟响应，通知正文末尾追加「（剩余 N 张待识别）」。
+  void _handleDelayedResponse({
+    required String imagePath,
+    required Future<BookkeepingResult> aiFuture,
+    required int finalId,
+    required bool showNotification,
+  }) {
+    // 安全网：60 秒后如果 AI 仍无响应（Dio 20s 超时意外失效的极端情况），
+    // 强制完成并通知用户，避免「⏳ 识别耗时较长」永久挂起
+    aiFuture
+        .timeout(const Duration(seconds: 60))
+        .then((result) async {
+      _pendingTimeoutCount--;
+      await _markAsProcessed(imagePath);
+
+      if (showNotification) {
+        final l10n = _safeL10n();
+        final suffix = _pendingTimeoutCount > 0
+            ? '（剩余 $_pendingTimeoutCount 张待识别）'
+            : '';
+
+        if (result.success) {
+          // 刷新统计 & 触发同步（fromImage 已落库，PostProcessor 需手动跑）
+          try {
+            final ledgerId = await _resolveLedgerId();
+            if (ledgerId != null) {
+              // ignore: invalid_use_of_visible_for_testing_member
+              _container.read(statsRefreshProvider.notifier).state++;
+              await PostProcessor.runC(_container,
+                  ledgerId: ledgerId, tags: true);
+            }
+          } catch (_) {}
+        }
+
+        await _showFinalNotification(
+          progressId: finalId,
+          finalId: finalId,
+          capturePath: imagePath,
+          title: result.success
+              ? _successTitle(result, l10n)
+              : l10n.autoBillingNotifyRecognizeFailedTitle,
+          body: (result.success
+                      ? _successBody(result, l10n)
+                      : l10n.autoBillingNotifyRecognizeFailedBody) +
+              suffix,
+        );
+      }
+
+      if (result.success) {
+        logger.info('AutoBilling', '延迟响应：自动记账成功',
+            'ids=${result.transactionIds}');
+      }
+    }).catchError((e, st) {
+      _pendingTimeoutCount--;
+      logger.error('AutoBilling', '延迟响应处理失败', '$e', st);
+      // 连兜底也失败了 → 不能再让「⏳ 识别耗时较长」挂在那
+      if (showNotification) {
+        final l10n = _safeL10n();
+        _showFinalNotification(
+          progressId: finalId,
+          finalId: finalId,
+          capturePath: imagePath,
+          title: l10n.autoBillingNotifyProcessFailedTitle,
+          body: l10n.autoBillingNotifyProcessFailedBody('识别超时，请稍后重试'),
+        );
+      }
+    });
+  }
+
   /// 显示通知。
   ///
   /// 通知失败**绝不向外抛**:通知只是进度提示,记账主流程不能因它中断。
@@ -481,6 +641,8 @@ class AutoBillingService {
       channelDescription: '截图自动识别通知',
       importance: Importance.high,
       priority: Priority.high,
+      enableVibration: true,
+      playSound: true,
     );
 
     const iosDetails = DarwinNotificationDetails();
@@ -498,24 +660,96 @@ class AutoBillingService {
     }
   }
 
-  /// 显示「最终结果」通知。
+  /// 显示「最终结果」通知（横幅弹出）。
   ///
-  /// iOS 上,**用同一 ID 重复 `show()` 只会静默更新通知中心条目,不会重新弹
-  /// banner**。所以「正在识别 → 成功/失败」如果共用 ID,用户只能看到第一条
-  /// banner,直到进通知中心才看到结果。
-  ///
-  /// 这个方法用**新 ID** 发结果通知,iOS 把它当作新通知重新弹 banner。
-  /// 不 cancel 旧的「正在识别」—— 实测在 AppIntent background-launch 状态下
-  /// cancel + show 紧挨着的组合 iOS 会把它当成一次「替换」处理,banner 不弹;
-  /// 留着旧的反而能保证新的作为独立通知正常弹出(旧的在结果通知出现后用户可自
-  /// 行清理或自然过期)。
+  /// [capturePath] 为截屏文件路径。传入后优先通过原生 MethodChannel 发送，
+  /// 同时取消原生侧对应截图的 15s 超时定时器。不传时走原有降级链路。
   Future<void> _showFinalNotification({
     required int progressId,
     required int finalId,
     required String title,
     required String body,
+    String? capturePath,
   }) async {
-    await _showNotification(id: finalId, title: title, body: body);
+    // 优先走 captureResult（取消原生超时 + 原生通知）
+    if (capturePath != null) {
+      try {
+        await _shakeBillingControlChannel.invokeMethod('captureResult', {
+          'path': capturePath,
+          'title': title,
+          'body': body,
+        });
+        logger.info('AutoBilling', '原生结果通知已发送', 'title=$title');
+        return;
+      } catch (e) {
+        logger.debug('AutoBilling', '原生通知发送失败，降级到 Flutter 通知: $e');
+      }
+    }
+
+    // 降级：Flutter 本地通知
+    try {
+      const androidDetails = AndroidNotificationDetails(
+        'shake_result',
+        '摇一摇记账结果',
+        channelDescription: '摇一摇自动记账最终结果通知',
+        importance: Importance.high,
+        priority: Priority.high,
+        enableVibration: true,
+        playSound: true,
+      );
+
+      const iosDetails = DarwinNotificationDetails();
+
+      const details = NotificationDetails(
+        android: androidDetails,
+        iOS: iosDetails,
+      );
+
+      await _notificationsPlugin.show(finalId, title, body, details);
+      return;
+    } catch (e) {
+      logger.warning('AutoBilling', 'Flutter 通知也失败，保存待发送通知', '$e');
+    }
+
+    // 兜底：Engine 被 ROM 挂起时两种方式都失败，
+    // 保存到 SharedPreferences，下次启动时恢复展示
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('pending_notification_title', title);
+      await prefs.setString('pending_notification_body', body);
+      logger.info('AutoBilling', '待发送通知已保存到 SharedPreferences');
+    } catch (e) {
+      logger.error('AutoBilling', '保存待发送通知失败', e);
+    }
+  }
+
+  /// 检查并显示待发送的通知（应用启动时调用）
+  Future<void> flushPendingNotification() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final title = prefs.getString('pending_notification_title');
+      final body = prefs.getString('pending_notification_body');
+      if (title == null || body == null) return;
+
+      await prefs.remove('pending_notification_title');
+      await prefs.remove('pending_notification_body');
+      logger.info('AutoBilling', '恢复待发送通知: $title');
+
+      await _notificationsPlugin.show(
+        9102, title, body, const NotificationDetails(
+          android: AndroidNotificationDetails(
+            'shake_result',
+            '摇一摇记账结果',
+            channelDescription: '摇一摇自动记账最终结果通知',
+            importance: Importance.high,
+            priority: Priority.high,
+          ),
+          iOS: DarwinNotificationDetails(),
+        ),
+      );
+    } catch (e) {
+      logger.error('AutoBilling', '恢复待发送通知失败', e);
+    }
   }
 
   /// 释放资源(AI 服务无 native handle,不需要 dispose,保留方法以备后续添加)

--- a/lib/services/platform/shake_billing_service.dart
+++ b/lib/services/platform/shake_billing_service.dart
@@ -1,0 +1,360 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../automation/auto_billing_service.dart';
+
+/// 摇一摇自动记账服务（仅Android）
+///
+/// 管理无障碍截屏的接收、队列处理、保活服务联动，以及与系统无障碍设置的交互。
+/// 与 [ScreenshotMonitorService] 职责分离 — 截图监听走 ContentObserver，
+/// 摇一摇走 AccessibilityService，互不干扰。
+class ShakeBillingService {
+  static const _accessibilityChannel = MethodChannel('com.tntlikely.beecount/accessibility_billing');
+  static const _keepAliveChannel = MethodChannel('com.tntlikely.beecount/keep_alive');
+  static const _shakeBillingControlChannel = MethodChannel('com.tntlikely.beecount/shake_billing_control');
+  // 共享截图通道，用于无障碍设置查询（Android 端注册在 MainActivity）
+  static const _screenshotChannel = MethodChannel('com.tntlikely.beecount/screenshot');
+
+  static const _shakeBillingEnabledKey = 'shake_billing_enabled';
+  static const _keepAliveEnabledKey = 'keep_alive_enabled';
+
+  final ProviderContainer _container;
+  late final AutoBillingService _autoBillingService;
+
+  /// 保活服务是否已启用（内存状态，与摇一摇开关联动）
+  bool _isKeepAliveEnabled = false;
+
+  /// 摇一摇自动记账是否已启用（内存状态，避免后台异步事件中的竞态条件）
+  bool _isShakeBillingEnabled = false;
+
+  // ── 顺序处理队列（避免后台攒的多个截图同时触发 AI 造成通知轰炸） ──
+  final _captureQueue = <String>[];
+  bool _isProcessingCapture = false;
+
+  // 单例模式
+  static ShakeBillingService? _instance;
+
+  factory ShakeBillingService(ProviderContainer container) {
+    _instance ??= ShakeBillingService._internal(container);
+    return _instance!;
+  }
+
+  ShakeBillingService._internal(this._container) {
+    _autoBillingService = AutoBillingService(_container);
+    _setupMethodCallHandler();
+  }
+
+  /// 设置方法调用处理器
+  void _setupMethodCallHandler() {
+    print('📳 [ShakeBilling] 初始化方法调用处理器');
+
+    // 摇一摇无障碍截屏监听通道
+    _accessibilityChannel.setMethodCallHandler((call) async {
+      print('📳 [ShakeBilling] 收到无障碍方法调用: ${call.method}');
+      if (call.method == 'onAccessibilityCapture') {
+        final data = call.arguments as String;
+        print('📳 [ShakeBilling] 无障碍截屏数据: $data');
+        await _handleAccessibilityCapture(data);
+      } else if (call.method == 'onAccessibilityServiceInterrupted') {
+        print('⚠️ [ShakeBilling] 无障碍服务被系统中断');
+        // Flutter 侧无需特殊处理，UI 会在 App resume 时刷新状态
+      }
+    });
+  }
+
+  // ── 摇一摇自动记账开关 ──
+
+  /// 摇一摇自动记账是否已启用
+  ///
+  /// 注意：摇一摇使用无障碍截图存私有目录，不依赖相册权限，
+  /// 因此不受 Google Play 构建限制，与截图监听独立判断。
+  Future<bool> isShakeBillingEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_shakeBillingEnabledKey) ?? false;
+  }
+
+  /// 启用摇一摇自动记账（同时自动开启保活服务）
+  Future<void> enableShakeBilling() async {
+    if (!Platform.isAndroid) {
+      throw UnsupportedError('仅支持 Android 平台');
+    }
+
+    // 先设置内存状态（同步操作，无竞态风险）
+    _isShakeBillingEnabled = true;
+
+    try {
+      await _shakeBillingControlChannel.invokeMethod('enableShake');
+    } catch (e) {
+      print('⚠️ [ShakeBilling] 通知 Android 启用摇一摇失败: $e');
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_shakeBillingEnabledKey, true);
+    print('✅ [ShakeBilling] 摇一摇自动记账已启用');
+
+    // 同步启用保活服务（五层保活机制）
+    try {
+      await enableKeepAlive();
+      _isKeepAliveEnabled = true;
+    } catch (e) {
+      print('⚠️ [ShakeBilling] 启用保活服务失败（不影响摇一摇）: $e');
+    }
+  }
+
+  /// 禁用摇一摇自动记账（同步关闭保活服务）
+  Future<void> disableShakeBilling() async {
+    // 先设置内存状态（同步操作，阻止后续无障碍截屏入队）
+    _isShakeBillingEnabled = false;
+
+    try {
+      await _shakeBillingControlChannel.invokeMethod('disableShake');
+    } catch (e) {
+      print('⚠️ [ShakeBilling] 通知 Android 禁用摇一摇失败: $e');
+    }
+
+    // 清空待处理的截屏队列，取消正在进行的处理
+    _captureQueue.clear();
+    _isProcessingCapture = false;
+    print('🧹 [ShakeBilling] 已清空截屏处理队列');
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_shakeBillingEnabledKey, false);
+    print('✅ [ShakeBilling] 摇一摇自动记账已禁用');
+
+    try {
+      await disableKeepAlive();
+      _isKeepAliveEnabled = false;
+    } catch (e) {
+      print('⚠️ [ShakeBilling] 关闭保活服务失败: $e');
+    }
+  }
+
+  /// 处理无障碍截屏数据（摇一摇路径）
+  ///
+  /// [data] 有两种格式：
+  /// - 文件路径（API 31+ takeScreenshot） → 走 processScreenshot
+  /// - "text:" 前缀（API 30- 节点文本）  → 走 processText
+  ///
+  /// 数据先入顺序队列，由 [_processCaptureQueue] 逐个处理，间隔 2 秒，
+  /// 防止 App 切后台期间攒的多个截图同时触发 AI 造成通知轰炸。
+  Future<void> _handleAccessibilityCapture(String data) async {
+    // 内存状态检查 — Engine 重启后状态会丢失，回查持久化配置恢复
+    if (!_isShakeBillingEnabled) {
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        _isShakeBillingEnabled = prefs.getBool(_shakeBillingEnabledKey) ?? false;
+      } catch (_) {}
+      if (!_isShakeBillingEnabled) {
+        print('⏭️ [ShakeBilling] 摇一摇已禁用，忽略无障碍截屏');
+        _logStage('shake_disabled_ignore');
+        return;
+      }
+      print('♻️ [ShakeBilling] 从持久化配置恢复摇一摇启用状态');
+    }
+
+    _captureQueue.add(data);
+    if (!_isProcessingCapture) {
+      _isProcessingCapture = true;
+      await _processCaptureQueue();
+    }
+  }
+
+  /// 记录 Dart 关键阶段到原生 Logcat（闪退后仍可通过日志查看）
+  void _logStage(String stage) {
+    print('🐛 [DartStage] $stage');
+    try {
+      _shakeBillingControlChannel.invokeMethod('logStage', {'stage': stage});
+    } catch (_) {}
+  }
+
+  /// 顺序消费 [_captureQueue]，每次处理完一个等待 2 秒再处理下一个。
+  Future<void> _processCaptureQueue() async {
+    _logStage('capture_queue_start');
+    while (_captureQueue.isNotEmpty) {
+      _logStage('capture_queue_process_item');
+      final data = _captureQueue.removeAt(0);
+      try {
+        if (data.startsWith('text:')) {
+          _logStage('process_text');
+          final text = data.substring(5);
+          if (text.trim().isEmpty) {
+            continue;
+          }
+          await _autoBillingService.processText(text, showProgressNotifications: false);
+        } else {
+          _logStage('process_screenshot');
+          await _autoBillingService.processScreenshot(data, showProgressNotifications: false);
+          // 清理私有缓存文件（无障碍截图存在 cacheDir，无存储权限限制）
+          try {
+            final file = File(data);
+            if (await file.exists()) {
+              await file.delete();
+            }
+          } catch (_) {}
+        }
+        _logStage('cancel_progress_notification');
+        // AI 出结果了，关闭之前 Kotlin 发的进度通知
+        try {
+          await _keepAliveChannel.invokeMethod('cancelProgressNotification');
+        } catch (_) {}
+        _logStage('queue_delay');
+        // 每个结果间隔 2 秒，避免 AI 调用和通知同时弹出
+        await Future.delayed(const Duration(seconds: 2));
+      } catch (e) {
+        _logStage('capture_queue_error');
+        print('❌ [ShakeBilling] 处理截屏失败: $e');
+        // 即使出错也关闭进度通知
+        try {
+          await _keepAliveChannel.invokeMethod('cancelProgressNotification');
+        } catch (_) {}
+      }
+    }
+    _logStage('capture_queue_done');
+    _isProcessingCapture = false;
+  }
+
+  // ── 后台保活开关 ──
+
+  /// 保活是否已启用
+  Future<bool> isKeepAliveEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_keepAliveEnabledKey) ?? false;
+  }
+
+  /// 启用保活（启动前台保活服务 + 持久化状态）
+  Future<void> enableKeepAlive() async {
+    if (!Platform.isAndroid) {
+      throw UnsupportedError('仅支持 Android 平台');
+    }
+    try {
+      await _keepAliveChannel.invokeMethod('startKeepAlive');
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keepAliveEnabledKey, true);
+      print('✅ [ShakeBilling] 保活服务已启用');
+    } catch (e) {
+      print('❌ [ShakeBilling] 启用保活服务失败: $e');
+      rethrow;
+    }
+  }
+
+  /// 禁用保活（停止前台保活服务 + 持久化状态）
+  Future<void> disableKeepAlive() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _keepAliveChannel.invokeMethod('stopKeepAlive');
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keepAliveEnabledKey, false);
+      print('✅ [ShakeBilling] 保活服务已禁用');
+    } catch (e) {
+      print('❌ [ShakeBilling] 禁用保活服务失败: $e');
+      rethrow;
+    }
+  }
+
+  /// 保活前台服务是否在运行中
+  Future<bool> isKeepAliveRunning() async {
+    try {
+      final result = await _keepAliveChannel.invokeMethod('isKeepAliveRunning');
+      return result == true;
+    } catch (e) {
+      print('❌ [ShakeBilling] 检查保活服务状态失败: $e');
+      return false;
+    }
+  }
+
+  /// 是否已忽略电池优化
+  Future<bool> isIgnoringBatteryOptimizations() async {
+    try {
+      final result = await _keepAliveChannel.invokeMethod('isIgnoringBatteryOptimizations');
+      return result == true;
+    } catch (e) {
+      print('❌ [ShakeBilling] 检查电池优化状态失败: $e');
+      return false;
+    }
+  }
+
+  /// 打开系统电池优化设置页面
+  Future<void> openBatteryOptimizationSettings() async {
+    try {
+      await _keepAliveChannel.invokeMethod('openBatteryOptimizationSettings');
+    } catch (e) {
+      print('❌ [ShakeBilling] 打开电池优化设置失败: $e');
+    }
+  }
+
+  /// 打开自启动管理页面（各 ROM 适配）
+  Future<bool> openAutoStartSettings() async {
+    try {
+      final result = await _keepAliveChannel.invokeMethod('openAutoStartSettings');
+      return result == true;
+    } catch (e) {
+      print('❌ [ShakeBilling] 打开自启动设置失败: $e');
+      return false;
+    }
+  }
+
+  /// 查询保活综合状态
+  Future<Map<String, dynamic>> getKeepAliveStatus() async {
+    try {
+      final result = await _keepAliveChannel.invokeMethod('getKeepAliveStatus');
+      if (result is Map) {
+        return Map<String, dynamic>.from(result);
+      }
+    } catch (e) {
+      print('❌ [ShakeBilling] 查询保活状态失败: $e');
+    }
+    return {};
+  }
+
+  // ── 无障碍服务查询（与截图服务共用系统通道） ──
+
+  /// 检查无障碍服务是否已启用
+  Future<bool> checkAccessibilityServiceEnabled() async {
+    try {
+      final result = await _screenshotChannel.invokeMethod('isAccessibilityServiceEnabled');
+      return result == true;
+    } catch (e) {
+      print('📳 [ShakeBilling] 检查无障碍服务状态失败: $e');
+      return false;
+    }
+  }
+
+  /// 打开系统无障碍设置页面
+  Future<void> openAccessibilitySettings() async {
+    try {
+      await _screenshotChannel.invokeMethod('openAccessibilitySettings');
+    } catch (e) {
+      print('📳 [ShakeBilling] 打开无障碍设置失败: $e');
+    }
+  }
+
+  // ── 通知渠道查询 ──
+
+  /// 获取指定通知渠道的详细信息（用于判断横幅弹窗条件等）
+  Future<Map<String, dynamic>> getNotificationChannelInfo(String channelId) async {
+    try {
+      final result = await _keepAliveChannel.invokeMethod('getNotificationChannelInfo', {
+        'channelId': channelId,
+      });
+      if (result is Map) {
+        return Map<String, dynamic>.from(result);
+      }
+    } catch (e) {
+      print('📢 [ShakeBilling] 查询通知渠道信息失败: $e');
+    }
+    return {};
+  }
+
+  /// 打开指定通知渠道的系统设置页面
+  Future<void> openNotificationChannelSettings(String channelId) async {
+    try {
+      await _keepAliveChannel.invokeMethod('openNotificationChannelSettings', {
+        'channelId': channelId,
+      });
+    } catch (e) {
+      print('📢 [ShakeBilling] 打开通知渠道设置失败: $e');
+    }
+  }
+}


### PR DESCRIPTION
## 变更类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 代码重构
- [ ] 性能优化
- [ ] 其他

## 变更说明

当前安卓端缺少一种更无感或更自动化的记账方式。现有方案需手动截屏（电源键+音量键）触发相册监听，操作路径长且截图残留系统相册难以清理。某些品牌ROM甚至需要截图后马上切入app，app才能识别到新截图再触发流程，极大影响用户体验。Android 缺少 iOS Shortcuts + Back Tap 这类系统级快捷记账能力，因此借助 AccessibilityService + 加速度传感器自建一条不依赖相册的独立通路。

**本功能优势**：
- **任意界面触发**：摇一摇即可自动截图记账，不受 App 页面层级限制，任何界面均可触发
- **无需前台运行**：功能开启后，无需 App 在前台也可正常触发，不打断当前操作
- **不留痕迹**：截图存 App 私有目录，记账完毕自动删除，不占用相册空间，无需存储权限
- **双路径覆盖**：API 31+ 走系统截图 API → 视觉 AI；API 30- 降级为节点文本提取 → 文字 AI
- **抗误触**：ShakeDetector v2 基于加速度 jerk + 峰值节律分析，日常携带不误触
- **稳定保活**：五层保活体系（前台服务 + AlarmManager + JobScheduler + WakeLock + 独立 Engine）保障后台稳定运行，开机自启无需每次手动开启

**实现内容**：
- Android 原生层新增 BillingAccessibilityService（无障碍服务）、ShakeDetector v2（加速度检测）、ScreenshotController（三级降级截屏）、AccessibilityBridge（Engine 共享单例）、KeepAliveService / KeepAliveJobService / BootReceiver（五层保活）
- Flutter 层 ScreenshotMonitorService 增加无障碍监听与顺序处理队列；AutoBillingService 重构至 smart_billing/ 目录，统一摇一摇/截屏/iOS 三个入口；新增摇一摇设置页与保活状态管理；启动时自动恢复截图、摇一摇、保活状态；全局异常写入崩溃日志
- 删除旧 automation/ 目录，迁移至 smart_billing/

> **说明①**：AI 智能识别记账（截图 → OCR → 语义解析 → 自动填单）依赖已有 AutoBillingService 及 AI Kit 管道实现，非本次 PR 新增。本期聚焦打通 Android 侧「摇一摇 → 截屏 → 投递」链路与服务稳定性，识别侧仅做适配重构，无算法改动。
>
> **说明②**：「自动检测支付页」未在本期实现。原因：支付页检测需持续监听前台页面变化，且支付宝/微信等页面在不同版本间布局波动频繁，包名白名单 + 关键词匹配误触率高、维护成本大，且不同APP需做不同适配。本次实现的摇一摇自动记账功能可在任意界面触发，后续AI识别流程会先检查是否有账单，再识别具体的账单。


## 相关 Issue

无对应 issue。

## 测试情况

- [x] 已在 Android 上测试
- [ ] 已在 iOS 上测试
- [ ] 添加了单元测试
- [ ] 添加了集成测试

## 截图（如适用）

![Uploading Screenshot_20260609_155600_com_tntlikely_beecount_dev_MainActivity.jpg…]()

## 检查清单

- [x] 代码遵循项目规范
- [x] 已运行 `dart format` 格式化代码
- [x] 已运行 `flutter analyze` 无警告
- [x] 已更新相关文档（设计文档更新至 v2.0）
- [x] 提交信息符合规范