### PR TITLE
fix: 图片识别非账单时提示「未识别到账单」而非「识别失败」

### DIFF
--- a/lib/ai/core/ai_extraction_engine.dart
+++ b/lib/ai/core/ai_extraction_engine.dart
@@ -129,10 +129,10 @@ class DefaultAiExtractionEngine implements AiExtractionEngine {
       return _parser.parse(response);
     } on AIException catch (e) {
       logger.warning(_tag, '图片账单提取失败: ${e.message}');
-      return const [];
+      rethrow;
     } catch (e, st) {
       logger.error(_tag, '图片账单提取异常', e, st);
-      return const [];
+      rethrow;
     }
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1700,6 +1700,7 @@
   "aiOcrNoAmount": "No valid amount recognized, please add manually",
   "aiNotConfiguredHint": "AI service not configured. Go to \"Me → AI Settings\" to set up.",
   "aiOcrCheckLog": "Recognition failed. Check logs for details.",
+  "aiOcrNoBill": "No bill recognized. Make sure the image is a bill, then try again.",
   "aiNotConfiguredNotificationTitle": "❌ Cannot recognize screenshot",
   "aiNotConfiguredNotificationBody": "AI service not configured. Tap to set up.",
   "autoBillingNotifyDetectedTitle": "✅ Screenshot detected",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1711,6 +1711,8 @@
   "autoBillingNotifyTextAnalyzingBody": "Calling AI to parse payment info...",
   "autoBillingNotifyRecognizeFailedTitle": "❌ Recognition failed",
   "autoBillingNotifyRecognizeFailedBody": "Could not extract billing info from screenshot. Check AI config or the image.",
