### PR TITLE
fix: 通知发送失败不再中断自动记账流程(iOS27 未授权场景)

### DIFF
--- a/lib/services/automation/auto_billing_service.dart
+++ b/lib/services/automation/auto_billing_service.dart
@@ -64,7 +64,12 @@ class AutoBillingService {
       iOS: iosSettings,
     );
 
-    await _notificationsPlugin.initialize(initSettings);
+    // 同 _showNotification:通知子系统任何异常都不允许影响记账主流程
+    try {
+      await _notificationsPlugin.initialize(initSettings);
+    } catch (e) {
+      logger.warning('AutoBilling', '通知初始化失败(仅影响进度通知,不影响记账): $e');
+    }
   }
 
   /// 加载已处理的截图列表
@@ -459,7 +464,12 @@ class AutoBillingService {
         : l10n.autoBillingNotifySuccessSingleBodyDefault;
   }
 
-  /// 显示通知
+  /// 显示通知。
+  ///
+  /// 通知失败**绝不向外抛**:通知只是进度提示,记账主流程不能因它中断。
+  /// iOS 27 起对未授权通知的应用调 show() 会抛 PlatformException(Error 2003,
+  /// "Source is not authorized"),而 iOS ≤26 同场景是静默不弹 —— 不隔离的话
+  /// 截图还没进 AI 识别就在"开始识别"通知处整链失败(#322)。
   Future<void> _showNotification({
     required int id,
     required String title,
@@ -480,7 +490,12 @@ class AutoBillingService {
       iOS: iosDetails,
     );
 
-    await _notificationsPlugin.show(id, title, body, details);
+    try {
+      await _notificationsPlugin.show(id, title, body, details);
+    } catch (e) {
+      logger.warning('AutoBilling',
+          '通知发送失败(未授权通知时属预期,不中断记账流程): $e');
+    }
   }
 
   /// 显示「最终结果」通知。


### PR DESCRIPTION
Closes #322

## 根因

`AutoBillingService._showNotification` 直接 `await _notificationsPlugin.show(...)` 无异常隔离,且 `processScreenshot` 在 AI 识别**之前**就发"开始识别"进度通知。iOS 27 起,对未授权通知的应用调用 `show()` 会抛 `PlatformException(Error 2003, "Source is not authorized")`(iOS ≤26 同场景是静默不弹)——异常一路冒泡,截图还没进识别整条链路就以"处理截图失败"中断,表现为快捷指令"灵动岛进度条走完后毫无反应"。与 issue 日志堆栈完全吻合,也解释了评论中"给了通知权限就恢复"的现象。

## 修复

确立不变量:**通知子系统的任何异常不得中断记账主流程**(通知只是进度提示)。

- `_showNotification`:`show()` 包 try/catch + `logger.warning`,失败仅记日志。该方法是全部 5 个进度/结果通知调用点与 `_showFinalNotification` 的唯一收敛处,一处隔离全覆盖
- `_initNotifications`:`initialize()` 同样隔离(同一类入口,防御一致)

未授权用户的行为变化:自动记账**正常完成**,仅看不到进度/结果通知(与 iOS ≤26 未授权时的体验一致)。

## 验证

- `flutter analyze`:857,与基线一致,无新增
- `flutter test test/services/ test/utils/`:除一条**与本 PR 无关的既有失败**外全过——`bill_creation_service_test` 的"账户匹配 AI 账户名完全相等"用例报 `DuplicateNameException: account "支付宝" already exists`,已在合并前的 main(e46dd07)上单跑复现确认为更早引入的既有问题,将另行跟进
- 真机回归建议:iOS27 + 未授权通知 → 快捷指令截屏 → 应正常记账入库;授权后 → 进度/结果通知恢复

## 建议跟进(本 PR 外)

- 文档/FAQ 补一条:iOS 27 起需授权通知才能看到自动记账进度提示