### PR TITLE
fix: 净值趋势折算到主币种 + 去折算开关(与 Web 折算口径统一)

### DIFF
--- a/lib/data/repositories/account_repository.dart
+++ b/lib/data/repositories/account_repository.dart
@@ -167,10 +167,15 @@ abstract class AccountRepository {
     required DateTime endDate,
   });
 
-  /// 净值趋势序列:每日 (资产合计, 负债合计, 净资产)。
-  /// 多币种裸加(未折算);负债类(credit_card/loan)计入 liabilities。
+  /// 净值趋势序列:每日 (资产合计, 负债合计, 净资产),已折算到主币种。
+  /// [ratesToBase]:各币种 → 主币种汇率(主币种自身 1.0);缺汇率的币种整条剔除
+  /// (与净资产卡 convertedNetWorth 同口径)。负债类(credit_card/loan)计入 liabilities。
   Future<List<({DateTime date, double assets, double liabilities, double net})>>
-      getNetWorthTrendSeries({required DateTime startDate, required DateTime endDate});
+      getNetWorthTrendSeries({
+    required DateTime startDate,
+    required DateTime endDate,
+    required Map<String, double> ratesToBase,
+  });
 
   /// 获取资产构成（按账户类型分组的余额汇总）
   Future<List<({String type, double totalBalance})>> getAssetCompositionByType();