+  "autoBillingNotifyNoBillTitle": "No bill found",
+  "autoBillingNotifyNoBillBody": "No billing info found in this screenshot — it may not be a bill.",
   "autoBillingNotifyFileUnavailableTitle": "Recognition failed",
   "autoBillingNotifyFileUnavailableBody": "Screenshot file is not available",
   "autoBillingNotifyNoLedgerTitle": "❌ Auto billing failed",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7662,6 +7662,12 @@ abstract class AppLocalizations {
   /// **'Recognition failed. Check logs for details.'**
   String get aiOcrCheckLog;
 
+  /// No description provided for @aiOcrNoBill.
+  ///
+  /// In en, this message translates to:
+  /// **'No bill recognized. Make sure the image is a bill, then try again.'**
+  String get aiOcrNoBill;
+
   /// No description provided for @aiNotConfiguredNotificationTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7728,6 +7728,18 @@ abstract class AppLocalizations {
   /// **'Could not extract billing info from screenshot. Check AI config or the image.'**
   String get autoBillingNotifyRecognizeFailedBody;
 
+  /// No description provided for @autoBillingNotifyNoBillTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No bill found'**
+  String get autoBillingNotifyNoBillTitle;
+
+  /// No description provided for @autoBillingNotifyNoBillBody.
+  ///
+  /// In en, this message translates to:
+  /// **'No billing info found in this screenshot — it may not be a bill.'**
+  String get autoBillingNotifyNoBillBody;
+
   /// No description provided for @autoBillingNotifyFileUnavailableTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4043,6 +4043,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoBillingNotifyRecognizeFailedBody => 'Could not extract billing info from screenshot. Check AI config or the image.';
 
   @override
+  String get autoBillingNotifyNoBillTitle => 'No bill found';
+
+  @override
+  String get autoBillingNotifyNoBillBody => 'No billing info found in this screenshot — it may not be a bill.';
+
+  @override
   String get autoBillingNotifyFileUnavailableTitle => 'Recognition failed';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4010,6 +4010,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiOcrCheckLog => 'Recognition failed. Check logs for details.';
 
   @override
+  String get aiOcrNoBill => 'No bill recognized. Make sure the image is a bill, then try again.';
+
+  @override
   String get aiNotConfiguredNotificationTitle => '❌ Cannot recognize screenshot';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -4010,6 +4010,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get aiOcrCheckLog => '识别失败，请查看日志了解详情';
 
   @override
+  String get aiOcrNoBill => '未识别到账单信息，请确认图片是账单后重试';
+
+  @override
   String get aiNotConfiguredNotificationTitle => '❌ 无法识别截图';
 
   @override
@@ -10785,6 +10788,9 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get aiOcrCheckLog => '識別失敗，請查看日誌瞭解詳情';
+
+  @override
+  String get aiOcrNoBill => '未識別到帳單資訊，請確認圖片是帳單後重試';
 
   @override
   String get aiNotConfiguredNotificationTitle => '❌ 無法識別截圖';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -4043,6 +4043,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get autoBillingNotifyRecognizeFailedBody => '无法从截图提取账单信息，请检查 AI 配置或图片';
 
   @override
+  String get autoBillingNotifyNoBillTitle => '未识别到账单';
+
+  @override
+  String get autoBillingNotifyNoBillBody => '这张截图未识别到账单信息，可能不是账单';
+
+  @override
   String get autoBillingNotifyFileUnavailableTitle => '识别失败';
 
   @override
@@ -10821,6 +10827,12 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get autoBillingNotifyRecognizeFailedBody => '無法從截圖提取帳單資訊，請檢查 AI 配置或圖片';
+
+  @override
+  String get autoBillingNotifyNoBillTitle => '未識別到帳單';
+
+  @override
+  String get autoBillingNotifyNoBillBody => '這張截圖未識別到帳單資訊，可能不是帳單';
 
   @override
   String get autoBillingNotifyFileUnavailableTitle => '識別失敗';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1581,6 +1581,7 @@
   "aiOcrNoAmount": "未识别到有效金额，请手动记账",
   "aiNotConfiguredHint": "未配置 AI 服务，请前往「我的 → AI 设置」配置",
   "aiOcrCheckLog": "识别失败，请查看日志了解详情",
+  "aiOcrNoBill": "未识别到账单信息，请确认图片是账单后重试",
   "aiNotConfiguredNotificationTitle": "❌ 无法识别截图",
   "aiNotConfiguredNotificationBody": "未配置 AI 服务，点击前往设置",
   "autoBillingNotifyDetectedTitle": "✅ 检测到截图",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1592,6 +1592,8 @@
   "autoBillingNotifyTextAnalyzingBody": "正在调用 AI 解析支付信息...",
   "autoBillingNotifyRecognizeFailedTitle": "❌ 识别失败",
   "autoBillingNotifyRecognizeFailedBody": "无法从截图提取账单信息，请检查 AI 配置或图片",
+  "autoBillingNotifyNoBillTitle": "未识别到账单",
+  "autoBillingNotifyNoBillBody": "这张截图未识别到账单信息，可能不是账单",
   "autoBillingNotifyFileUnavailableTitle": "识别失败",
   "autoBillingNotifyFileUnavailableBody": "截图文件不可用",
   "autoBillingNotifyNoLedgerTitle": "❌ 自动记账失败",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -146,6 +146,8 @@
   "autoBillingNotifyTextAnalyzingBody": "正在呼叫 AI 解析支付資訊...",
   "autoBillingNotifyRecognizeFailedTitle": "❌ 識別失敗",
   "autoBillingNotifyRecognizeFailedBody": "無法從截圖提取帳單資訊，請檢查 AI 配置或圖片",
+  "autoBillingNotifyNoBillTitle": "未識別到帳單",
+  "autoBillingNotifyNoBillBody": "這張截圖未識別到帳單資訊，可能不是帳單",
   "autoBillingNotifyFileUnavailableTitle": "識別失敗",
   "autoBillingNotifyFileUnavailableBody": "截圖檔案不可用",
   "autoBillingNotifyNoLedgerTitle": "❌ 自動記帳失敗",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -135,6 +135,7 @@
   "aiOcrNoAmount": "未識別到有效金額，請手動記帳",
   "aiNotConfiguredHint": "未配置 AI 服務，請前往「我的 → AI 設定」配置",
   "aiOcrCheckLog": "識別失敗，請查看日誌瞭解詳情",
+  "aiOcrNoBill": "未識別到帳單資訊，請確認圖片是帳單後重試",
   "aiNotConfiguredNotificationTitle": "❌ 無法識別截圖",
   "aiNotConfiguredNotificationBody": "未配置 AI 服務，點選前往設定",
   "autoBillingNotifyDetectedTitle": "✅ 偵測到截圖",

--- a/lib/services/automation/auto_billing_service.dart
+++ b/lib/services/automation/auto_billing_service.dart
@@ -298,11 +298,17 @@ class AutoBillingService {
         if (showNotification) {
           final l10n =
               lookupAppLocalizations(PlatformDispatcher.instance.locale);
+          // failedCount>0:提取到账单但入库失败(真·错误);否则=AI 判定不是账单
+          final isNoBill = result.failedCount == 0;
           await _showFinalNotification(
             progressId: notificationId,
             finalId: resultNotificationId,
-            title: l10n.autoBillingNotifyRecognizeFailedTitle,
-            body: l10n.autoBillingNotifyRecognizeFailedBody,
+            title: isNoBill
+                ? l10n.autoBillingNotifyNoBillTitle
+                : l10n.autoBillingNotifyRecognizeFailedTitle,
+            body: isNoBill
+                ? l10n.autoBillingNotifyNoBillBody
+                : l10n.autoBillingNotifyRecognizeFailedBody,
           );
         }
         return null;

--- a/lib/services/automation/auto_billing_service.dart
+++ b/lib/services/automation/auto_billing_service.dart
@@ -140,11 +140,11 @@ class AutoBillingService {
     _lastProcessedPath = imagePath;
     _lastProcessedTime = now;
 
-    try {
-      const notificationId = 1001;
-      // 最终结果(成功/失败)用独立 ID,避免 iOS 把它当成对 1001 的静默更新
-      const resultNotificationId = 1101;
+    const notificationId = 1001;
+    // 最终结果(成功/失败)用独立 ID,避免 iOS 把它当成对 1001 的静默更新
+    const resultNotificationId = 1101;
 
+    try {
       // 检查文件是否存在
       final file = File(imagePath);
 
@@ -331,6 +331,18 @@ class AutoBillingService {
         'error': e.toString(),
         'stage': '未知阶段',
       }, stackTrace);
+      if (showNotification) {
+        try {
+          final l10n =
+              lookupAppLocalizations(PlatformDispatcher.instance.locale);
+          await _showFinalNotification(
+            progressId: notificationId,
+            finalId: resultNotificationId,
+            title: l10n.autoBillingNotifyRecognizeFailedTitle,
+            body: l10n.autoBillingNotifyRecognizeFailedBody,
+          );
+        } catch (_) {}
+      }
       return null;
     } finally {
       final totalElapsed =

--- a/lib/utils/image_billing_helper.dart
+++ b/lib/utils/image_billing_helper.dart
@@ -121,7 +121,9 @@ class ImageBillingHelper {
 
       // 6. 提示用户
       if (!result.success) {
-        showToast(context, l10n.aiOcrCheckLog);
+        // failedCount>0:提取到账单但入库失败(真·错误);否则=AI 判定不是账单/没提取到
+        showToast(context,
+            result.failedCount > 0 ? l10n.aiOcrCheckLog : l10n.aiOcrNoBill);
         return;
       }
 


### PR DESCRIPTION
## 问题

AI 图片识别返回空数组 `[]`(billGuard 判定「这不是账单」—— 是一次**成功**的 API 响应,非错误)时,手动图片记账却弹 toast「识别失败,请查看日志了解详情」(`aiOcrCheckLog`),误导用户。语音路径早已区分(「未识别到记账信息」),图片路径没有。

## 根因

`extractFromImage` 把**所有**失败(`AIException`、其它异常)都吞成 `const []`,与 billGuard 成功返回的 `[]` 无法区分;调用点 `!result.success` 一律弹「识别失败」。

## 改动(精准区分)

1. **引擎** `ai_extraction_engine.dart` `extractFromImage`:两个 catch 由 `return const []` 改为 `rethrow` —— 真异常(网络/API)向上抛,只有「成功解析但空」才返回 `[]`。**仅改 image**,`extractFromText`/`extractFromAudio` 不动(语音经 `extractFromAudio` 自己 catch、对话/文本经 `extractFromText` 仍吞,行为不变)。
2. **i18n** 新增 `aiOcrNoBill` =「未识别到账单信息,请确认图片是账单后重试」(zh/en/zh_TW)。
3. **手动图片** `image_billing_helper.dart`:`!result.success` 时按 `failedCount` 区分 —— `>0`(提取到但入库失败,真错误)仍用 `aiOcrCheckLog`;否则(不是账单/没提取到)用 `aiOcrNoBill`。真异常落到既有 `catch` → `aiOcrFailed`(「识别失败: …」)。
4. **自动记账** `auto_billing_service.dart`:因引擎改为 rethrow,真异常会落到 `catch`(原先只 log、不通知)→ 补一条失败通知,避免真错误**静默无提示**(并把两个 notification id 提到 `try` 外)。

## 验证

- `flutter analyze`:0 新增 error(仅既有 `avoid_print` info)。
- `flutter test`:273 通过,唯一失败 `bill_creation_service_test`(账户重名)在 main 上同样失败,与本次无关。

## 备注(可选后续)

自动记账「不是账单」的**通知**目前仍是「识别失败」,与手动 toast 的「未识别到账单」措辞略有不一致 —— 属通知面、本次未改;如需对齐可另开。