### PR TITLE
fix: 净值趋势「全部」起点排除以成员加入的共享账本

### DIFF
--- a/lib/data/repositories/local/local_transaction_repository.dart
+++ b/lib/data/repositories/local/local_transaction_repository.dart
@@ -779,7 +779,17 @@ class LocalTransactionRepository implements TransactionRepository {
 
   @override
   Future<DateTime?> getEarliestTransactionDate() async {
+    // 排除以成员身份加入的共享账本(is_shared=1 且 my_role!='owner')——与资产统计 /
+    // getAccountDailyBalances 同口径(#333),否则趋势「全部」起点会被别人账本的
+    // 早期流水拉前。自己 Own 的共享账本不排除。
+    final sharedRows = await (db.selectOnly(db.ledgers)
+          ..addColumns([db.ledgers.id])
+          ..where(db.ledgers.isShared.equals(true) &
+              db.ledgers.myRole.equals('owner').not()))
+        .get();
+    final sharedIds = sharedRows.map((r) => r.read(db.ledgers.id)!).toList();
     final row = await (db.select(db.transactions)
+          ..where((t) => t.ledgerId.isNotIn(sharedIds))
           ..orderBy([
             (t) => d.OrderingTerm(
                 expression: t.happenedAt, mode: d.OrderingMode.asc)

--- a/test/data/repositories/net_worth_trend_test.dart
+++ b/test/data/repositories/net_worth_trend_test.dart
@@ -91,4 +91,34 @@ void main() {
     expect(series.first.liabilities, 0.0);
     expect(series.first.net, 1700.0);
   });
+
+  test('getEarliestTransactionDate 排除以成员身份加入的共享账本', () async {
+    // 自己账本(id=1,owner、非共享)
+    await db.into(db.ledgers).insert(LedgersCompanion.insert(name: '个人'));
+    // 以成员加入的共享账本(id=2,is_shared 且 my_role!=owner)
+    await db.into(db.ledgers).insert(LedgersCompanion.insert(
+        name: '共享',
+        isShared: const d.Value(true),
+        myRole: const d.Value('viewer')));
+    final acc = await db.into(db.accounts).insert(AccountsCompanion.insert(
+        ledgerId: 1, name: '现金', type: const d.Value('cash')));
+    // 共享账本(id=2)更早的交易 2026-01 —— 应被排除
+    await db.into(db.transactions).insert(TransactionsCompanion.insert(
+        ledgerId: 2,
+        type: 'expense',
+        amount: 100,
+        accountId: d.Value(acc),
+        happenedAt: d.Value(DateTime(2026, 1, 5))));
+    // 自己账本(id=1)的交易 2026-03 —— 趋势起点应取这个
+    await db.into(db.transactions).insert(TransactionsCompanion.insert(
+        ledgerId: 1,
+        type: 'expense',
+        amount: 200,
+        accountId: d.Value(acc),
+        happenedAt: d.Value(DateTime(2026, 3, 10))));
+
+    final earliest = await repo.getEarliestTransactionDate();
+    // 排除共享账本 2026-01,起点 = 自己账本最早 2026-03
+    expect(earliest, DateTime(2026, 3, 10));
+  });
 }


### PR DESCRIPTION
净值趋势「全部」范围起点用 getEarliestTransactionDate(全局最早交易),此前没排除以成员身份加入的共享账本(is_shared 且 my_role!=owner)—— 别人账本的早期流水会把起点拉前,而趋势数据本身(getAccountDailyBalances #333)已排除共享账本,导致起点与曲线脱节。改为同口径排除(自己 Own 的共享账本不排除)。测试:net_worth_trend_test 新增共享账本排除用例(4 passed)。