--- a/lib/data/repositories/local/local_account_repository.dart
+++ b/lib/data/repositories/local/local_account_repository.dart
@@ -881,7 +881,11 @@ class LocalAccountRepository implements AccountRepository {
 
   @override
   Future<List<({DateTime date, double assets, double liabilities, double net})>>
-      getNetWorthTrendSeries({required DateTime startDate, required DateTime endDate}) async {
+      getNetWorthTrendSeries({
+    required DateTime startDate,
+    required DateTime endDate,
+    required Map<String, double> ratesToBase,
+  }) async {
     final accounts = await getAllAccounts();
     if (accounts.isEmpty) return [];
 
@@ -900,7 +904,10 @@ class LocalAccountRepository implements AccountRepository {
       for (final account in accounts) {
         final balances = allBalances[account.id]!;
         if (dayIndex < balances.length) {
-          final bal = balances[dayIndex].balance;
+          // 折算到主币种:缺汇率的币种整条剔除(与净资产卡同口径,绝不按 1.0 裸加)。
+          final rate = ratesToBase[account.currency.toUpperCase()];
+          if (rate == null) continue;
+          final bal = balances[dayIndex].balance * rate;
           if (isAssetType(account.type)) {
             assets += bal;
           } else {

--- a/lib/data/repositories/local/local_repository.dart
+++ b/lib/data/repositories/local/local_repository.dart
@@ -1611,8 +1611,13 @@ class LocalRepository extends BaseRepository {
 
   @override
   Future<List<({DateTime date, double assets, double liabilities, double net})>>
-      getNetWorthTrendSeries({required DateTime startDate, required DateTime endDate}) =>
-          _accountRepo.getNetWorthTrendSeries(startDate: startDate, endDate: endDate);
+      getNetWorthTrendSeries({
+    required DateTime startDate,
+    required DateTime endDate,
+    required Map<String, double> ratesToBase,
+  }) =>
+          _accountRepo.getNetWorthTrendSeries(
+              startDate: startDate, endDate: endDate, ratesToBase: ratesToBase);
 
   @override
   Future<List<({String type, double totalBalance})>> getAssetCompositionByType() =>

--- a/lib/pages/account/accounts_page.dart
+++ b/lib/pages/account/accounts_page.dart
@@ -1153,15 +1153,14 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
                       },
                     ),
                   ),
-                  // 多币种折算开关 + 汇率管理入口:仅在使用中币种 ≥2 时出现。
+                  // 汇率管理入口:仅在使用中币种 ≥2 时出现。折算开关已下线
+                  // (多币种恒折算,与 Web 端对齐),这里只保留汇率管理入口。
                   Consumer(
                     builder: (context, ref, _) {
                       final used = ref.watch(usedCurrenciesProvider).valueOrNull;
                       if (used == null || used.length < 2) {
                         return const SizedBox.shrink();
                       }
-                      final convertEnabled =
-                          ref.watch(assetConversionEnabledProvider);
                       return Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -1170,27 +1169,6 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
                             indent: 16,
                             endIndent: 16,
                             color: BeeTokens.divider(context),
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 4),
-                            child: SwitchListTile(
-                              dense: true,
-                              visualDensity: VisualDensity.compact,
-                              title: Text(
-                                l10n.assetConversionToggle,
-                                style: TextStyle(
-                                  fontSize: 14,
-                                  color: BeeTokens.textPrimary(context),
-                                ),
-                              ),
-                              value: convertEnabled,
-                              activeColor: primaryColor,
-                              onChanged: (value) {
-                                ref
-                                    .read(assetConversionEnabledProvider.notifier)
-                                    .state = value;
-                              },
-                            ),
                           ),
                           ListTile(
                             dense: true,

--- a/lib/providers/currency_providers.dart
+++ b/lib/providers/currency_providers.dart
@@ -17,9 +17,6 @@ import 'sync_providers.dart';
 /// 模式下改动会推到 server,其余云模式 / 纯本地只存本地。
 final baseCurrencyProvider = StateProvider<String>((ref) => 'CNY');
 
-/// 资产页「按主币种折算」开关(设备级 prefs,不同步)。
-final assetConversionEnabledProvider = StateProvider<bool>((ref) => true);
-
 /// 汇率数据变更信号:拉取成功 / 手动编辑后 bump,触发 effectiveRates 重算。
 final rateRefreshTickProvider = StateProvider<int>((ref) => 0);
 
@@ -42,15 +39,10 @@ final baseCurrencyInitProvider = FutureProvider<void>((ref) async {
     await prefs.setString('baseCurrency', saved);
   }
   ref.read(baseCurrencyProvider.notifier).state = saved.toUpperCase();
-  ref.read(assetConversionEnabledProvider.notifier).state =
-      prefs.getBool('assetConversionEnabled') ?? true;
 
   ref.listen<String>(baseCurrencyProvider, (prev, next) async {
     await prefs.setString('baseCurrency', next);
     _pushBaseCurrencyToCloud(ref, next);
-  });
-  ref.listen<bool>(assetConversionEnabledProvider, (prev, next) async {
-    await prefs.setBool('assetConversionEnabled', next);
   });
 });
 
@@ -85,11 +77,11 @@ final usedCurrenciesProvider = FutureProvider<Set<String>>((ref) async {
   return used;
 });
 
-/// 多币种态总闸(README D6):≥2 种币种 且 折算开关开。
+/// 多币种态总闸(README D6):使用中币种 ≥2 即恒为折算态,与 Web 端对齐。
+/// 原「按主币种折算」开关已下线(默认折算),不再有「非折算多币种」态。
 final multiCurrencyActiveProvider = Provider<bool>((ref) {
   final used = ref.watch(usedCurrenciesProvider).valueOrNull;
-  if (used == null || used.length < 2) return false;
-  return ref.watch(assetConversionEnabledProvider);
+  return used != null && used.length >= 2;
 });
 
 /// 有效汇率:手动 > 最新自动;缺失显式缺失(D5)。

--- a/lib/providers/statistics_providers.dart
+++ b/lib/providers/statistics_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'database_providers.dart';
 import 'ui_state_providers.dart';
+import 'currency_providers.dart';
 import '../services/system/logger_service.dart';
 
 // 统计：账本数量
@@ -162,9 +163,19 @@ final netWorthTrendSeriesProvider = FutureProvider.family.autoDispose<
     ({DateTime startDate, DateTime endDate})>((ref, params) async {
   final repo = ref.watch(repositoryProvider);
   ref.watch(statsRefreshProvider);
+  // 折算到主币种,与净资产卡(convertedNetWorthProvider)同口径:各币种 → base 汇率,
+  // base 自身 1.0;缺汇率的币种在 repo 内整条剔除。这样趋势末点 = 当前净资产。
+  final base = ref.watch(baseCurrencyProvider).toUpperCase();
+  final rates = await ref.watch(effectiveRatesProvider.future);
+  final ratesToBase = <String, double>{base: 1.0};
+  for (final e in rates.entries) {
+    final r = double.tryParse(e.value.rate);
+    if (r != null && r > 0) ratesToBase[e.key.toUpperCase()] = r;
+  }
   final link = ref.keepAlive();
   ref.onDispose(() => link.close());
-  return repo.getNetWorthTrendSeries(startDate: params.startDate, endDate: params.endDate);
+  return repo.getNetWorthTrendSeries(
+      startDate: params.startDate, endDate: params.endDate, ratesToBase: ratesToBase);
 });
 
 /// 全局最早一笔交易的发生时间（净值趋势「全部」范围的起点）。无交易返回 null。

--- a/test/data/repositories/net_worth_trend_test.dart
+++ b/test/data/repositories/net_worth_trend_test.dart
@@ -40,7 +40,9 @@ void main() {
         happenedAt: d.Value(DateTime(2026, 6, 10))));
 
     final series = await repo.getNetWorthTrendSeries(
-        startDate: DateTime(2026, 6, 10), endDate: DateTime(2026, 6, 10));
+        startDate: DateTime(2026, 6, 10),
+        endDate: DateTime(2026, 6, 10),
+        ratesToBase: const {'CNY': 1.0});
 
     expect(series.length, 1);
     expect(series.first.assets, 800.0);
@@ -50,7 +52,43 @@ void main() {
 
   test('空账户返回空序列', () async {
     final series = await repo.getNetWorthTrendSeries(
-        startDate: DateTime(2026, 6, 1), endDate: DateTime(2026, 6, 3));
+        startDate: DateTime(2026, 6, 1),
+        endDate: DateTime(2026, 6, 3),
+        ratesToBase: const {'CNY': 1.0});
     expect(series, isEmpty);
+  });
+
+  test('多币种折算到主币种:各账户余额 × 汇率,缺汇率币种整条剔除', () async {
+    // CNY 现金 1000(主币种,× 1.0)
+    await db.into(db.accounts).insert(AccountsCompanion.insert(
+        ledgerId: 1,
+        name: '现金',
+        type: const d.Value('cash'),
+        initialBalance: const d.Value(1000.0)));
+    // USD 银行卡 100(× 7.0 = 700)
+    await db.into(db.accounts).insert(AccountsCompanion.insert(
+        ledgerId: 1,
+        name: '美元卡',
+        type: const d.Value('bank_card'),
+        currency: const d.Value('USD'),
+        initialBalance: const d.Value(100.0)));
+    // EUR 现金 50(ratesToBase 无 EUR → 整条剔除,不计入)
+    await db.into(db.accounts).insert(AccountsCompanion.insert(
+        ledgerId: 1,
+        name: '欧元',
+        type: const d.Value('cash'),
+        currency: const d.Value('EUR'),
+        initialBalance: const d.Value(50.0)));
+
+    final series = await repo.getNetWorthTrendSeries(
+        startDate: DateTime(2026, 6, 10),
+        endDate: DateTime(2026, 6, 10),
+        ratesToBase: const {'CNY': 1.0, 'USD': 7.0}); // 故意不含 EUR
+
+    expect(series.length, 1);
+    // 1000(CNY) + 100×7(USD) = 1700;EUR 缺汇率被剔除,不计入
+    expect(series.first.assets, 1700.0);
+    expect(series.first.liabilities, 0.0);
+    expect(series.first.net, 1700.0);
   });
 }

--- a/test/providers/currency_providers_test.dart
+++ b/test/providers/currency_providers_test.dart
@@ -1,7 +1,7 @@
 // 多币种 provider 层纯逻辑单测(不打网络)。
 // 覆盖两个纯逻辑触点:
 //   ① baseCurrencyInitProvider 的初始化优先级(prefs 兜底链 selected_currency)
-//   ② multiCurrencyActiveProvider 的总闸(币种数 × 折算开关)
+//   ② multiCurrencyActiveProvider 的总闸(币种数 ≥2 即恒折算,折算开关已下线)
 //
 // 拉取链 refreshExchangeRates / effectiveRates 走 IO,不在这里测(由 service /
 // repository 层各自的测试覆盖)。
@@ -55,34 +55,27 @@ void main() {
     });
   });
 
