### PR TITLE
feat: 账单标记 — 不计入收支 / 不计入预算 (#340)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ android/app/*.keystore
 .docs
 .tmp
 tmp
+# Playwright MCP capture artifacts
+.playwright-mcp/

--- a/lib/cloud/sync/entity_serializer.dart
+++ b/lib/cloud/sync/entity_serializer.dart
@@ -38,6 +38,10 @@ class EntitySerializer {
       'amount': tx.amount,
       'happenedAt': tx.happenedAt.toUtc().toIso8601String(),
       'note': tx.note,
+      // 账单标记(D2 两个独立 bool)。camelCase 键与 server 端
+      // _LEDGER_MERGE_SPECS / projection upsert 对齐 —— 改键名会让标记跨设备静默丢失。
+      'excludeFromStats': tx.excludeFromStats,
+      'excludeFromBudget': tx.excludeFromBudget,
       if (ledgerSyncId != null && ledgerSyncId.isNotEmpty)
         'ledgerSyncId': ledgerSyncId,
       'categoryName': categoryName,

--- a/lib/cloud/sync/sync_engine_apply.dart
+++ b/lib/cloud/sync/sync_engine_apply.dart
@@ -192,6 +192,16 @@ extension SyncEngineApplyExt on SyncEngine {
     final lastEditedByUserId =
         (payload['updatedByUserId'] as String?) ?? createdByUserId;
 
+    // 账单标记(D6 缺键保留):payload 不含该键 → null → update 走
+    // Value.absent() 不覆盖本地;含键(包括显式 false)→ 覆盖。insert 路径
+    // null 落默认 false。键名 camelCase 与 server 契约对齐。
+    final excludeStats = payload.containsKey('excludeFromStats')
+        ? (payload['excludeFromStats'] as bool? ?? false)
+        : null;
+    final excludeBudget = payload.containsKey('excludeFromBudget')
+        ? (payload['excludeFromBudget'] as bool? ?? false)
+        : null;
+
     if (existingId != null) {
       // 更新 — createdByUserId 走"本地为 null 就回填,否则保持"的策略。
       final shouldBackfillCreator =
@@ -212,6 +222,12 @@ extension SyncEngineApplyExt on SyncEngine {
             ? d.Value(createdByUserId)
             : const d.Value.absent(),
         lastEditedByUserId: d.Value(lastEditedByUserId),
+        excludeFromStats: excludeStats == null
+            ? const d.Value.absent()
+            : d.Value(excludeStats),
+        excludeFromBudget: excludeBudget == null
+            ? const d.Value.absent()
+            : d.Value(excludeBudget),
       ));
       // 更新标签和附件(existing 路径)
       await _syncTransactionTags(existingId, syncId, payload);
@@ -235,6 +251,8 @@ extension SyncEngineApplyExt on SyncEngine {
               categorySyncIdOverride: d.Value(categorySyncIdOverride),
               accountSyncIdOverride: d.Value(accountSyncIdOverride),
               toAccountSyncIdOverride: d.Value(toAccountSyncIdOverride),
+              excludeFromStats: d.Value(excludeStats ?? false),
+              excludeFromBudget: d.Value(excludeBudget ?? false),
             ),
           );
       // 写回 cache,后续同 syncId 的 update change 能命中

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -129,6 +129,15 @@ class Transactions extends Table {
   TextColumn get accountSyncIdOverride => text().nullable()();
   TextColumn get toAccountSyncIdOverride => text().nullable()();
   TextColumn get tagSyncIdsOverride => text().nullable()();  // JSON list
+
+  /// 不计入收支:true 时从收支统计/图表/月年汇总剔除,但仍计入账户余额、净资产、
+  /// 账单列表(.docs/transaction-flags/01 §二 D1)。
+  BoolColumn get excludeFromStats =>
+      boolean().withDefault(const Constant(false))();
+
+  /// 不计入预算:true 时从预算用量剔除。与 excludeFromStats 完全独立(D2)。
+  BoolColumn get excludeFromBudget =>
+      boolean().withDefault(const Constant(false))();
 }
 
 class RecurringTransactions extends Table {
@@ -420,7 +429,7 @@ class BeeDatabase extends _$BeeDatabase {
   BeeDatabase.forTesting(QueryExecutor executor) : super(executor);
 
   @override
-  int get schemaVersion => 28; // v28: 多币种 MVP — exchange_rates / exchange_rate_overrides
+  int get schemaVersion => 29; // v29: 账单标记 — exclude_from_stats / exclude_from_budget
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1101,6 +1110,14 @@ class BeeDatabase extends _$BeeDatabase {
                 'CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_override_pair '
                 'ON exchange_rate_overrides (base_currency, quote_currency);');
             logger.info('DBMigration', 'v28 迁移完成');
+          }
+          if (from < 29) {
+            logger.info('DBMigration', '开始迁移到 v29: 账单标记(不计入收支/不计入预算)');
+            await _addColumnIfMissing('transactions', 'exclude_from_stats',
+                'ALTER TABLE transactions ADD COLUMN exclude_from_stats INTEGER NOT NULL DEFAULT 0;');
+            await _addColumnIfMissing('transactions', 'exclude_from_budget',
+                'ALTER TABLE transactions ADD COLUMN exclude_from_budget INTEGER NOT NULL DEFAULT 0;');
+            logger.info('DBMigration', 'v29 迁移完成');
           }
         },
         onCreate: (m) async {

--- a/lib/data/db.g.dart
+++ b/lib/data/db.g.dart
@@ -1939,6 +1939,26 @@ class $TransactionsTable extends Transactions
   late final GeneratedColumn<String> tagSyncIdsOverride =
       GeneratedColumn<String>('tag_sync_ids_override', aliasedName, true,
           type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _excludeFromStatsMeta =
+      const VerificationMeta('excludeFromStats');
+  @override
+  late final GeneratedColumn<bool> excludeFromStats = GeneratedColumn<bool>(
+      'exclude_from_stats', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("exclude_from_stats" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  static const VerificationMeta _excludeFromBudgetMeta =
+      const VerificationMeta('excludeFromBudget');
+  @override
+  late final GeneratedColumn<bool> excludeFromBudget = GeneratedColumn<bool>(
+      'exclude_from_budget', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("exclude_from_budget" IN (0, 1))'),
+      defaultValue: const Constant(false));
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -1957,7 +1977,9 @@ class $TransactionsTable extends Transactions
         categorySyncIdOverride,
         accountSyncIdOverride,
         toAccountSyncIdOverride,
-        tagSyncIdsOverride
+        tagSyncIdsOverride,
+        excludeFromStats,
+        excludeFromBudget
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -2063,6 +2085,18 @@ class $TransactionsTable extends Transactions
           tagSyncIdsOverride.isAcceptableOrUnknown(
               data['tag_sync_ids_override']!, _tagSyncIdsOverrideMeta));
     }
+    if (data.containsKey('exclude_from_stats')) {
+      context.handle(
+          _excludeFromStatsMeta,
+          excludeFromStats.isAcceptableOrUnknown(
+              data['exclude_from_stats']!, _excludeFromStatsMeta));
+    }
+    if (data.containsKey('exclude_from_budget')) {
+      context.handle(
+          _excludeFromBudgetMeta,
+          excludeFromBudget.isAcceptableOrUnknown(
+              data['exclude_from_budget']!, _excludeFromBudgetMeta));
+    }
     return context;
   }
 
@@ -2109,6 +2143,10 @@ class $TransactionsTable extends Transactions
           data['${effectivePrefix}to_account_sync_id_override']),
       tagSyncIdsOverride: attachedDatabase.typeMapping.read(
           DriftSqlType.string, data['${effectivePrefix}tag_sync_ids_override']),
+      excludeFromStats: attachedDatabase.typeMapping.read(
+          DriftSqlType.bool, data['${effectivePrefix}exclude_from_stats'])!,
+      excludeFromBudget: attachedDatabase.typeMapping.read(
+          DriftSqlType.bool, data['${effectivePrefix}exclude_from_budget'])!,
     );
   }
 
@@ -2136,6 +2174,13 @@ class Transaction extends DataClass implements Insertable<Transaction> {
   final String? accountSyncIdOverride;
   final String? toAccountSyncIdOverride;
   final String? tagSyncIdsOverride;
+
+  /// 不计入收支:true 时从收支统计/图表/月年汇总剔除,但仍计入账户余额、净资产、
+  /// 账单列表(.docs/transaction-flags/01 §二 D1)。
+  final bool excludeFromStats;
+
+  /// 不计入预算:true 时从预算用量剔除。与 excludeFromStats 完全独立(D2)。
+  final bool excludeFromBudget;
   const Transaction(
       {required this.id,
       required this.ledgerId,
@@ -2153,7 +2198,9 @@ class Transaction extends DataClass implements Insertable<Transaction> {
       this.categorySyncIdOverride,
       this.accountSyncIdOverride,
       this.toAccountSyncIdOverride,
-      this.tagSyncIdsOverride});
+      this.tagSyncIdsOverride,
+      required this.excludeFromStats,
+      required this.excludeFromBudget});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -2200,6 +2247,8 @@ class Transaction extends DataClass implements Insertable<Transaction> {
     if (!nullToAbsent || tagSyncIdsOverride != null) {
       map['tag_sync_ids_override'] = Variable<String>(tagSyncIdsOverride);
     }
+    map['exclude_from_stats'] = Variable<bool>(excludeFromStats);
+    map['exclude_from_budget'] = Variable<bool>(excludeFromBudget);
     return map;
   }
 
@@ -2243,6 +2292,8 @@ class Transaction extends DataClass implements Insertable<Transaction> {
       tagSyncIdsOverride: tagSyncIdsOverride == null && nullToAbsent
           ? const Value.absent()
           : Value(tagSyncIdsOverride),
+      excludeFromStats: Value(excludeFromStats),
+      excludeFromBudget: Value(excludeFromBudget),
     );
   }
 
@@ -2272,6 +2323,8 @@ class Transaction extends DataClass implements Insertable<Transaction> {
           serializer.fromJson<String?>(json['toAccountSyncIdOverride']),
       tagSyncIdsOverride:
           serializer.fromJson<String?>(json['tagSyncIdsOverride']),
+      excludeFromStats: serializer.fromJson<bool>(json['excludeFromStats']),
+      excludeFromBudget: serializer.fromJson<bool>(json['excludeFromBudget']),
     );
   }
   @override
@@ -2298,6 +2351,8 @@ class Transaction extends DataClass implements Insertable<Transaction> {
       'toAccountSyncIdOverride':
           serializer.toJson<String?>(toAccountSyncIdOverride),
       'tagSyncIdsOverride': serializer.toJson<String?>(tagSyncIdsOverride),
+      'excludeFromStats': serializer.toJson<bool>(excludeFromStats),
+      'excludeFromBudget': serializer.toJson<bool>(excludeFromBudget),
     };
   }
 
