### PR TITLE
fix: 修复 #329 后 ai_bookkeeper 测试编译失败

### DIFF
--- a/test/services/ai/ai_bookkeeper_test.dart
+++ b/test/services/ai/ai_bookkeeper_test.dart
@@ -23,11 +23,13 @@ class _FakeEngine implements AiExtractionEngine {
   });
 
   @override
-  Future<List<BillInfo>> extractFromText(String text, AiExtractionContext ctx) async =>
+  Future<List<BillInfo>> extractFromText(String text, AiExtractionContext ctx,
+          {String billGuard = ''}) async =>
       bills;
 
   @override
-  Future<List<BillInfo>> extractFromImage(File image, AiExtractionContext ctx) async =>
+  Future<List<BillInfo>> extractFromImage(File image, AiExtractionContext ctx,
+          {String billGuard = ''}) async =>
       bills;
 
   @override


### PR DESCRIPTION
## 背景

#329 给 `AiExtractionEngine.extractFromText/extractFromImage` 新增了可选命名参数 `{String billGuard = ''}`,但未同步更新测试里的 `_FakeEngine` mock,导致其 override 变成无效签名(Dart `invalid_override` 编译错误),`flutter analyze`/`flutter test` 无法通过。

## 修复

给 `_FakeEngine` 的两个 override 补上 `{String billGuard = ''}`,与接口一致。

## 验证

- `flutter analyze test/services/ai/ai_bookkeeper_test.dart` → No issues found
- `flutter test test/services/ai/ai_bookkeeper_test.dart` → All 5 tests passed