### PR TITLE
feat: 账本卡片增加可见的操作菜单按钮

### DIFF
--- a/lib/pages/main/ledgers_page_new.dart
+++ b/lib/pages/main/ledgers_page_new.dart
@@ -232,6 +232,7 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
                 selected: !ledger.isRemoteOnly && ledger.id == currentId,
                 onTap: () => _handleLocalLedgerTap(ledger),
                 onLongPress: () => _showLocalLedgerActions(context, ledger),
+                onMore: () => _showLocalLedgerActions(context, ledger),
               )),
         ],
 
@@ -275,6 +276,7 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
                   ledger: ledger,
                   onTap: () => _handleRemoteLedgerTap(context, ledger),
                   onLongPress: () => _showRemoteLedgerActions(context, ledger),
+                  onMore: () => _showRemoteLedgerActions(context, ledger),
                 )),
         ],
 
@@ -313,6 +315,7 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
                             selected: !ledger.isRemoteOnly && ledger.id == currentId,
                             onTap: () => _handleLocalLedgerTap(ledger),
                             onLongPress: () => _showLocalLedgerActions(context, ledger),
+                            onMore: () => _showLocalLedgerActions(context, ledger),
                           )),
                     ],
 
@@ -332,6 +335,7 @@ class _LedgersPageNewState extends ConsumerState<LedgersPageNew> {
                             ledger: ledger,
                             onTap: () => _handleRemoteLedgerTap(context, ledger),
                             onLongPress: () => _showRemoteLedgerActions(context, ledger),
+                            onMore: () => _showRemoteLedgerActions(context, ledger),
                           )),
                     ],
 

--- a/lib/widgets/biz/ledger_card.dart
+++ b/lib/widgets/biz/ledger_card.dart
@@ -20,6 +20,11 @@ class LedgerCard extends ConsumerWidget {
   final LedgerDisplayItem ledger;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
+
+  /// 右下角「⋯」按钮回调 —— 与 [onLongPress] 调同一个操作菜单。
+  /// 长按是不可发现的手势,预算管理等入口藏在里面没人找得到,
+  /// 必须有一个可见的等价入口。
+  final VoidCallback? onMore;
   final bool selected;
 
   const LedgerCard({
@@ -27,6 +32,7 @@ class LedgerCard extends ConsumerWidget {
     required this.ledger,
     this.onTap,
     this.onLongPress,
+    this.onMore,
     this.selected = false,
   });
 
@@ -243,6 +249,23 @@ class LedgerCard extends ConsumerWidget {
                         ),
                       ],
                     ),
+                  ),
+                ),
+
+              // 右下角操作按钮(长按菜单的可见等价入口;放蒙层之后保证远程账本也可点)
+              if (onMore != null)
+                Positioned(
+                  right: 4,
+                  bottom: 4,
+                  child: IconButton(
+                    onPressed: onMore,
+                    tooltip: l10n.ledgersActions,
+                    icon: Icon(
+                      Icons.more_horiz,
+                      size: 20,
+                      color: BeeTokens.iconSecondary(context),
+                    ),
+                    visualDensity: VisualDensity.compact,
                   ),
                 ),
             ],


### PR DESCRIPTION
## 背景

大量用户反馈找不到预算在哪 —— 预算管理等入口藏在账本卡片的**长按手势**后面,长按没有任何视觉提示,属于不可发现的交互。

## 改动

- \`LedgerCard\` 新增 \`onMore\` 参数:卡片右下角渲染「⋯」按钮(tooltip 复用 \`ledgersActions\`),点击调起与长按完全相同的操作菜单(编辑/预算管理/成员管理/删除)
- 远程账本卡片按钮置于下载蒙层之上,同样可点
- 账本管理页 4 处调用点(新版列表 + 旧版兼容列表 × 本地/远程)全部接上
- 长按手势保留不变,纯增量

## 验证

- \`flutter analyze\` 与基线一致(0 error,54 个历史 info 不变)
- \`flutter build apk --debug --flavor dev\` 通过
- 真机/模拟器:账本管理页每张卡片右下角应出现「⋯」,点击弹出操作菜单