@@ -2318,7 +2373,9 @@ class Transaction extends DataClass implements Insertable<Transaction> {
           Value<String?> categorySyncIdOverride = const Value.absent(),
           Value<String?> accountSyncIdOverride = const Value.absent(),
           Value<String?> toAccountSyncIdOverride = const Value.absent(),
-          Value<String?> tagSyncIdsOverride = const Value.absent()}) =>
+          Value<String?> tagSyncIdsOverride = const Value.absent(),
+          bool? excludeFromStats,
+          bool? excludeFromBudget}) =>
       Transaction(
         id: id ?? this.id,
         ledgerId: ledgerId ?? this.ledgerId,
@@ -2349,6 +2406,8 @@ class Transaction extends DataClass implements Insertable<Transaction> {
         tagSyncIdsOverride: tagSyncIdsOverride.present
             ? tagSyncIdsOverride.value
             : this.tagSyncIdsOverride,
+        excludeFromStats: excludeFromStats ?? this.excludeFromStats,
+        excludeFromBudget: excludeFromBudget ?? this.excludeFromBudget,
       );
   Transaction copyWithCompanion(TransactionsCompanion data) {
     return Transaction(
@@ -2385,6 +2444,12 @@ class Transaction extends DataClass implements Insertable<Transaction> {
       tagSyncIdsOverride: data.tagSyncIdsOverride.present
           ? data.tagSyncIdsOverride.value
           : this.tagSyncIdsOverride,
+      excludeFromStats: data.excludeFromStats.present
+          ? data.excludeFromStats.value
+          : this.excludeFromStats,
+      excludeFromBudget: data.excludeFromBudget.present
+          ? data.excludeFromBudget.value
+          : this.excludeFromBudget,
     );
   }
 
@@ -2407,7 +2472,9 @@ class Transaction extends DataClass implements Insertable<Transaction> {
           ..write('categorySyncIdOverride: $categorySyncIdOverride, ')
           ..write('accountSyncIdOverride: $accountSyncIdOverride, ')
           ..write('toAccountSyncIdOverride: $toAccountSyncIdOverride, ')
-          ..write('tagSyncIdsOverride: $tagSyncIdsOverride')
+          ..write('tagSyncIdsOverride: $tagSyncIdsOverride, ')
+          ..write('excludeFromStats: $excludeFromStats, ')
+          ..write('excludeFromBudget: $excludeFromBudget')
           ..write(')'))
         .toString();
   }
@@ -2430,7 +2497,9 @@ class Transaction extends DataClass implements Insertable<Transaction> {
       categorySyncIdOverride,
       accountSyncIdOverride,
       toAccountSyncIdOverride,
-      tagSyncIdsOverride);
+      tagSyncIdsOverride,
+      excludeFromStats,
+      excludeFromBudget);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -2451,7 +2520,9 @@ class Transaction extends DataClass implements Insertable<Transaction> {
           other.categorySyncIdOverride == this.categorySyncIdOverride &&
           other.accountSyncIdOverride == this.accountSyncIdOverride &&
           other.toAccountSyncIdOverride == this.toAccountSyncIdOverride &&
-          other.tagSyncIdsOverride == this.tagSyncIdsOverride);
+          other.tagSyncIdsOverride == this.tagSyncIdsOverride &&
+          other.excludeFromStats == this.excludeFromStats &&
+          other.excludeFromBudget == this.excludeFromBudget);
 }
 
 class TransactionsCompanion extends UpdateCompanion<Transaction> {
@@ -2472,6 +2543,8 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
   final Value<String?> accountSyncIdOverride;
   final Value<String?> toAccountSyncIdOverride;
   final Value<String?> tagSyncIdsOverride;
+  final Value<bool> excludeFromStats;
+  final Value<bool> excludeFromBudget;
   const TransactionsCompanion({
     this.id = const Value.absent(),
     this.ledgerId = const Value.absent(),
@@ -2490,6 +2563,8 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
     this.accountSyncIdOverride = const Value.absent(),
     this.toAccountSyncIdOverride = const Value.absent(),
     this.tagSyncIdsOverride = const Value.absent(),
+    this.excludeFromStats = const Value.absent(),
+    this.excludeFromBudget = const Value.absent(),
   });
   TransactionsCompanion.insert({
     this.id = const Value.absent(),
@@ -2509,6 +2584,8 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
     this.accountSyncIdOverride = const Value.absent(),
     this.toAccountSyncIdOverride = const Value.absent(),
     this.tagSyncIdsOverride = const Value.absent(),
+    this.excludeFromStats = const Value.absent(),
+    this.excludeFromBudget = const Value.absent(),
   })  : ledgerId = Value(ledgerId),
         type = Value(type),
         amount = Value(amount);
@@ -2530,6 +2607,8 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
     Expression<String>? accountSyncIdOverride,
     Expression<String>? toAccountSyncIdOverride,
     Expression<String>? tagSyncIdsOverride,
+    Expression<bool>? excludeFromStats,
+    Expression<bool>? excludeFromBudget,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -2554,6 +2633,8 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
         'to_account_sync_id_override': toAccountSyncIdOverride,
       if (tagSyncIdsOverride != null)
         'tag_sync_ids_override': tagSyncIdsOverride,
+      if (excludeFromStats != null) 'exclude_from_stats': excludeFromStats,
+      if (excludeFromBudget != null) 'exclude_from_budget': excludeFromBudget,
     });
   }
 
@@ -2574,7 +2655,9 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
       Value<String?>? categorySyncIdOverride,
       Value<String?>? accountSyncIdOverride,
       Value<String?>? toAccountSyncIdOverride,
-      Value<String?>? tagSyncIdsOverride}) {
+      Value<String?>? tagSyncIdsOverride,
+      Value<bool>? excludeFromStats,
+      Value<bool>? excludeFromBudget}) {
     return TransactionsCompanion(
       id: id ?? this.id,
       ledgerId: ledgerId ?? this.ledgerId,
@@ -2596,6 +2679,8 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
       toAccountSyncIdOverride:
           toAccountSyncIdOverride ?? this.toAccountSyncIdOverride,
       tagSyncIdsOverride: tagSyncIdsOverride ?? this.tagSyncIdsOverride,
+      excludeFromStats: excludeFromStats ?? this.excludeFromStats,
+      excludeFromBudget: excludeFromBudget ?? this.excludeFromBudget,
     );
   }
 
@@ -2657,6 +2742,12 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
     if (tagSyncIdsOverride.present) {
       map['tag_sync_ids_override'] = Variable<String>(tagSyncIdsOverride.value);
     }
+    if (excludeFromStats.present) {
+      map['exclude_from_stats'] = Variable<bool>(excludeFromStats.value);
+    }
+    if (excludeFromBudget.present) {
+      map['exclude_from_budget'] = Variable<bool>(excludeFromBudget.value);
+    }
     return map;
   }
 
@@ -2679,7 +2770,9 @@ class TransactionsCompanion extends UpdateCompanion<Transaction> {
           ..write('categorySyncIdOverride: $categorySyncIdOverride, ')
           ..write('accountSyncIdOverride: $accountSyncIdOverride, ')
           ..write('toAccountSyncIdOverride: $toAccountSyncIdOverride, ')
-          ..write('tagSyncIdsOverride: $tagSyncIdsOverride')
+          ..write('tagSyncIdsOverride: $tagSyncIdsOverride, ')
+          ..write('excludeFromStats: $excludeFromStats, ')
+          ..write('excludeFromBudget: $excludeFromBudget')
           ..write(')'))
         .toString();
   }
@@ -11480,6 +11573,8 @@ typedef $$TransactionsTableCreateCompanionBuilder = TransactionsCompanion
   Value<String?> accountSyncIdOverride,
   Value<String?> toAccountSyncIdOverride,
   Value<String?> tagSyncIdsOverride,
+  Value<bool> excludeFromStats,
+  Value<bool> excludeFromBudget,
 });
 typedef $$TransactionsTableUpdateCompanionBuilder = TransactionsCompanion
     Function({
@@ -11500,6 +11595,8 @@ typedef $$TransactionsTableUpdateCompanionBuilder = TransactionsCompanion
   Value<String?> accountSyncIdOverride,
   Value<String?> toAccountSyncIdOverride,
   Value<String?> tagSyncIdsOverride,
+  Value<bool> excludeFromStats,
+  Value<bool> excludeFromBudget,
 });
 
 class $$TransactionsTableFilterComposer
@@ -11566,6 +11663,14 @@ class $$TransactionsTableFilterComposer
 
   ColumnFilters<String> get tagSyncIdsOverride => $composableBuilder(
       column: $table.tagSyncIdsOverride,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<bool> get excludeFromStats => $composableBuilder(
+      column: $table.excludeFromStats,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<bool> get excludeFromBudget => $composableBuilder(
+      column: $table.excludeFromBudget,
       builder: (column) => ColumnFilters(column));
 }
 
@@ -11634,6 +11739,14 @@ class $$TransactionsTableOrderingComposer
   ColumnOrderings<String> get tagSyncIdsOverride => $composableBuilder(
       column: $table.tagSyncIdsOverride,
       builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<bool> get excludeFromStats => $composableBuilder(
+      column: $table.excludeFromStats,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<bool> get excludeFromBudget => $composableBuilder(
+      column: $table.excludeFromBudget,
+      builder: (column) => ColumnOrderings(column));
 }
 
 class $$TransactionsTableAnnotationComposer
@@ -11695,6 +11808,12 @@ class $$TransactionsTableAnnotationComposer
 
   GeneratedColumn<String> get tagSyncIdsOverride => $composableBuilder(
       column: $table.tagSyncIdsOverride, builder: (column) => column);
+
+  GeneratedColumn<bool> get excludeFromStats => $composableBuilder(
+      column: $table.excludeFromStats, builder: (column) => column);
+
+  GeneratedColumn<bool> get excludeFromBudget => $composableBuilder(
+      column: $table.excludeFromBudget, builder: (column) => column);
 }
 
 class $$TransactionsTableTableManager extends RootTableManager<
@@ -11740,6 +11859,8 @@ class $$TransactionsTableTableManager extends RootTableManager<
             Value<String?> accountSyncIdOverride = const Value.absent(),
             Value<String?> toAccountSyncIdOverride = const Value.absent(),
             Value<String?> tagSyncIdsOverride = const Value.absent(),
+            Value<bool> excludeFromStats = const Value.absent(),
+            Value<bool> excludeFromBudget = const Value.absent(),
           }) =>
               TransactionsCompanion(
             id: id,
@@ -11759,6 +11880,8 @@ class $$TransactionsTableTableManager extends RootTableManager<
             accountSyncIdOverride: accountSyncIdOverride,
             toAccountSyncIdOverride: toAccountSyncIdOverride,
             tagSyncIdsOverride: tagSyncIdsOverride,
+            excludeFromStats: excludeFromStats,
+            excludeFromBudget: excludeFromBudget,
           ),
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -11778,6 +11901,8 @@ class $$TransactionsTableTableManager extends RootTableManager<
             Value<String?> accountSyncIdOverride = const Value.absent(),
             Value<String?> toAccountSyncIdOverride = const Value.absent(),
             Value<String?> tagSyncIdsOverride = const Value.absent(),
+            Value<bool> excludeFromStats = const Value.absent(),
+            Value<bool> excludeFromBudget = const Value.absent(),
           }) =>
               TransactionsCompanion.insert(
             id: id,
@@ -11797,6 +11922,8 @@ class $$TransactionsTableTableManager extends RootTableManager<
             accountSyncIdOverride: accountSyncIdOverride,
             toAccountSyncIdOverride: toAccountSyncIdOverride,
             tagSyncIdsOverride: tagSyncIdsOverride,
+            excludeFromStats: excludeFromStats,
+            excludeFromBudget: excludeFromBudget,
           ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))