-  group('multiCurrencyActiveProvider 总闸', () {
-    Future<bool> evaluate({
-      required Set<String> used,
-      required bool conversionEnabled,
-    }) async {
+  group('multiCurrencyActiveProvider 总闸(折算开关已下线,≥2 币种恒折算)', () {
+    Future<bool> evaluate({required Set<String> used}) async {
       final container = ProviderContainer(overrides: [
         usedCurrenciesProvider.overrideWith((ref) => Future.value(used)),
       ]);
       addTearDown(container.dispose);
-      container.read(assetConversionEnabledProvider.notifier).state =
-          conversionEnabled;
       // 等 FutureProvider 解析完成,multiCurrencyActiveProvider 才能读到 valueOrNull
       await container.read(usedCurrenciesProvider.future);
       return container.read(multiCurrencyActiveProvider);
     }
 
     test('单币种 → false', () async {
-      expect(await evaluate(used: {'CNY'}, conversionEnabled: true), isFalse);
+      expect(await evaluate(used: {'CNY'}), isFalse);
     });
 
-    test('双币种 + 折算开关开 → true', () async {
-      expect(
-          await evaluate(used: {'CNY', 'USD'}, conversionEnabled: true), isTrue);
+    test('双币种 → 恒为 true(无需开关)', () async {
+      expect(await evaluate(used: {'CNY', 'USD'}), isTrue);
     });
 
-    test('双币种 + 折算开关关 → false', () async {
-      expect(await evaluate(used: {'CNY', 'USD'}, conversionEnabled: false),
-          isFalse);
+    test('三币种 → true', () async {
+      expect(await evaluate(used: {'CNY', 'USD', 'JPY'}), isTrue);
     });
   });
 }


### PR DESCRIPTION
## 净值趋势折算到主币种 + 去折算开关(双端折算口径统一 — App)

承接净值趋势 T1,补齐折算口径一致性:

- **净值趋势折算到主币种**:此前多币种「裸加」(各币种原值直接相加,不乘汇率),趋势末点与净资产卡对不上(USD/EUR 没折算)。改为各账户余额 × 当前汇率折算(provider 传 `effectiveRates` 给 repo,缺汇率币种整条剔除,与净资产卡 `convertedNetWorth` 同口径)。末点 = 当前净资产。历史月用当前汇率回算(精确历史折算留交易级阶段)。
- **去掉「按主币种折算」开关**:删 `assetConversionEnabledProvider` + 资产页 toggle;`multiCurrencyActive` 简化为 `usedCurrencies≥2`。多币种恒折算、单币种本币,与 Web 对齐。

测试:`net_worth_trend_test`(单币种不变 / 多币种 ×汇率 / 缺汇率剔除)+ `currency_providers_test`。
