### PR TITLE
feat(ai): 优化 AI 识别 prompt 非账单过滤与智谱 API 超时配置

### DIFF
--- a/lib/ai/core/ai_extraction_engine.dart
+++ b/lib/ai/core/ai_extraction_engine.dart
@@ -14,16 +14,24 @@ import 'prompt_builder.dart';
 /// Riverpod / UI,可以独立单测。
 abstract class AiExtractionEngine {
   /// 从文本提取账单信息。空 list 表示失败或无有效账单。
+  ///
+  /// [billGuard] 前置过滤段，截图/自动路径传入 [PromptBuilder.billGuardForImage]，
+  /// 聊天等主动输入传空字符串。
   Future<List<BillInfo>> extractFromText(
     String text,
-    AiExtractionContext context,
-  );
+    AiExtractionContext context, {
+    String billGuard = '',
+  });
 
   /// 从图片提取账单信息。空 list 表示失败或无有效账单。
+  ///
+  /// [billGuard] 前置过滤段，截图/自动路径传入 [PromptBuilder.billGuardForImage]，
+  /// 手动选图等主动输入传空字符串。
   Future<List<BillInfo>> extractFromImage(
     File image,
-    AiExtractionContext context,
-  );
+    AiExtractionContext context, {
+    String billGuard = '',
+  });
 
   /// 从音频提取账单信息(语音转文字 → 文本提取)。
   Future<AudioExtractionResult> extractFromAudio(
@@ -62,8 +70,9 @@ class DefaultAiExtractionEngine implements AiExtractionEngine {
   @override
   Future<List<BillInfo>> extractFromText(
     String text,
-    AiExtractionContext context,
-  ) async {
+    AiExtractionContext context, {
+    String billGuard = '',
+  }) async {
     if (text.trim().isEmpty) {
       logger.warning(_tag, '输入文本为空');
       return const [];
@@ -72,6 +81,7 @@ class DefaultAiExtractionEngine implements AiExtractionEngine {
       final prompt = _promptBuilder.build(
         context: context,
         inputSource: '从以下支付账单文本中',
+        billGuard: billGuard,
         ocrText: text,
       );
       logger.debug(_tag, '文本 prompt 长度: ${prompt.length}');
@@ -95,8 +105,9 @@ class DefaultAiExtractionEngine implements AiExtractionEngine {
   @override
   Future<List<BillInfo>> extractFromImage(
     File image,
-    AiExtractionContext context,
-  ) async {
+    AiExtractionContext context, {
+    String billGuard = '',
+  }) async {
     if (!await image.exists()) {
       logger.warning(_tag, '图片文件不存在');
       return const [];
@@ -105,6 +116,7 @@ class DefaultAiExtractionEngine implements AiExtractionEngine {
       final prompt = _promptBuilder.build(
         context: context,
         inputSource: '分析支付账单截图，从中',
+        billGuard: billGuard,
       );
       logger.debug(_tag, '图片 prompt 长度: ${prompt.length}');
       logger.debug(_tag, '完整 prompt:\n$prompt');

--- a/lib/ai/core/prompt_builder.dart
+++ b/lib/ai/core/prompt_builder.dart
@@ -8,9 +8,20 @@ import 'ai_extraction_context.dart';
 class PromptBuilder {
   const PromptBuilder();
 
-  /// 默认模板。强制 JSON 数组 + 完整字段说明 + 多笔示例。
+  /// 默认模板。先判断是否为账单，再强制 JSON 数组 + 完整字段说明 + 多笔示例。
   static const String defaultTemplate =
-      '''{{INPUT_SOURCE}}提取记账信息，返回JSON数组。
+      '''严格判断以下内容是否为支付账单、收据或交易凭证。
+
+以下情况不属于账单，必须返回空数组 []：
+- 电脑/手机桌面截图
+- 聊天记录、朋友圈、微博等社交页面
+- 新闻、文章、网页浏览页
+- 照片、自拍、风景图
+- 应用主界面、设置页面
+- 任何不包含具体消费金额、商家名称、交易时间的图片或文字
+
+只有在确定是真实的支付账单、收据（含电子发票、支付凭证截图）时，才{{INPUT_SOURCE}}提取记账信息，返回JSON数组。
+如果不确定，也返回空数组 []。
 
 当前时间：{{CURRENT_TIME}}
 

--- a/lib/ai/core/prompt_builder.dart
+++ b/lib/ai/core/prompt_builder.dart
@@ -4,24 +4,16 @@ import 'ai_extraction_context.dart';
 ///
 /// 默认模板要求 AI 返回 JSON 数组(单笔也包成 `[{...}]`),通过占位符
 /// `{{INPUT_SOURCE}}` / `{{CURRENT_TIME}}` / `{{OCR_TEXT}}` /
-/// `{{CATEGORIES}}` / `{{ACCOUNTS}}` 注入运行时变量。
+/// `{{BILL_GUARD}}` / `{{CATEGORIES}}` / `{{ACCOUNTS}}` 注入运行时变量。
 class PromptBuilder {
   const PromptBuilder();
 
-  /// 默认模板。先判断是否为账单，再强制 JSON 数组 + 完整字段说明 + 多笔示例。
+  /// 默认模板。强制 JSON 数组 + 完整字段说明 + 多笔示例。
+  ///
+  /// 调用方可通过 [build] 的 [billGuard] 参数决定是否注入前置过滤段
+  /// （如 `[billGuardForImage]`），避免误伤聊天记账等主动输入路径。
   static const String defaultTemplate =
-      '''严格判断以下内容是否为支付账单、收据或交易凭证。
-
-以下情况不属于账单，必须返回空数组 []：
-- 电脑/手机桌面截图
-- 聊天记录、朋友圈、微博等社交页面
-- 新闻、文章、网页浏览页
-- 照片、自拍、风景图
-- 应用主界面、设置页面
-- 任何不包含具体消费金额、商家名称、交易时间的图片或文字
-
-只有在确定是真实的支付账单、收据（含电子发票、支付凭证截图）时，才{{INPUT_SOURCE}}提取记账信息，返回JSON数组。
-如果不确定，也返回空数组 []。
+      '''{{BILL_GUARD}}{{INPUT_SOURCE}}提取记账信息，返回JSON数组。
 
 当前时间：{{CURRENT_TIME}}
 
@@ -63,6 +55,20 @@ class PromptBuilder {
 
 注意：只返回 JSON 数组（即使只有一笔也用数组包裹），尽量推断时间不要返回 null，note 必须 ≤15 字（长标题要精简）''';
 
+  /// 截图/自动路径使用的账单过滤段。
+  ///
+  /// 拼在默认模板最前面，让 AI 先判断输入是否为真实账单，非账单直接返回 []。
+  /// 聊天记账、语音记账等主动输入路径不应注入此段（传空字符串即可）。
+  static const String billGuardForImage = '请先判断输入图片是否为账单。'
+      '以下情况通常不属于账单（仅供参考，不仅限于此）：\n'
+      '- 电脑/手机桌面截图\n'
+      '- 聊天记录、朋友圈、微博等社交页面\n'
+      '- 新闻、文章、网页浏览页\n'
+      '- 照片、自拍、风景图\n'
+      '- 应用主界面、设置页面\n'
+      '\n'
+      '判断后，不是账单则返回JSON空数组[]，是账单则继续。\n';
+
   /// Hardcoded fallback 分类(context 不提供时使用)
   static const String _hardcodedCategoryHint = '分类列表：\n'
       '支出：餐饮、交通、购物、娱乐、居家、通讯、水电、医疗、教育\n'
@@ -71,11 +77,13 @@ class PromptBuilder {
   /// 拼装最终 prompt。
   ///
   /// [inputSource] 输入源描述(如 "从以下支付账单文本中" / "分析支付账单截图，从中")
+  /// [billGuard] 前置过滤段，截图/自动路径传入 [billGuardForImage]，聊天等主动输入传空字符串。
   /// [ocrText] 文本输入(图片场景留空)
   /// [now] 时间锚点,默认 `DateTime.now()` (测试可注入固定时间)
   String build({
     required AiExtractionContext context,
     required String inputSource,
+    String billGuard = '',
     String ocrText = '',
     DateTime? now,
   }) {
@@ -89,6 +97,7 @@ class PromptBuilder {
         : defaultTemplate;
 
     return template
+        .replaceAll('{{BILL_GUARD}}', billGuard)
         .replaceAll('{{INPUT_SOURCE}}', inputSource)
         .replaceAll('{{CURRENT_TIME}}', currentTime)
         .replaceAll('{{CURRENT_DATE}}', currentDate)

--- a/lib/ai/providers/ai_provider_factory.dart
+++ b/lib/ai/providers/ai_provider_factory.dart
@@ -410,6 +410,9 @@ class AIProviderFactory {
       model: config.visionModel,
       imageFile: image,
       temperature: 0.3,
+      // 视觉模型处理大图更慢，给 120s 避免误超时
+      receiveTimeout: const Duration(seconds: 120),
+      sendTimeout: const Duration(seconds: 120),
     );
 
     final task = _SimpleTask(prompt);
@@ -430,6 +433,9 @@ class AIProviderFactory {
       apiKey: config.apiKey,
       model: config.audioModel,
       audioFile: audio,
+      // 语音需上传音频文件，给更长的发送和接收超时
+      receiveTimeout: const Duration(seconds: 120),
+      sendTimeout: const Duration(seconds: 120),
     );
 
     final task = _SimpleTask('请将语音内容转换为文字，只返回识别的文字内容，不要添加任何解释或标点修饰。');

--- a/lib/services/ai/ai_bookkeeper.dart
+++ b/lib/services/ai/ai_bookkeeper.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import '../../ai/core/ai_extraction_context.dart';
 import '../../ai/core/ai_extraction_engine.dart';
 import '../../ai/core/bill_info.dart';
+import '../../ai/core/prompt_builder.dart';
 import '../../data/repositories/base_repository.dart';
 import '../../l10n/app_localizations.dart';
 import '../billing/bill_creation_service.dart';
@@ -36,17 +37,21 @@ class AiBookkeeper {
         _persister = persister;
 
   /// 文本记账(对话 / 自动通知文本)
+  ///
+  /// [billGuard] 前置过滤段，截图/自动路径传入 [PromptBuilder.billGuardForImage]，
+  /// 聊天等主动输入传空字符串。
   Future<BookkeepingResult> fromText({
     required String text,
     required int ledgerId,
     required List<String> billingTypes,
+    String billGuard = '',
     AppLocalizations? l10n,
   }) async {
     final context = await AiExtractionContext.forLedger(
       repository: _repo,
       ledgerId: ledgerId,
     );
-    final bills = await _engine.extractFromText(text, context);
+    final bills = await _engine.extractFromText(text, context, billGuard: billGuard);
     return _persistAll(
       bills: bills,
       ledgerId: ledgerId,
@@ -57,6 +62,8 @@ class AiBookkeeper {
 
   /// 图片记账(相册 / 相机 / 自动截图)
   ///
+  /// [billGuard] 前置过滤段，截图/自动路径传入 [PromptBuilder.billGuardForImage]，
+  /// 手动选图等主动输入传空字符串。
   /// [onSaved] 每成功保存一笔就回调一次(传入 txId 和这笔在结果中的序号),
   /// 常用于给每笔挂图片附件 — 用户期望多笔记账时每笔都能溯源到原图,所以
   /// 默认行为是「**每笔都挂**」,而非只挂首笔。
@@ -64,6 +71,7 @@ class AiBookkeeper {
     required File image,
     required int ledgerId,
     required List<String> billingTypes,
+    String billGuard = '',
     AppLocalizations? l10n,
     Future<void> Function(int txId, int index)? onSaved,
   }) async {
@@ -71,7 +79,7 @@ class AiBookkeeper {
       repository: _repo,
       ledgerId: ledgerId,
     );
-    final bills = await _engine.extractFromImage(image, context);
+    final bills = await _engine.extractFromImage(image, context, billGuard: billGuard);
     return _persistAll(
       bills: bills,
       ledgerId: ledgerId,

--- a/lib/services/automation/auto_billing_service.dart
+++ b/lib/services/automation/auto_billing_service.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../../ai/core/prompt_builder.dart';
 import '../../ai/providers/ai_provider_config.dart';
 import '../../ai/providers/ai_provider_manager.dart';
 import '../../l10n/app_localizations.dart';
@@ -248,6 +249,7 @@ class AutoBillingService {
       final result = await _container.read(aiBookkeeperProvider).fromImage(
         image: file,
         ledgerId: ledgerId,
+        billGuard: PromptBuilder.billGuardForImage,
         billingTypes: const [
           TagSeedService.billingTypeImage,
           TagSeedService.billingTypeAi,

--- a/lib/utils/image_billing_helper.dart
+++ b/lib/utils/image_billing_helper.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 
+import '../ai/core/prompt_builder.dart';
 import '../ai/providers/ai_provider_config.dart';
 import '../ai/providers/ai_provider_manager.dart';
 import '../l10n/app_localizations.dart';
@@ -102,6 +103,7 @@ class ImageBillingHelper {
       final result = await bookkeeper.fromImage(
         image: imageFile,
         ledgerId: currentLedger.id,
+        billGuard: PromptBuilder.billGuardForImage,
         billingTypes: billingTypes,
         l10n: l10n,
         // 多笔时每笔都挂同一张原图,方便后续从任意一笔溯源

--- a/packages/flutter_ai_kit_zhipu/lib/src/zhipu_glm_provider.dart
+++ b/packages/flutter_ai_kit_zhipu/lib/src/zhipu_glm_provider.dart
@@ -42,10 +42,16 @@ class ZhipuGLMProvider implements AIProvider<String, String> {
   /// 音频文件（可选，用于GLM-4语音识别）
   final File? audioFile;
 
-  final Dio _dio = Dio(BaseOptions(
-    connectTimeout: const Duration(seconds: 20),
-    receiveTimeout: const Duration(seconds: 20),
-  ));
+  late final Dio _dio;
+
+  /// 连接超时（默认 30s）
+  final Duration connectTimeout;
+
+  /// 接收超时（默认 60s，对齐 app 层 OpenAI 兼容路径）
+  final Duration receiveTimeout;
+
+  /// 发送超时（默认 60s，上传 base64 大图/音频时有用）
+  final Duration sendTimeout;
 
   ZhipuGLMProvider({
     required this.apiKey,
@@ -53,7 +59,16 @@ class ZhipuGLMProvider implements AIProvider<String, String> {
     this.temperature = 0.1,
     this.imageFile,
     this.audioFile,
-  });
+    this.connectTimeout = const Duration(seconds: 30),
+    this.receiveTimeout = const Duration(seconds: 60),
+    this.sendTimeout = const Duration(seconds: 60),
+  }) {
+    _dio = Dio(BaseOptions(
+      connectTimeout: connectTimeout,
+      receiveTimeout: receiveTimeout,
+      sendTimeout: sendTimeout,
+    ));
+  }
 
   @override
   bool supportsTask(String taskType) {

--- a/packages/flutter_ai_kit_zhipu/lib/src/zhipu_glm_provider.dart
+++ b/packages/flutter_ai_kit_zhipu/lib/src/zhipu_glm_provider.dart
@@ -42,7 +42,10 @@ class ZhipuGLMProvider implements AIProvider<String, String> {
   /// 音频文件（可选，用于GLM-4语音识别）
   final File? audioFile;
 
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 20),
+    receiveTimeout: const Duration(seconds: 20),
+  ));
 
   ZhipuGLMProvider({
     required this.apiKey,


### PR DESCRIPTION
## 变更类型
- [x] 性能优化
- [ ] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码重构
- [ ] 其他

## 变更说明

### 1. 优化 AI 识别 prompt，extract 账单前置过滤为可注入模板变量

**文件**:
- `lib/ai/core/prompt_builder.dart`
- `lib/ai/core/ai_extraction_engine.dart`
- `lib/services/ai/ai_bookkeeper.dart`
- `lib/services/automation/auto_billing_service.dart`
- `lib/utils/image_billing_helper.dart`

原始 prompt 直接要求提取记账信息，AI 对非账单内容（桌面截图、聊天记录、自拍等）会解析出错误的 JSON。改动：

- prompt_builder 默认模板提取 billGuard 为 `{{BILL_GUARD}}` 占位符，`build()` 新增 `billGuard` 参数，调用方可按需注入
- 新增 `billGuardForImage` 常量：以示例方式引导 AI 判断（"仅供参考，不仅限于此"），非账单返回 `JSON` 空数组 `[]`
- 截图手动记账 + 无障碍自动记账路径注入 `billGuardForImage`，聊天/语音/文本不注入，不影响正常使用

### 2. 智谱 API 超时参数化，按能力设置不同超时

**文件**:
- `packages/flutter_ai_kit_zhipu/lib/src/zhipu_glm_provider.dart`
- `lib/ai/providers/ai_provider_factory.dart`

- ZhipuGLMProvider 构造函数新增 `connectTimeout`（默认 30s）、`receiveTimeout`（默认 60s）、`sendTimeout`（默认 60s），Dio 在构造体中初始化
- ai_provider_factory 按能力传入不同超时：视觉/语音 120s，对话保持默认值，避免大图/音频上传误超时

## 相关 Issue

无

## 测试情况

- [x] 已在 Android 上测试
- [ ] 已在 iOS 上测试
- [ ] 添加了单元测试
- [ ] 添加了集成测试

## 截图（如适用）

不适用

## 检查清单

- [x] 代码遵循项目规范
- [ ] 已运行 `dart format` 格式化代码
- [ ] 已运行 `flutter analyze` 无警告
- [ ] 已更新相关文档
- [x] 提交信息符合规范