--- a/lib/data/repositories/local/local_account_repository.dart
+++ b/lib/data/repositories/local/local_account_repository.dart
@@ -405,11 +405,13 @@ class LocalAccountRepository implements AccountRepository {
   Future<double> getAccountExpense(int accountId) async {
     double expense = 0.0;
 
-    // 获取作为主账户的支出和转出(排除共享账本)
+    // 获取作为主账户的支出和转出(排除共享账本;不计入收支的交易也排除)
     final sharedIds = await _sharedLedgerIds();
     final normalTxs = await (db.select(db.transactions)
           ..where((t) =>
-              t.accountId.equals(accountId) & t.ledgerId.isNotIn(sharedIds)))
+              t.accountId.equals(accountId) &
+              t.ledgerId.isNotIn(sharedIds) &
+              t.excludeFromStats.equals(false)))
         .get();
 
     for (final t in normalTxs) {
@@ -428,11 +430,13 @@ class LocalAccountRepository implements AccountRepository {
   Future<double> getAccountIncome(int accountId) async {
     double income = 0.0;
 
-    // 获取作为主账户的收入(排除共享账本)
+    // 获取作为主账户的收入(排除共享账本;不计入收支的交易也排除)
     final sharedIds = await _sharedLedgerIds();
     final normalTxs = await (db.select(db.transactions)
           ..where((t) =>
-              t.accountId.equals(accountId) & t.ledgerId.isNotIn(sharedIds)))
+              t.accountId.equals(accountId) &
+              t.ledgerId.isNotIn(sharedIds) &
+              t.excludeFromStats.equals(false)))
         .get();
 
     for (final t in normalTxs) {
@@ -441,12 +445,13 @@ class LocalAccountRepository implements AccountRepository {
       }
     }
 
-    // 作为转入账户的转账(排除共享账本)
+    // 作为转入账户的转账(排除共享账本;不计入收支的交易也排除)
     final transfersIn = await (db.select(db.transactions)
           ..where((t) =>
               t.toAccountId.equals(accountId) &
               t.type.equals('transfer') &
-              t.ledgerId.isNotIn(sharedIds)))
+              t.ledgerId.isNotIn(sharedIds) &
+              t.excludeFromStats.equals(false)))
         .get();
 
     for (final t in transfersIn) {
@@ -490,10 +495,13 @@ class LocalAccountRepository implements AccountRepository {
     // 总收入/支出：直接从交易表查询，排除转账类型
     final accountIds = accounts.map((a) => a.id).toSet();
 
+    // 收入/支出排除不计入收支的交易(余额不受影响,见上方 totalBalance)
     final sharedIds = await _sharedLedgerIds();
     final allTxs = await (db.select(db.transactions)
           ..where((t) =>
-              t.accountId.isNotNull() & t.ledgerId.isNotIn(sharedIds)))
+              t.accountId.isNotNull() &
+              t.ledgerId.isNotIn(sharedIds) &
+              t.excludeFromStats.equals(false)))
         .get();
 
     double totalIncome = 0.0;

--- a/lib/data/repositories/local/local_account_repository.dart
+++ b/lib/data/repositories/local/local_account_repository.dart
@@ -664,6 +664,8 @@ class LocalAccountRepository implements AccountRepository {
         note: row.data['note'] as String?,
         recurringId: row.data['recurring_id'] as int?,
         syncId: row.data['sync_id'] as String?,
+        excludeFromStats: (row.data['exclude_from_stats'] as int? ?? 0) != 0,
+        excludeFromBudget: (row.data['exclude_from_budget'] as int? ?? 0) != 0,
       );
     }).toList();
   }

--- a/lib/data/repositories/local/local_budget_repository.dart
+++ b/lib/data/repositories/local/local_budget_repository.dart
@@ -177,6 +177,7 @@ class LocalBudgetRepository implements BudgetRepository {
         FROM transactions
         WHERE ledger_id = ?
           AND type = 'expense'
+          AND exclude_from_budget = 0
           AND happened_at >= ?
           AND happened_at < ?
         ''',
@@ -197,6 +198,7 @@ class LocalBudgetRepository implements BudgetRepository {
         LEFT JOIN categories c ON t.category_id = c.id
         WHERE t.ledger_id = ?
           AND t.type = 'expense'
+          AND t.exclude_from_budget = 0
           AND t.happened_at >= ?
           AND t.happened_at < ?
           AND (t.category_id = ? OR c.parent_id = ?)

--- a/lib/data/repositories/local/local_repository.dart
+++ b/lib/data/repositories/local/local_repository.dart
@@ -310,6 +310,8 @@ class LocalRepository extends BaseRepository {
     String? categorySyncIdOverride,
     String? accountSyncIdOverride,
     String? toAccountSyncIdOverride,
+    bool excludeFromStats = false,
+    bool excludeFromBudget = false,
   }) async {
     final id = await _transactionRepo.addTransaction(
       ledgerId: ledgerId,
@@ -324,6 +326,8 @@ class LocalRepository extends BaseRepository {
       categorySyncIdOverride: categorySyncIdOverride,
       accountSyncIdOverride: accountSyncIdOverride,
       toAccountSyncIdOverride: toAccountSyncIdOverride,
+      excludeFromStats: excludeFromStats,
+      excludeFromBudget: excludeFromBudget,
     );
     if (changeTracker != null) {
       final tx = await _transactionRepo.getTransactionById(id);
@@ -394,6 +398,8 @@ class LocalRepository extends BaseRepository {
     String? categorySyncIdOverride,
     String? accountSyncIdOverride,
     String? toAccountSyncIdOverride,
+    bool? excludeFromStats,
+    bool? excludeFromBudget,
   }) async {
     if (changeTracker != null) {
       final tx = await _transactionRepo.getTransactionById(id);
@@ -405,6 +411,8 @@ class LocalRepository extends BaseRepository {
           categorySyncIdOverride: categorySyncIdOverride,
           accountSyncIdOverride: accountSyncIdOverride,
           toAccountSyncIdOverride: toAccountSyncIdOverride,
+          excludeFromStats: excludeFromStats,
+          excludeFromBudget: excludeFromBudget,
         );
         await changeTracker!.recordLedgerChange(
           entityType: 'transaction',
@@ -423,6 +431,8 @@ class LocalRepository extends BaseRepository {
       categorySyncIdOverride: categorySyncIdOverride,
       accountSyncIdOverride: accountSyncIdOverride,
       toAccountSyncIdOverride: toAccountSyncIdOverride,
+      excludeFromStats: excludeFromStats,
+      excludeFromBudget: excludeFromBudget,
     );
   }
 

--- a/lib/data/repositories/local/local_statistics_repository.dart
+++ b/lib/data/repositories/local/local_statistics_repository.dart
@@ -23,6 +23,7 @@ class LocalStatisticsRepository implements StatisticsRepository {
           ..where((t) =>
               t.ledgerId.equals(ledgerId) &
               t.type.equals(type) &
+              t.excludeFromStats.equals(false) &
               t.happenedAt.isBiggerOrEqualValue(start) & t.happenedAt.isSmallerThanValue(end)))
         .join([
       d.leftOuterJoin(db.categories,
@@ -116,6 +117,7 @@ class LocalStatisticsRepository implements StatisticsRepository {
           ..where((t) =>
               t.ledgerId.equals(ledgerId) &
               t.type.equals(type) &
+              t.excludeFromStats.equals(false) &
               t.happenedAt.isBiggerOrEqualValue(start) & t.happenedAt.isSmallerThanValue(end)))
         .join([
       d.leftOuterJoin(db.categories,
@@ -198,6 +200,7 @@ class LocalStatisticsRepository implements StatisticsRepository {
           ..where((t) =>
               t.ledgerId.equals(ledgerId) &
               t.type.equals(type) &
+              t.excludeFromStats.equals(false) &
               t.happenedAt.isBiggerOrEqualValue(start) & t.happenedAt.isSmallerThanValue(end)))
         .get();
     final map = <DateTime, double>{};
@@ -228,6 +231,7 @@ class LocalStatisticsRepository implements StatisticsRepository {
           ..where((t) =>
               t.ledgerId.equals(ledgerId) &
               t.type.equals(type) &
+              t.excludeFromStats.equals(false) &
               t.happenedAt.isBiggerOrEqualValue(yr.start) &
               t.happenedAt.isSmallerThanValue(yr.end)))
         .get();
@@ -250,7 +254,10 @@ class LocalStatisticsRepository implements StatisticsRepository {
     required String type,
   }) async {
     final rows = await (db.select(db.transactions)
-          ..where((t) => t.ledgerId.equals(ledgerId) & t.type.equals(type)))
+          ..where((t) =>
+              t.ledgerId.equals(ledgerId) &
+              t.type.equals(type) &
+              t.excludeFromStats.equals(false)))
         .get();
     if (rows.isEmpty) return const [];
     final sd = await _monthStartDayOf(ledgerId);
@@ -283,6 +290,7 @@ class LocalStatisticsRepository implements StatisticsRepository {
         COALESCE(SUM(CASE WHEN type = 'expense' THEN amount ELSE 0 END), 0) AS expense
       FROM transactions
       WHERE ledger_id = ?1 AND happened_at >= ?2 AND happened_at < ?3
+        AND exclude_from_stats = 0
       ''',
       variables: [
         d.Variable<int>(ledgerId),
@@ -328,6 +336,7 @@ class LocalStatisticsRepository implements StatisticsRepository {
         COALESCE(SUM(CASE WHEN type = 'expense' THEN amount ELSE 0 END), 0) AS expense
       FROM transactions
       WHERE ledger_id = ?1 AND happened_at >= ?2 AND happened_at < ?3
+        AND exclude_from_stats = 0
       ''',
       variables: [
         d.Variable<int>(ledgerId),
@@ -360,6 +369,7 @@ class LocalStatisticsRepository implements StatisticsRepository {
         COALESCE(SUM(CASE WHEN type = 'expense' THEN amount ELSE 0 END), 0) AS expense
       FROM transactions
       WHERE ledger_id = ?1 AND happened_at >= ?2 AND happened_at < ?3
+        AND exclude_from_stats = 0
       ''',
       variables: [
         d.Variable<int>(ledgerId),

--- a/lib/data/repositories/local/local_tag_repository.dart
+++ b/lib/data/repositories/local/local_tag_repository.dart
@@ -682,6 +682,8 @@ class LocalTagRepository implements TagRepository {
           happenedAt: row.read<DateTime>('happened_at'),
           note: row.read<String?>('note'),
           recurringId: row.read<int?>('recurring_id'),
+          excludeFromStats: row.read<bool>('exclude_from_stats'),
+          excludeFromBudget: row.read<bool>('exclude_from_budget'),
         );
       }).toList();
     });

--- a/lib/data/repositories/local/local_transaction_repository.dart
+++ b/lib/data/repositories/local/local_transaction_repository.dart
@@ -364,6 +364,8 @@ class LocalTransactionRepository implements TransactionRepository {
     String? categorySyncIdOverride,
     String? accountSyncIdOverride,
     String? toAccountSyncIdOverride,
+    bool excludeFromStats = false,
+    bool excludeFromBudget = false,
   }) async {
     return db.into(db.transactions).insert(TransactionsCompanion.insert(
           ledgerId: ledgerId,
@@ -378,6 +380,8 @@ class LocalTransactionRepository implements TransactionRepository {
           categorySyncIdOverride: d.Value(categorySyncIdOverride),
           accountSyncIdOverride: d.Value(accountSyncIdOverride),
           toAccountSyncIdOverride: d.Value(toAccountSyncIdOverride),
+          excludeFromStats: d.Value(excludeFromStats),
+          excludeFromBudget: d.Value(excludeFromBudget),
         ));
   }
 
@@ -492,6 +496,8 @@ class LocalTransactionRepository implements TransactionRepository {
     String? categorySyncIdOverride,
     String? accountSyncIdOverride,
     String? toAccountSyncIdOverride,
+    bool? excludeFromStats,
+    bool? excludeFromBudget,
   }) async {
     // 处理 accountId 参数
     final d.Value<int?> accountIdValue;
@@ -515,6 +521,13 @@ class LocalTransactionRepository implements TransactionRepository {
         categorySyncIdOverride: d.Value(categorySyncIdOverride),
         accountSyncIdOverride: d.Value(accountSyncIdOverride),
         toAccountSyncIdOverride: d.Value(toAccountSyncIdOverride),
+        // null = 不更新(保持原值);非 null = 显式写入
+        excludeFromStats: excludeFromStats == null
+            ? const d.Value.absent()
+            : d.Value(excludeFromStats),
+        excludeFromBudget: excludeFromBudget == null
+            ? const d.Value.absent()
+            : d.Value(excludeFromBudget),
       ),
     );
   }

--- a/lib/data/repositories/transaction_repository.dart
+++ b/lib/data/repositories/transaction_repository.dart
@@ -128,6 +128,8 @@ abstract class TransactionRepository {
     String? categorySyncIdOverride,
     String? accountSyncIdOverride,
     String? toAccountSyncIdOverride,
+    bool excludeFromStats = false,
+    bool excludeFromBudget = false,
   });
 
   /// 批量新增交易，单事务内插入，返回插入条数。
@@ -179,6 +181,8 @@ abstract class TransactionRepository {
     String? categorySyncIdOverride,
     String? accountSyncIdOverride,
     String? toAccountSyncIdOverride,
+    bool? excludeFromStats,
+    bool? excludeFromBudget,
   });
 
   /// 删除交易

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3023,5 +3023,10 @@
   "netWorthTrendLineNet": "Net Worth",
   "netWorthTrendLineAssets": "Total Assets",
   "netWorthTrendLineLiabilities": "Total Liabilities",
-  "netWorthTrendMultiCurrencyNote": "Historical net worth is the raw sum of each currency, not converted"
+  "netWorthTrendMultiCurrencyNote": "Historical net worth is the raw sum of each currency, not converted",
+  "txFlagExcludeFromStats": "Exclude from income/expense",
+  "txFlagExcludeFromBudget": "Exclude from budget",
+  "txFlagMoreOptions": "More options",
+  "txFlagExcludeFromStatsHint": "Excluded from stats, still counts toward balance",
+  "txFlagExcludeFromBudgetHint": "Doesn't count against your budget"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3028,5 +3028,7 @@
   "txFlagExcludeFromBudget": "Exclude from budget",
   "txFlagMoreOptions": "More options",
   "txFlagExcludeFromStatsHint": "Excluded from stats, still counts toward balance",
-  "txFlagExcludeFromBudgetHint": "Doesn't count against your budget"
+  "txFlagExcludeFromBudgetHint": "Doesn't count against your budget",
+  "txFlagExcludedTag": "Excluded",
+  "txFlagBudgetExcludedTag": "No budget"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3027,6 +3027,7 @@
   "txFlagExcludeFromStats": "Exclude from income/expense",
   "txFlagExcludeFromBudget": "Exclude from budget",
   "txFlagMoreOptions": "More options",
+  "txFlagDialogTitle": "Transaction flags",
   "txFlagExcludeFromStatsHint": "Excluded from stats, still counts toward balance",
   "txFlagExcludeFromBudgetHint": "Doesn't count against your budget",
   "txFlagExcludedTag": "Excluded",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12803,6 +12803,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Doesn\'t count against your budget'**
   String get txFlagExcludeFromBudgetHint;
+
+  /// No description provided for @txFlagExcludedTag.
+  ///
+  /// In en, this message translates to:
+  /// **'Excluded'**
+  String get txFlagExcludedTag;
+
+  /// No description provided for @txFlagBudgetExcludedTag.
+  ///
+  /// In en, this message translates to:
+  /// **'No budget'**
+  String get txFlagBudgetExcludedTag;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12773,6 +12773,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Historical net worth is the raw sum of each currency, not converted'**
   String get netWorthTrendMultiCurrencyNote;
+
+  /// No description provided for @txFlagExcludeFromStats.
+  ///
+  /// In en, this message translates to:
+  /// **'Exclude from income/expense'**
+  String get txFlagExcludeFromStats;
+
+  /// No description provided for @txFlagExcludeFromBudget.
+  ///
+  /// In en, this message translates to:
+  /// **'Exclude from budget'**
+  String get txFlagExcludeFromBudget;
+
+  /// No description provided for @txFlagMoreOptions.
+  ///
+  /// In en, this message translates to:
+  /// **'More options'**
+  String get txFlagMoreOptions;
+
+  /// No description provided for @txFlagExcludeFromStatsHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Excluded from stats, still counts toward balance'**
+  String get txFlagExcludeFromStatsHint;
+
+  /// No description provided for @txFlagExcludeFromBudgetHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Doesn\'t count against your budget'**
+  String get txFlagExcludeFromBudgetHint;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12792,6 +12792,12 @@ abstract class AppLocalizations {
   /// **'More options'**
   String get txFlagMoreOptions;
 
+  /// No description provided for @txFlagDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Transaction flags'**
+  String get txFlagDialogTitle;
+
   /// No description provided for @txFlagExcludeFromStatsHint.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6767,6 +6767,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get txFlagMoreOptions => 'More options';
 
   @override
+  String get txFlagDialogTitle => 'Transaction flags';
+
+  @override
   String get txFlagExcludeFromStatsHint => 'Excluded from stats, still counts toward balance';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6756,4 +6756,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get netWorthTrendMultiCurrencyNote => 'Historical net worth is the raw sum of each currency, not converted';
+
+  @override
+  String get txFlagExcludeFromStats => 'Exclude from income/expense';
+
+  @override
+  String get txFlagExcludeFromBudget => 'Exclude from budget';
+
+  @override
+  String get txFlagMoreOptions => 'More options';
+
+  @override
+  String get txFlagExcludeFromStatsHint => 'Excluded from stats, still counts toward balance';
+
+  @override
+  String get txFlagExcludeFromBudgetHint => 'Doesn\'t count against your budget';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6771,4 +6771,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get txFlagExcludeFromBudgetHint => 'Doesn\'t count against your budget';
+
+  @override
+  String get txFlagExcludedTag => 'Excluded';
+
+  @override
+  String get txFlagBudgetExcludedTag => 'No budget';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6756,6 +6756,21 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get netWorthTrendMultiCurrencyNote => '历史净值为各币种原值相加,未折算';
+
+  @override
+  String get txFlagExcludeFromStats => '不计入收支';
+
+  @override
+  String get txFlagExcludeFromBudget => '不计入预算';
+
+  @override
+  String get txFlagMoreOptions => '更多选项';
+
+  @override
+  String get txFlagExcludeFromStatsHint => '不计入收支统计,但仍计入账户余额';
+
+  @override
+  String get txFlagExcludeFromBudgetHint => '不占用预算额度';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).
@@ -13482,4 +13497,19 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get netWorthTrendMultiCurrencyNote => '歷史淨值為各幣種原值相加,未折算';
+
+  @override
+  String get txFlagExcludeFromStats => '不計入收支';
+
+  @override
+  String get txFlagExcludeFromBudget => '不計入預算';
+
+  @override
+  String get txFlagMoreOptions => '更多選項';
+
+  @override
+  String get txFlagExcludeFromStatsHint => '不計入收支統計,但仍計入帳戶餘額';
+
+  @override
+  String get txFlagExcludeFromBudgetHint => '不佔用預算額度';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6767,6 +6767,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get txFlagMoreOptions => '更多选项';
 
   @override
+  String get txFlagDialogTitle => '账单标记';
+
+  @override
   String get txFlagExcludeFromStatsHint => '不计入收支统计,但仍计入账户余额';
 
   @override
@@ -13512,6 +13515,9 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get txFlagMoreOptions => '更多選項';
+
+  @override
+  String get txFlagDialogTitle => '帳單標記';
 
   @override
   String get txFlagExcludeFromStatsHint => '不計入收支統計,但仍計入帳戶餘額';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6771,6 +6771,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get txFlagExcludeFromBudgetHint => '不占用预算额度';
+
+  @override
+  String get txFlagExcludedTag => '不计收支';
+
+  @override
+  String get txFlagBudgetExcludedTag => '不计预算';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).
@@ -13512,4 +13518,10 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get txFlagExcludeFromBudgetHint => '不佔用預算額度';
+
+  @override
+  String get txFlagExcludedTag => '不計收支';
+
+  @override
+  String get txFlagBudgetExcludedTag => '不計預算';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2969,5 +2969,7 @@
   "txFlagExcludeFromBudget": "不计入预算",
   "txFlagMoreOptions": "更多选项",
   "txFlagExcludeFromStatsHint": "不计入收支统计,但仍计入账户余额",
-  "txFlagExcludeFromBudgetHint": "不占用预算额度"
+  "txFlagExcludeFromBudgetHint": "不占用预算额度",
+  "txFlagExcludedTag": "不计收支",
+  "txFlagBudgetExcludedTag": "不计预算"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2964,5 +2964,10 @@
   "netWorthTrendLineNet": "净资产",
   "netWorthTrendLineAssets": "总资产",
   "netWorthTrendLineLiabilities": "总负债",
-  "netWorthTrendMultiCurrencyNote": "历史净值为各币种原值相加,未折算"
+  "netWorthTrendMultiCurrencyNote": "历史净值为各币种原值相加,未折算",
+  "txFlagExcludeFromStats": "不计入收支",
+  "txFlagExcludeFromBudget": "不计入预算",
+  "txFlagMoreOptions": "更多选项",
+  "txFlagExcludeFromStatsHint": "不计入收支统计,但仍计入账户余额",
+  "txFlagExcludeFromBudgetHint": "不占用预算额度"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2968,6 +2968,7 @@
   "txFlagExcludeFromStats": "不计入收支",
   "txFlagExcludeFromBudget": "不计入预算",
   "txFlagMoreOptions": "更多选项",
+  "txFlagDialogTitle": "账单标记",
   "txFlagExcludeFromStatsHint": "不计入收支统计,但仍计入账户余额",
   "txFlagExcludeFromBudgetHint": "不占用预算额度",
   "txFlagExcludedTag": "不计收支",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -2670,6 +2670,7 @@
   "txFlagExcludeFromStats": "不計入收支",
   "txFlagExcludeFromBudget": "不計入預算",
   "txFlagMoreOptions": "更多選項",
+  "txFlagDialogTitle": "帳單標記",
   "txFlagExcludeFromStatsHint": "不計入收支統計,但仍計入帳戶餘額",
   "txFlagExcludeFromBudgetHint": "不佔用預算額度",
   "txFlagExcludedTag": "不計收支",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -2666,5 +2666,10 @@
   "netWorthTrendLineNet": "淨資產",
   "netWorthTrendLineAssets": "總資產",
   "netWorthTrendLineLiabilities": "總負債",
-  "netWorthTrendMultiCurrencyNote": "歷史淨值為各幣種原值相加,未折算"
+  "netWorthTrendMultiCurrencyNote": "歷史淨值為各幣種原值相加,未折算",
+  "txFlagExcludeFromStats": "不計入收支",
+  "txFlagExcludeFromBudget": "不計入預算",
+  "txFlagMoreOptions": "更多選項",
+  "txFlagExcludeFromStatsHint": "不計入收支統計,但仍計入帳戶餘額",
+  "txFlagExcludeFromBudgetHint": "不佔用預算額度"
 }

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -2671,5 +2671,7 @@
   "txFlagExcludeFromBudget": "不計入預算",
   "txFlagMoreOptions": "更多選項",
   "txFlagExcludeFromStatsHint": "不計入收支統計,但仍計入帳戶餘額",
-  "txFlagExcludeFromBudgetHint": "不佔用預算額度"
+  "txFlagExcludeFromBudgetHint": "不佔用預算額度",
+  "txFlagExcludedTag": "不計收支",
+  "txFlagBudgetExcludedTag": "不計預算"
 }

--- a/lib/pages/transaction/transaction_editor_page.dart
+++ b/lib/pages/transaction/transaction_editor_page.dart
@@ -383,7 +383,7 @@ class _TransactionEditorPageState extends ConsumerState<TransactionEditorPage>
           // 刷新：预算数据
           ref.read(budgetRefreshProvider.notifier).state++;
           // 更新小组件数据（后台执行，不阻塞UI）
-          if (mounted) {
+          if (context.mounted) {
             updateAppWidget(ref, context);
           }
           // 先关闭页面，再播放反馈

--- a/lib/pages/transaction/transaction_editor_page.dart
+++ b/lib/pages/transaction/transaction_editor_page.dart
@@ -32,6 +32,8 @@ class TransactionEditorPage extends ConsumerStatefulWidget {
   final int? initialAccountId;
   final int? initialToAccountId; // 转账时的目标账户
   final List<int>? initialTagIds; // 初始标签ID列表
+  final bool initialExcludeFromStats; // 不计入收支，编辑模式回显
+  final bool initialExcludeFromBudget; // 不计入预算，编辑模式回显
 
   const TransactionEditorPage({
     super.key,
@@ -45,6 +47,8 @@ class TransactionEditorPage extends ConsumerStatefulWidget {
     this.initialAccountId,
     this.initialToAccountId,
     this.initialTagIds,
+    this.initialExcludeFromStats = false,
+    this.initialExcludeFromBudget = false,
   });
 
   @override
@@ -237,6 +241,9 @@ class _TransactionEditorPageState extends ConsumerState<TransactionEditorPage>
         showAccountPicker: true,
         ledgerId: ledgerId,
         editingTransactionId: widget.editingTransactionId,
+        transactionKind: kind,
+        initialExcludeFromStats: widget.initialExcludeFromStats,
+        initialExcludeFromBudget: widget.initialExcludeFromBudget,
         onSubmit: (res) async {
           final repo = ref.read(repositoryProvider);
           final attachmentService = ref.read(attachmentServiceProvider);
@@ -270,6 +277,8 @@ class _TransactionEditorPageState extends ConsumerState<TransactionEditorPage>
               accountId: accountIdForUpdate,
               categorySyncIdOverride: categoryOverride,
               accountSyncIdOverride: accountOverride,
+              excludeFromStats: res.excludeFromStats,
+              excludeFromBudget: res.excludeFromBudget,
             );
             transactionId = widget.editingTransactionId!;
             // 共享账本:本地 lastEditedByUserId 立即回填,UI 头像组直接展示
@@ -286,6 +295,8 @@ class _TransactionEditorPageState extends ConsumerState<TransactionEditorPage>
               accountId: accountIdForAdd,
               categorySyncIdOverride: categoryOverride,
               accountSyncIdOverride: accountOverride,
+              excludeFromStats: res.excludeFromStats,
+              excludeFromBudget: res.excludeFromBudget,
             );
             // 共享账本:新建本地 tx 也回填创建人 + 编辑人(同一个 user)
             await TxAuthorService.markCreated(ref, transactionId);

--- a/lib/utils/transaction_edit_utils.dart
+++ b/lib/utils/transaction_edit_utils.dart
@@ -62,6 +62,9 @@ class TransactionEditUtils {
           initialToAccountId: initialToAccountId,
           // 标签
           initialTagIds: tagIds,
+          // 账单标记（不计入收支/预算）回显
+          initialExcludeFromStats: transaction.excludeFromStats,
+          initialExcludeFromBudget: transaction.excludeFromBudget,
         ),
       ),
     );

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -254,10 +254,9 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
   // 待上传的附件列表（新建交易时）
   List<File> _pendingAttachments = [];
 
-  // 交易标记（更多选项区）
+  // 交易标记（旗标弹窗）
   bool _excludeFromStats = false;
   bool _excludeFromBudget = false;
-  bool _moreExpanded = false;
 
   @override
   void initState() {
@@ -265,8 +264,6 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     _date = widget.initialDate;
     _excludeFromStats = widget.initialExcludeFromStats;
     _excludeFromBudget = widget.initialExcludeFromBudget;
-    // 编辑已有交易且任一标记非默认时，默认展开“更多选项”，避免用户看不到
-    _moreExpanded = _excludeFromStats || _excludeFromBudget;
     _selectedAccountId = widget.initialAccountId;
     _selectedTagIds = List.from(widget.initialTagIds ?? []);
     // 保留原始小数（最多两位），避免编辑已有记录时小数被截断为整数
@@ -731,8 +728,6 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
             // 标签和附件选择区域（一行）
             const SizedBox(height: 8),
             _buildTagAndAttachmentRow(),
-            // 更多选项（不计入收支/预算）——按交易类型条件显示
-            _buildMoreOptionsSection(),
             const SizedBox(height: 10),
             // 数字键盘
             LayoutBuilder(builder: (ctx, c) {
@@ -962,120 +957,104 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     return _buildRowContent(selectedTags, _pendingAttachments.length, []);
   }
 
-  /// 更多选项区：可展开折叠头 + 两个标记开关。
+  /// 交易标记弹窗：两个标记开关。
   /// 可见性(01 §三):不计入收支 对 income/expense 显示;不计入预算 仅 expense。
-  /// 转账两个开关都不显示 → 整个区域不渲染。
-  Widget _buildMoreOptionsSection() {
+  /// 转账两个开关都不显示 → 旗标图标本身不渲染,不会触发此弹窗。
+  Future<void> _showFlagsDialog() async {
     final l10n = AppLocalizations.of(context);
     final primary = ref.watch(primaryColorProvider);
     final kind = widget.transactionKind;
     final showStats = kind != 'transfer';
     final showBudget = kind == 'expense';
-    // 两个开关都不该显示(转账)→ 不渲染更多选项区
-    if (!showStats && !showBudget) return const SizedBox.shrink();
 
-    final hasNonDefault = _excludeFromStats || _excludeFromBudget;
+    // 弹窗内用临时变量 + StatefulBuilder 实现实时切换,关闭时写回 sheet 状态。
+    bool stats = _excludeFromStats;
+    bool budget = _excludeFromBudget;
 
-    Widget switchTile({
-      required String title,
-      required String hint,
-      required bool value,
-      required ValueChanged<bool> onChanged,
-    }) {
-      return SwitchListTile(
-        contentPadding: EdgeInsets.zero,
-        dense: true,
-        title: Text(
-          title,
-          style: TextStyle(
-            color: BeeTokens.textPrimary(context),
-            fontSize: 15.0.scaled(context, ref),
-          ),
-        ),
-        subtitle: Text(
-          hint,
-          style: TextStyle(
-            color: BeeTokens.textTertiary(context),
-            fontSize: 12.0.scaled(context, ref),
-          ),
-        ),
-        value: value,
-        activeColor: primary,
-        onChanged: onChanged,
-      );
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const SizedBox(height: 4),
-        // 折叠头
-        InkWell(
-          borderRadius: BorderRadius.circular(8),
-          onTap: () => setState(() => _moreExpanded = !_moreExpanded),
-          child: Padding(
-            padding: EdgeInsets.symmetric(vertical: 6.0.scaled(context, ref)),
-            child: Row(
-              children: [
-                Text(
-                  l10n.txFlagMoreOptions,
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            Widget switchTile({
+              required String title,
+              required String hint,
+              required bool value,
+              required ValueChanged<bool> onChanged,
+            }) {
+              return SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+                title: Text(
+                  title,
                   style: TextStyle(
-                    color: BeeTokens.textSecondary(context),
-                    fontSize: 14.0.scaled(context, ref),
-                    fontWeight: FontWeight.w500,
+                    color: BeeTokens.textPrimary(context),
+                    fontSize: 15.0.scaled(context, ref),
                   ),
                 ),
-                // 折叠态有非默认标记 → 小圆点提示
-                if (hasNonDefault && !_moreExpanded) ...[
-                  SizedBox(width: 6.0.scaled(context, ref)),
-                  Container(
-                    width: 6.0.scaled(context, ref),
-                    height: 6.0.scaled(context, ref),
-                    decoration: BoxDecoration(
-                      color: primary,
-                      shape: BoxShape.circle,
-                    ),
+                subtitle: Text(
+                  hint,
+                  style: TextStyle(
+                    color: BeeTokens.textTertiary(context),
+                    fontSize: 12.0.scaled(context, ref),
                   ),
+                ),
+                value: value,
+                activeColor: primary,
+                onChanged: onChanged,
+              );
+            }
+
+            return AlertDialog(
+              backgroundColor: BeeTokens.surface(context),
+              title: Text(
+                l10n.txFlagDialogTitle,
+                style: TextStyle(
+                  color: BeeTokens.textPrimary(context),
+                  fontSize: 17.0.scaled(context, ref),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (showStats)
+                    switchTile(
+                      title: l10n.txFlagExcludeFromStats,
+                      hint: l10n.txFlagExcludeFromStatsHint,
+                      value: stats,
+                      onChanged: (v) {
+                        setDialogState(() => stats = v);
+                        // 实时写回 sheet 状态,图标 active 态即时更新
+                        setState(() => _excludeFromStats = v);
+                      },
+                    ),
+                  if (showBudget)
+                    switchTile(
+                      title: l10n.txFlagExcludeFromBudget,
+                      hint: l10n.txFlagExcludeFromBudgetHint,
+                      value: budget,
+                      onChanged: (v) {
+                        setDialogState(() => budget = v);
+                        setState(() => _excludeFromBudget = v);
+                      },
+                    ),
                 ],
-                const Spacer(),
-                Icon(
-                  _moreExpanded ? Icons.expand_less : Icons.expand_more,
-                  size: 20.0.scaled(context, ref),
-                  color: BeeTokens.iconSecondary(context),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: Text(
+                    AppLocalizations.of(context).commonConfirm,
+                    style: TextStyle(color: primary),
+                  ),
                 ),
               ],
-            ),
-          ),
-        ),
-        // 展开区
-        AnimatedSize(
-          duration: const Duration(milliseconds: 150),
-          alignment: Alignment.topCenter,
-          child: _moreExpanded
-              ? Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (showStats)
-                      switchTile(
-                        title: l10n.txFlagExcludeFromStats,
-                        hint: l10n.txFlagExcludeFromStatsHint,
-                        value: _excludeFromStats,
-                        onChanged: (v) =>
-                            setState(() => _excludeFromStats = v),
-                      ),
-                    if (showBudget)
-                      switchTile(
-                        title: l10n.txFlagExcludeFromBudget,
-                        hint: l10n.txFlagExcludeFromBudgetHint,
-                        value: _excludeFromBudget,
-                        onChanged: (v) =>
-                            setState(() => _excludeFromBudget = v),
-                      ),
-                  ],
-                )
-              : const SizedBox.shrink(),
-        ),
-      ],
+            );
+          },
+        );
+      },
     );
   }
 
@@ -1161,9 +1140,38 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
               ],
             ),
           ),
+          // 旗标图标:紧跟附件图标。转账(两个标记都不适用)→ 不渲染。
+          ..._buildFlagIcon(),
         ],
       ),
     );
+  }
+
+  /// 账单标记旗标图标:点击打开标记弹窗。
+  /// 可见性:转账(income/expense 均不适用)时整体不渲染。
+  /// active 态(任一标记为真)用主题色 + 实心旗;否则与附件图标一致的次级灰 + 空心旗。
+  List<Widget> _buildFlagIcon() {
+    final kind = widget.transactionKind;
+    final showStats = kind != 'transfer';
+    final showBudget = kind == 'expense';
+    // 两个开关都不适用(转账)→ 不显示旗标触发器
+    if (!showStats && !showBudget) return const [];
+
+    final active = _excludeFromStats || _excludeFromBudget;
+    return [
+      const SizedBox(width: 16),
+      GestureDetector(
+        onTap: _showFlagsDialog,
+        behavior: HitTestBehavior.opaque,
+        child: Icon(
+          active ? Icons.flag : Icons.outlined_flag,
+          size: 18,
+          color: active
+              ? ref.watch(primaryColorProvider)
+              : BeeTokens.iconSecondary(context),
+        ),
+      ),
+    ];
   }
 
   Future<void> _handleAttachmentTap(List<TransactionAttachment> savedAttachments) async {

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -13,6 +13,7 @@ import '../../l10n/app_localizations.dart';
 import '../../services/data/note_history_service.dart';
 import '../../services/attachment_service.dart';
 import '../../providers.dart';
+import '../../utils/ui_scale_extensions.dart';
 import '../../pages/tag/widgets/tag_selector.dart';
 import 'note_picker_dialog.dart';
 import 'account_selector.dart';
@@ -184,6 +185,8 @@ typedef AmountEditorResult = ({
   int? accountId,
   List<int> tagIds,
   List<File> pendingAttachments,
+  bool excludeFromStats,
+  bool excludeFromBudget,
 });
 
 class AmountEditorSheet extends ConsumerStatefulWidget {
@@ -197,6 +200,9 @@ class AmountEditorSheet extends ConsumerStatefulWidget {
   final ValueChanged<AmountEditorResult> onSubmit;
   final int ledgerId;
   final int? editingTransactionId; // 编辑模式时的交易ID，用于显示已有附件
+  final String transactionKind; // 'expense' / 'income' / 'transfer'，决定标记开关可见性
+  final bool initialExcludeFromStats; // 不计入收支，编辑模式回显
+  final bool initialExcludeFromBudget; // 不计入预算，编辑模式回显
 
   const AmountEditorSheet({
     super.key,
@@ -210,6 +216,9 @@ class AmountEditorSheet extends ConsumerStatefulWidget {
     required this.onSubmit,
     required this.ledgerId,
     this.editingTransactionId,
+    this.transactionKind = 'expense',
+    this.initialExcludeFromStats = false,
+    this.initialExcludeFromBudget = false,
   });
 
   @override
@@ -245,10 +254,19 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
   // 待上传的附件列表（新建交易时）
   List<File> _pendingAttachments = [];
 
+  // 交易标记（更多选项区）
+  bool _excludeFromStats = false;
+  bool _excludeFromBudget = false;
+  bool _moreExpanded = false;
+
   @override
   void initState() {
     super.initState();
     _date = widget.initialDate;
+    _excludeFromStats = widget.initialExcludeFromStats;
+    _excludeFromBudget = widget.initialExcludeFromBudget;
+    // 编辑已有交易且任一标记非默认时，默认展开“更多选项”，避免用户看不到
+    _moreExpanded = _excludeFromStats || _excludeFromBudget;
     _selectedAccountId = widget.initialAccountId;
     _selectedTagIds = List.from(widget.initialTagIds ?? []);
     // 保留原始小数（最多两位），避免编辑已有记录时小数被截断为整数
@@ -713,6 +731,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
             // 标签和附件选择区域（一行）
             const SizedBox(height: 8),
             _buildTagAndAttachmentRow(),
+            // 更多选项（不计入收支/预算）——按交易类型条件显示
+            _buildMoreOptionsSection(),
             const SizedBox(height: 10),
             // 数字键盘
             LayoutBuilder(builder: (ctx, c) {
@@ -818,6 +838,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                                 accountId: _selectedAccountId,
                                 tagIds: _selectedTagIds,
                                 pendingAttachments: _pendingAttachments,
+                                excludeFromStats: _excludeFromStats,
+                                excludeFromBudget: _excludeFromBudget,
                               ));
 
                               // 注意：不需要在这里重置 _isSubmitting
@@ -938,6 +960,123 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
       return _buildRowContent(selectedTags, totalCount, attachments);
     }
     return _buildRowContent(selectedTags, _pendingAttachments.length, []);
+  }
+
+  /// 更多选项区：可展开折叠头 + 两个标记开关。
+  /// 可见性(01 §三):不计入收支 对 income/expense 显示;不计入预算 仅 expense。
+  /// 转账两个开关都不显示 → 整个区域不渲染。
+  Widget _buildMoreOptionsSection() {
+    final l10n = AppLocalizations.of(context);
+    final primary = ref.watch(primaryColorProvider);
+    final kind = widget.transactionKind;
+    final showStats = kind != 'transfer';
+    final showBudget = kind == 'expense';
+    // 两个开关都不该显示(转账)→ 不渲染更多选项区
+    if (!showStats && !showBudget) return const SizedBox.shrink();
+
+    final hasNonDefault = _excludeFromStats || _excludeFromBudget;
+
+    Widget switchTile({
+      required String title,
+      required String hint,
+      required bool value,
+      required ValueChanged<bool> onChanged,
+    }) {
+      return SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        dense: true,
+        title: Text(
+          title,
+          style: TextStyle(
+            color: BeeTokens.textPrimary(context),
+            fontSize: 15.0.scaled(context, ref),
+          ),
+        ),
+        subtitle: Text(
+          hint,
+          style: TextStyle(
+            color: BeeTokens.textTertiary(context),
+            fontSize: 12.0.scaled(context, ref),
+          ),
+        ),
+        value: value,
+        activeColor: primary,
+        onChanged: onChanged,
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 4),
+        // 折叠头
+        InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: () => setState(() => _moreExpanded = !_moreExpanded),
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 6.0.scaled(context, ref)),
+            child: Row(
+              children: [
+                Text(
+                  l10n.txFlagMoreOptions,
+                  style: TextStyle(
+                    color: BeeTokens.textSecondary(context),
+                    fontSize: 14.0.scaled(context, ref),
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                // 折叠态有非默认标记 → 小圆点提示
+                if (hasNonDefault && !_moreExpanded) ...[
+                  SizedBox(width: 6.0.scaled(context, ref)),
+                  Container(
+                    width: 6.0.scaled(context, ref),
+                    height: 6.0.scaled(context, ref),
+                    decoration: BoxDecoration(
+                      color: primary,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ],
+                const Spacer(),
+                Icon(
+                  _moreExpanded ? Icons.expand_less : Icons.expand_more,
+                  size: 20.0.scaled(context, ref),
+                  color: BeeTokens.iconSecondary(context),
+                ),
+              ],
+            ),
+          ),
+        ),
+        // 展开区
+        AnimatedSize(
+          duration: const Duration(milliseconds: 150),
+          alignment: Alignment.topCenter,
+          child: _moreExpanded
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (showStats)
+                      switchTile(
+                        title: l10n.txFlagExcludeFromStats,
+                        hint: l10n.txFlagExcludeFromStatsHint,
+                        value: _excludeFromStats,
+                        onChanged: (v) =>
+                            setState(() => _excludeFromStats = v),
+                      ),
+                    if (showBudget)
+                      switchTile(
+                        title: l10n.txFlagExcludeFromBudget,
+                        hint: l10n.txFlagExcludeFromBudgetHint,
+                        value: _excludeFromBudget,
+                        onChanged: (v) =>
+                            setState(() => _excludeFromBudget = v),
+                      ),
+                  ],
+                )
+              : const SizedBox.shrink(),
+        ),
+      ],
+    );
   }
 
   Widget _buildRowContent(List<Tag> selectedTags, int attachmentCount, List<TransactionAttachment> savedAttachments) {

--- a/lib/widgets/biz/transaction_list.dart
+++ b/lib/widgets/biz/transaction_list.dart
@@ -520,6 +520,8 @@ class TransactionListState extends ConsumerState<TransactionList> {
                           : accountName,
                         tags: tagsList.isNotEmpty ? tagsList : null,
                         attachmentCount: attachmentCount,
+                        excludeFromStats: it.t.excludeFromStats,
+                        excludeFromBudget: it.t.excludeFromBudget,
                         onAttachmentTap: attachmentCount > 0
                             ? () async {
                                 switchToStreamMode(); // 用户交互，切换到 Stream 模式

--- a/lib/widgets/biz/transaction_list_item.dart
+++ b/lib/widgets/biz/transaction_list_item.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/db.dart' as db;
+import '../../l10n/app_localizations.dart';
 import '../../styles/tokens.dart';
 import '../../widgets/ui/ui.dart';
 import '../../widgets/category_icon.dart';
@@ -39,6 +40,9 @@ class TransactionListItem extends ConsumerWidget {
   final int attachmentCount; // 附件数量
   final VoidCallback? onAttachmentTap; // 点击附件图标回调
 
+  final bool excludeFromStats; // 不计入收支:第二行显示「不计收支」标签
+  final bool excludeFromBudget; // 不计入预算:第二行显示「不计预算」标签
+
   const TransactionListItem({
       super.key,
       required this.icon,
@@ -64,6 +68,8 @@ class TransactionListItem extends ConsumerWidget {
       this.onTagTap,
       this.attachmentCount = 0,
       this.onAttachmentTap,
+      this.excludeFromStats = false,
+      this.excludeFromBudget = false,
   });
 
 
@@ -77,7 +83,11 @@ class TransactionListItem extends ConsumerWidget {
         happenedAt != null &&
         (happenedAt!.hour != 0 || happenedAt!.minute != 0 || happenedAt!.second != 0);
 
-    return showTime || accountName != null || attachmentCount > 0;
+    return showTime ||
+        accountName != null ||
+        attachmentCount > 0 ||
+        excludeFromStats ||
+        excludeFromBudget;
   }
 
   /// 构建次要信息小部件（时间 · 账户 + 附件图标）
@@ -138,20 +148,47 @@ class TransactionListItem extends ConsumerWidget {
       return widget;
     }
 
-    // 如果只有附件，没有其他信息
-    if (parts.isEmpty && attachmentCount > 0) {
-      return buildAttachmentWidget();
+    // 「不计收支 / 不计预算」标签:第二行末尾的次要灰色文字标签（01 §4.2）
+    final flagTags = <Widget>[
+      if (excludeFromStats)
+        Text(AppLocalizations.of(context).txFlagExcludedTag, style: textStyle),
+      if (excludeFromBudget)
+        Text(AppLocalizations.of(context).txFlagBudgetExcludedTag,
+            style: textStyle),
+    ];
+
+    // 如果只有附件 / 标签，没有时间·账户文字
+    if (parts.isEmpty) {
+      final children = <Widget>[
+        if (attachmentCount > 0) buildAttachmentWidget(),
+        ...flagTags,
+      ];
+      // 用 Wrap 避免次要行溢出（标签可能与附件并排）
+      return Wrap(
+        spacing: 6,
+        runSpacing: 2,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: children,
+      );
     }
 
-    // 有其他信息时
-    return Row(
-      mainAxisSize: MainAxisSize.min,
+    // 有时间·账户文字时:文字 + 附件保持原有 ' · ' 风格，标签紧随其后
+    return Wrap(
+      spacing: 6,
+      runSpacing: 2,
+      crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        Text(parts.join(' · '), style: textStyle),
-        if (attachmentCount > 0) ...[
-          Text(' · ', style: textStyle),
-          buildAttachmentWidget(),
-        ],
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(parts.join(' · '), style: textStyle),
+            if (attachmentCount > 0) ...[
+              Text(' · ', style: textStyle),
+              buildAttachmentWidget(),
+            ],
+          ],
+        ),
+        ...flagTags,
       ],
     );
   }

--- a/lib/widgets/biz/transaction_list_item.dart
+++ b/lib/widgets/biz/transaction_list_item.dart
@@ -90,6 +90,27 @@ class TransactionListItem extends ConsumerWidget {
         excludeFromBudget;
   }
 
+  /// 「不计收支 / 不计预算」标记的小 pill（中性灰底，de-emphasis）
+  /// 视觉对齐 TagChip(small)：pill 圆角 + 低透明度填充 + fontSize 11
+  Widget _flagChip(BuildContext context, String label) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: BeeTokens.isDark(context)
+            ? Colors.white.withValues(alpha: 0.1)
+            : Colors.black.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          color: BeeTokens.textTertiary(context),
+        ),
+      ),
+    );
+  }
+
   /// 构建次要信息小部件（时间 · 账户 + 附件图标）
   Widget _buildSecondaryInfo(BuildContext context, WidgetRef ref) {
     final parts = <String>[];
@@ -148,13 +169,13 @@ class TransactionListItem extends ConsumerWidget {
       return widget;
     }
 
-    // 「不计收支 / 不计预算」标签:第二行末尾的次要灰色文字标签（01 §4.2）
+    // 「不计收支 / 不计预算」标签:第二行末尾的次要标签，改为与标签 chip 一致的
+    // 中性 pill 样式（de-emphasis，沿用 TagChip 的中性灰底 + pill 圆角）
     final flagTags = <Widget>[
       if (excludeFromStats)
-        Text(AppLocalizations.of(context).txFlagExcludedTag, style: textStyle),
+        _flagChip(context, AppLocalizations.of(context).txFlagExcludedTag),
       if (excludeFromBudget)
-        Text(AppLocalizations.of(context).txFlagBudgetExcludedTag,
-            style: textStyle),
+        _flagChip(context, AppLocalizations.of(context).txFlagBudgetExcludedTag),
     ];
 
     // 如果只有附件 / 标签，没有时间·账户文字

--- a/lib/widgets/transaction/transfer_form.dart
+++ b/lib/widgets/transaction/transfer_form.dart
@@ -155,6 +155,7 @@ class _TransferFormState extends ConsumerState<TransferForm> {
         showAccountPicker: false,
         ledgerId: ledgerId,
         editingTransactionId: widget.editingTransactionId,
+        transactionKind: 'transfer',
         onSubmit: (result) async {
           final attachmentService = ref.read(attachmentServiceProvider);
           // 获取虚拟转账分类ID

--- a/test/data/sync_pull_errors_schema_test.dart
+++ b/test/data/sync_pull_errors_schema_test.dart
@@ -2,7 +2,7 @@
 //
 // v25 → v26 migration 是所有用户启动必跑的关键路径,出错 = 整体崩盘。
 // 本测试验证:
-//   1. schemaVersion 在最新版本(当前为 28,v28 加了 exchange_rates / exchange_rate_overrides)
+//   1. schemaVersion 在最新版本(当前为 29,v29 加了 exclude_from_stats / exclude_from_budget)
 //   2. sync_pull_errors 表完整 schema,所有列存在 + 默认值正确
 //   3. UNIQUE(change_id) 约束生效
 //   4. CRUD 基本操作正常
@@ -31,8 +31,8 @@ void main() {
     await db.close();
   });
 
-  test('schemaVersion = 28(确保 sync_pull_errors 表已纳入 schema)', () {
-    expect(db.schemaVersion, 28);
+  test('schemaVersion = 29(确保 sync_pull_errors 表已纳入 schema)', () {
+    expect(db.schemaVersion, 29);
   });
 
   test('sync_pull_errors 表存在,所有列就位', () async {

--- a/test/repositories/account_stats_exclude_flags_test.dart
+++ b/test/repositories/account_stats_exclude_flags_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/native.dart';
+import 'package:drift/drift.dart' show Value;
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+
+void main() {
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Future<int> seedLedger() {
+    return db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '测试账本',
+          monthStartDay: const Value(1),
+        ));
+  }
+
+  Future<int> seedAccount(int ledgerId) {
+    return db.into(db.accounts).insert(AccountsCompanion.insert(
+          ledgerId: ledgerId,
+          name: '现金',
+          syncId: const Value('acc-1'),
+        ));
+  }
+
+  /// 账户维度收支统计:excludeFromStats=true 的交易应被排除。
+  test('getAccountStats.expense 排除 excludeFromStats=true 的交易', () async {
+    final lid = await seedLedger();
+    final aid = await seedAccount(lid);
+
+    // 正常支出 100
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      accountId: aid,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: false,
+      excludeFromBudget: false,
+    );
+    // 不计入收支的支出 500
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 500,
+      accountId: aid,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: true,
+      excludeFromBudget: false,
+    );
+
+    final stats = await repo.getAccountStats(aid);
+
+    // 只算入正常的 100,排除被标记的 500
+    expect(stats.expense, 100.0);
+  });
+
+  /// D5 反向断言:被排除的交易仍计入账户余额口径。
+  test('getAccountBalance 余额仍包含 excludeFromStats=true 的交易 (D5)', () async {
+    final lid = await seedLedger();
+    final aid = await seedAccount(lid);
+
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      accountId: aid,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: false,
+      excludeFromBudget: false,
+    );
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 500,
+      accountId: aid,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: true,
+      excludeFromBudget: false,
+    );
+
+    final balance = await repo.getAccountBalance(aid);
+
+    // 余额 = -(100 + 500) = -600,被排除的 500 仍计入余额
+    expect(balance, -600.0);
+  });
+}

--- a/test/repositories/budget_exclude_flags_test.dart
+++ b/test/repositories/budget_exclude_flags_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/native.dart';
+import 'package:drift/drift.dart' show Value;
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+
+void main() {
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Future<int> seedLedger() {
+    return db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '测试账本',
+          monthStartDay: const Value(1),
+        ));
+  }
+
+  /// D2:预算用量只看 excludeFromBudget。
+  /// excludeFromBudget=true 的交易不计入预算用量;
+  /// excludeFromStats=true / excludeFromBudget=false 的交易仍计入预算用量。
+  test('getBudgetUsage 只按 excludeFromBudget 过滤 (D2)', () async {
+    final lid = await seedLedger();
+
+    // 设置总预算
+    final budgetId = await repo.createBudget(
+      ledgerId: lid,
+      type: 'total',
+      amount: 1000,
+    );
+
+    // (a) 正常支出 100 —— 计入
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: false,
+      excludeFromBudget: false,
+    );
+    // (b) 不计入预算的支出 500 —— 排除
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 500,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: false,
+      excludeFromBudget: true,
+    );
+    // (c) 不计入收支但计入预算的支出 30 —— 仍计入预算
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 30,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: true,
+      excludeFromBudget: false,
+    );
+
+    final usage = await repo.getBudgetUsage(budgetId, DateTime(2026, 6, 18));
+
+    // used = 100 + 30 = 130:(b) 被排除,(c) 仍计入
+    expect(usage.used, 130.0);
+  });
+}

--- a/test/repositories/statistics_exclude_flags_test.dart
+++ b/test/repositories/statistics_exclude_flags_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/native.dart';
+import 'package:drift/drift.dart' show Value;
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+
+void main() {
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Future<int> seedLedger() {
+    return db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '测试账本',
+          monthStartDay: const Value(1),
+        ));
+  }
+
+  /// 收支统计:excludeFromStats=true 的交易应被排除;余额口径不动。
+  test('totalsInRange 排除 excludeFromStats=true 的交易', () async {
+    final lid = await seedLedger();
+    // 正常支出 100
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: false,
+      excludeFromBudget: false,
+    );
+    // 不计入收支的支出 500
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 500,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: true,
+      excludeFromBudget: false,
+    );
+
+    final (income, expense) = await repo.totalsInRange(
+      ledgerId: lid,
+      start: DateTime(2026, 6, 1),
+      end: DateTime(2026, 7, 1),
+    );
+
+    expect(income, 0.0);
+    // 只算入正常的 100,排除被标记的 500
+    expect(expense, 100.0);
+  });
+
+  /// D5 反向断言:被排除的交易仍计入余额/净值口径。
+  /// getLedgerStats 的 balance 是余额路径,不应被 excludeFromStats 过滤。
+  test('getLedgerStats 余额仍包含 excludeFromStats=true 的交易 (D5)', () async {
+    final lid = await seedLedger();
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: false,
+      excludeFromBudget: false,
+    );
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 500,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: true,
+      excludeFromBudget: false,
+    );
+
+    final stats = await repo.getLedgerStats(ledgerId: lid);
+
+    // 余额 = -(100 + 500) = -600,被排除的 500 仍计入余额
+    expect(stats.balance, -600.0);
+    expect(stats.transactionCount, 2);
+  });
+}

--- a/test/repositories/transaction_exclude_flags_test.dart
+++ b/test/repositories/transaction_exclude_flags_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/native.dart';
+import 'package:drift/drift.dart' show Value;
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+
+void main() {
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Future<int> seedLedger() {
+    return db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '测试账本',
+          monthStartDay: const Value(1),
+        ));
+  }
+
+  test('addTransaction 写入 excludeFromStats / excludeFromBudget', () async {
+    final lid = await seedLedger();
+    final id = await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: true,
+      excludeFromBudget: false,
+    );
+
+    final tx = await repo.getTransactionById(id);
+    expect(tx, isNotNull);
+    expect(tx!.excludeFromStats, true);
+    expect(tx.excludeFromBudget, false);
+  });
+
+  test('updateTransaction 仅传 excludeFromBudget 不会清空 excludeFromStats',
+      () async {
+    final lid = await seedLedger();
+    final id = await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      happenedAt: DateTime(2026, 6, 18),
+      excludeFromStats: true,
+      excludeFromBudget: false,
+    );
+
+    await repo.updateTransaction(
+      id: id,
+      type: 'expense',
+      amount: 100,
+      excludeFromBudget: true,
+    );
+
+    final tx = await repo.getTransactionById(id);
+    expect(tx, isNotNull);
+    // excludeFromStats 未传 (null) → 应保持原值 true,不被清空
+    expect(tx!.excludeFromStats, true);
+    expect(tx.excludeFromBudget, true);
+  });
+}

--- a/test/sync/transaction_exclude_flags_apply_test.dart
+++ b/test/sync/transaction_exclude_flags_apply_test.dart
@@ -1,0 +1,156 @@
+// 交易同步 apply 路径的 D6「缺键保留」语义测试。
+//
+// 场景:本地已有一条 excludeFromStats=true 的交易(已上 syncId)。远端推来
+// 同 syncId 的 upsert change,只改 amount,payload 里**省略** excludeFromStats
+// 键(模拟老客户端 / 不带该字段的同步包)。apply 后:
+//   - amount 必须更新
+//   - excludeFromStats 必须仍为 true(不能被静默清掉)
+//
+// 这条用 engine.pull('') 走真实 applyRemoteChange seam(public 入口),
+// FakeBeeCountCloudProvider.pushFakeChange 注入远端 change。
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:drift/drift.dart' show Value;
+
+import 'package:beecount/cloud/sync/change_tracker.dart';
+import 'package:beecount/cloud/sync/sync_engine.dart';
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+
+import '../cloud/sync/_fakes/fake_beecount_cloud_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late BeeDatabase db;
+  late ChangeTracker changeTracker;
+  late LocalRepository repo;
+  late FakeBeeCountCloudProvider provider;
+  late SyncEngine engine;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    changeTracker = ChangeTracker(db);
+    repo = LocalRepository(db, changeTracker: changeTracker);
+    provider = FakeBeeCountCloudProvider();
+    engine = SyncEngine(
+      db: db,
+      provider: provider,
+      changeTracker: changeTracker,
+      repo: repo,
+    );
+  });
+
+  tearDown(() async => db.close());
+
+  Future<int> seedLedger() {
+    return db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '测试账本',
+          monthStartDay: const Value(1),
+        ));
+  }
+
+  test('(D6) 远端 upsert 省略 excludeFromStats 键 → 本地 true 仍保留', () async {
+    final lid = await seedLedger();
+    const txSyncId = 'tx-exclude-1';
+
+    // 本地先建一条 excludeFromStats=true 的交易(带固定 syncId)
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      happenedAt: DateTime(2026, 6, 18),
+      syncId: txSyncId,
+      excludeFromStats: true,
+      excludeFromBudget: false,
+    );
+
+    // 远端推同 syncId 的 upsert，只改 amount，**不带** excludeFromStats 键
+    provider.pushFakeChange(
+      entityType: 'transaction',
+      entitySyncId: txSyncId,
+      ledgerId: '$lid',
+      payload: {
+        'syncId': txSyncId,
+        'type': 'expense',
+        'amount': 250,
+        'happenedAt': '2026-06-18T00:00:00Z',
+        // 注意:故意省略 excludeFromStats / excludeFromBudget
+      },
+    );
+
+    await engine.pull('');
+
+    final tx = await repo.getTransactionBySyncId(txSyncId);
+    expect(tx, isNotNull);
+    expect(tx!.amount, 250, reason: 'amount 应被远端更新');
+    expect(tx.excludeFromStats, true,
+        reason: '缺键不应清空本地已有的 excludeFromStats(D6)');
+  });
+
+  test('(D6) 远端 upsert 显式 excludeFromStats=false → 覆盖本地 true', () async {
+    final lid = await seedLedger();
+    const txSyncId = 'tx-exclude-2';
+
+    await repo.addTransaction(
+      ledgerId: lid,
+      type: 'expense',
+      amount: 100,
+      happenedAt: DateTime(2026, 6, 18),
+      syncId: txSyncId,
+      excludeFromStats: true,
+      excludeFromBudget: true,
+    );
+
+    // 远端显式把两个标记都置 false → 应覆盖本地
+    provider.pushFakeChange(
+      entityType: 'transaction',
+      entitySyncId: txSyncId,
+      ledgerId: '$lid',
+      payload: {
+        'syncId': txSyncId,
+        'type': 'expense',
+        'amount': 100,
+        'happenedAt': '2026-06-18T00:00:00Z',
+        'excludeFromStats': false,
+        'excludeFromBudget': false,
+      },
+    );
+
+    await engine.pull('');
+
+    final tx = await repo.getTransactionBySyncId(txSyncId);
+    expect(tx, isNotNull);
+    expect(tx!.excludeFromStats, false, reason: '显式 false 应覆盖本地 true');
+    expect(tx.excludeFromBudget, false, reason: '显式 false 应覆盖本地 true');
+  });
+
+  test('(insert) 远端新增带 excludeFromBudget=true → 本地插入保留', () async {
+    final lid = await seedLedger();
+    const txSyncId = 'tx-exclude-3';
+
+    provider.pushFakeChange(
+      entityType: 'transaction',
+      entitySyncId: txSyncId,
+      ledgerId: '$lid',
+      payload: {
+        'syncId': txSyncId,
+        'type': 'expense',
+        'amount': 50,
+        'happenedAt': '2026-06-18T00:00:00Z',
+        'excludeFromStats': false,
+        'excludeFromBudget': true,
+      },
+    );
+
+    await engine.pull('');
+
+    final tx = await repo.getTransactionBySyncId(txSyncId);
+    expect(tx, isNotNull);
+    expect(tx!.excludeFromStats, false);
+    expect(tx.excludeFromBudget, true);
+  });
+}

--- a/test/utils/date_parser_test.dart
+++ b/test/utils/date_parser_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:beecount/utils/date_parser.dart';
+
+/// DateParser 单测。
+///
+/// 断言的是**当前线上实现**的行为(非某个理想化版本):
+/// - ISO 8601 路径走 `DateTime.parse(...).toLocal()` → 结果为本地时区(isUtc=false);
+/// - 中文日期路径走 `DateTime(...)` 构造 → 本地时区;
+/// - 常见格式路径走 `DateFormat(fmt).parse(str, /*utc=*/true)` → 结果带 UTC 标记
+///   (字面年月日时分原样保留,只是 isUtc=true)。这是 #314 在云端按客户端时区
+///   换算后,App 侧保持的解析口径。
+void main() {
+  group('DateParser.parse — 空与兜底', () {
+    final fallback = DateTime(2020, 1, 2, 3, 4, 5);
+
+    test('null 返回 fallback', () {
+      expect(DateParser.parse(null, fallback: fallback), fallback);
+    });
+
+    test('空白字符串返回 fallback', () {
+      expect(DateParser.parse('   ', fallback: fallback), fallback);
+    });
+
+    test('无法识别的字符串返回 fallback', () {
+      expect(DateParser.parse('not a date', fallback: fallback), fallback);
+    });
+  });
+
+  group('DateParser.tryParse', () {
+    test('null / 空 / 全空白 返回 null', () {
+      expect(DateParser.tryParse(null), isNull);
+      expect(DateParser.tryParse(''), isNull);
+      expect(DateParser.tryParse('   '), isNull);
+    });
+
+    test('非空但无法解析的串:当前实现回落到 now()(非 null)', () {
+      // 已知遗留:tryParse 文档称"失败返回 null",但它委托给
+      // parse(fallback: null),而 parse 解析失败时 `return fallback ?? DateTime.now()`
+      // → 返回 now()。只有 null/空白在 tryParse 入口被拦下返回 null。
+      // 此用例锁定**当前真实行为**;若日后修正为"失败即 null",改这里。
+      expect(DateParser.tryParse('not a date'), isNotNull);
+    });
+  });
+
+  group('ISO 8601(本地时区)', () {
+    test('纯日期', () {
+      final d = DateParser.parse('2024-11-05');
+      expect(d.year, 2024);
+      expect(d.month, 11);
+      expect(d.day, 5);
+      expect(d.isUtc, isFalse);
+    });
+
+    test('带时间', () {
+      final d = DateParser.parse('2024-11-05T23:16:00');
+      expect(d.year, 2024);
+      expect(d.month, 11);
+      expect(d.day, 5);
+      expect(d.hour, 23);
+      expect(d.minute, 16);
+      expect(d.isUtc, isFalse);
+    });
+  });
+
+  group('中文日期(本地时区)', () {
+    test('年月日', () {
+      final d = DateParser.parse('2024年11月5日');
+      expect(d, DateTime(2024, 11, 5));
+    });
+
+    test('年月日 时:分', () {
+      final d = DateParser.parse('2024年11月5日 12:30');
+      expect(d, DateTime(2024, 11, 5, 12, 30));
+    });
+
+    test('年月日 时:分:秒(零填充)', () {
+      final d = DateParser.parse('2024年11月05日 12:30:45');
+      expect(d, DateTime(2024, 11, 5, 12, 30, 45));
+    });
+  });
+
+  group('常见格式(字面分量保留,带 UTC 标记)', () {
+    test('yyyy/MM/dd', () {
+      final d = DateParser.parse('2024/11/05');
+      expect(d.year, 2024);
+      expect(d.month, 11);
+      expect(d.day, 5);
+      expect(d.isUtc, isTrue);
+    });
+
+    test('yyyy/MM/dd HH:mm — 分量原样,不做时区偏移', () {
+      final d = DateParser.parse('2024/08/29 23:16');
+      expect(d.year, 2024);
+      expect(d.month, 8);
+      expect(d.day, 29);
+      expect(d.hour, 23);
+      expect(d.minute, 16);
+      expect(d.isUtc, isTrue);
+    });
+
+    test('yyyy-MM-dd HH:mm:ss', () {
+      final d = DateParser.parse('2024-08-29 23:16:05');
+      expect(d.year, 2024);
+      expect(d.day, 29);
+      expect(d.hour, 23);
+      expect(d.second, 5);
+    });
+  });
+}


### PR DESCRIPTION
实现 [issue #340](https://github.com/TNT-Likely/BeeCount/issues/340)「账单标记」。设计见 `.docs/transaction-flags/`。

> ⚠️ 需配合云端先行部署:[BeeCount-Cloud#53](https://github.com/TNT-Likely/BeeCount-Cloud/pull/53)。本 PR 为 App 端,云模式下服务端收支/预算汇总按标记过滤依赖 server ≥ 对应版本(本机统计始终正确)。

## 做了什么

单笔交易两个**互相独立**布尔标记:
- **不计入收支**(`excludeFromStats`)— 仅从收支统计/图表/月年汇总 + 账户维度收支剔除;**账户余额、净资产、资产趋势照常计入**(D1/D5)。
- **不计入预算**(`excludeFromBudget`)— 仅从预算用量剔除(D2,与上者独立)。

## 改动(逐 Task TDD)

1. **schema v29**:`transactions` 加两列(`_addColumnIfMissing`,INTEGER NOT NULL DEFAULT 0)。
2. **Repository**:`addTransaction` += 两 bool 参(默认 false);`updateTransaction` += 两 `bool?`(null=不改)。
3. **收支统计过滤**:`local_statistics_repository` 8 处收支聚合 + `local_account_repository` 账户维度收支(getAccountExpense/Income/Stats)加 `excludeFromStats` 过滤;余额/净值/资产构成**不动**。
4. **预算过滤**:`local_budget_repository.getBudgetUsage` 总预算 + 分类预算两处求和加 `excludeFromBudget` 过滤。
5. **同步**:`entity_serializer` push camelCase `excludeFromStats`/`excludeFromBudget`;`sync_engine_apply` 用 `containsKey` 解析 —— **缺键保留本地值、不回落 false**(D6),显式值(含 false)才覆盖。
6. **记账面板**:「更多选项」可展开区两开关,按类型条件显示(收支=收/支,预算=仅支出),编辑回显 + 非默认角标;三语 i18n。
7. **列表**:第二排小灰字标签「不计收支」/「不计预算」(Wrap 防溢出),金额样式不变。
8. **收尾**:周期记账生成的交易默认 false(模板列/编辑为后续);顺手修了 `transaction_editor_page` 一处 `context.mounted` 告警。

## 验证

- `flutter test` → **260 passed**(唯一失败 `bill_creation_service_test` 账户重名,已确认 main 上同样失败,与本功能无关)。
- `flutter analyze` → 0 新增 error/warning(与 main 同基线)。
- 独立 code review:D1/D2/D5/D6 + 跨端 camelCase 契约 + 迁移 + 两处 raw-SQL `Transaction` 构造(均 `SELECT *`,安全)全部确认 SOUND。

## 跨端契约

同步 payload 键 camelCase `excludeFromStats`/`excludeFromBudget`,与 Cloud#53 的 `_LEDGER_MERGE_SPECS` / projection upsert 完全一致。