### PR TITLE
fix: 周期记账首笔包含今天(修复每天周期永不生效)+ 详细日志

### DIFF
--- a/lib/services/data/recurring_transaction_service.dart
+++ b/lib/services/data/recurring_transaction_service.dart
@@ -1,6 +1,5 @@
-import 'package:drift/drift.dart';
-import 'package:collection/collection.dart';
 import '../../data/db.dart';
+import '../system/logger_service.dart';
 
 /// 重复交易频率枚举
 enum RecurringFrequency {
@@ -27,6 +26,8 @@ enum RecurringFrequency {
 ///
 /// repository 参数可以是 BeeRepository 或 CloudRepository
 class RecurringTransactionService {
+  static const _tag = 'Recurring';
+
   final dynamic repository;
 
   RecurringTransactionService(this.repository);
@@ -42,143 +43,170 @@ class RecurringTransactionService {
     bool verbose = false,
   }) async {
     try {
-      if (verbose) {
-        print('🔄 [RecurringTransaction] 开始生成待处理的重复交易...');
-        print('🔧 [RecurringTransaction] Repository类型: ${repository.runtimeType}');
-      }
+      logger.info(_tag,
+          '开始生成待处理的重复交易 (Repository=${repository.runtimeType}, verbose=$verbose)');
 
       final service = RecurringTransactionService(repository);
       final generatedTransactions = await service.generatePendingTransactions();
 
       if (generatedTransactions.isNotEmpty) {
-        print('✅ [RecurringTransaction] 成功生成 ${generatedTransactions.length} 条重复交易记录');
-        // 收集生成了交易的账本ID
         final ledgerIds = generatedTransactions.map((t) => t.ledgerId).toSet();
+        logger.info(_tag,
+            '本次共生成 ${generatedTransactions.length} 条重复交易,涉及账本 $ledgerIds');
         return ledgerIds;
       } else {
-        if (verbose) {
-          print('ℹ️  [RecurringTransaction] 没有待生成的重复交易');
-        }
+        logger.info(_tag, '本次没有需要生成的重复交易');
         return {};
       }
     } catch (e, stackTrace) {
-      print('❌ [RecurringTransaction] 生成重复交易失败: $e');
-      if (verbose) {
-        print('📍 [RecurringTransaction] 错误堆栈:');
-        print(stackTrace.toString());
-      }
       // 不抛出异常，避免影响应用启动
+      logger.error(_tag, '生成重复交易失败', e, stackTrace);
       return {};
     }
   }
 
-  /// 计算下一次应该生成交易的日期
-  DateTime? calculateNextDate(RecurringTransaction recurring) {
-    final now = DateTime.now();
+  /// 计算下一次应该生成交易的日期。返回 null 表示本次无需生成。
+  ///
+  /// [now] 仅用于测试注入"当前时间";正常调用走 `DateTime.now()`。
+  ///
+  /// 关键口径(2026-06:修复"每天周期不生效"):
+  /// - **包含今天**:`nextDate <= now`(当天 00:00 <= 此刻)即生成,之前误用
+  ///   `base + interval` 把首笔推到了明天,导致从未生成过的 daily 永远不触发。
+  /// - **从未生成(lastGenerated==null)→ 首笔就落在基准日本身**(不加 interval),
+  ///   基准日受 issue #135 保护不早于今天零点 → 既"包含今天"又不回溯补历史。
+  /// - **已生成过 → 上次生成日 + interval**(月/年按目标日推进)。
+  DateTime? calculateNextDate(RecurringTransaction recurring, {DateTime? now}) {
+    final nowTs = now ?? DateTime.now();
     final lastGenerated = recurring.lastGeneratedDate;
     final frequency = RecurringFrequency.fromString(recurring.frequency);
     final interval = recurring.interval;
+    final firstGen = lastGenerated == null;
 
     // 如果有结束日期且已过期，返回null
-    if (recurring.endDate != null && now.isAfter(recurring.endDate!)) {
+    if (recurring.endDate != null && nowTs.isAfter(recurring.endDate!)) {
+      logger.info(_tag,
+          'calc id=${recurring.id} 跳过:已过结束日期 endDate=${recurring.endDate}');
       return null;
     }
 
     // 基准日期：最后生成日期 或 开始日期。
     // 防止历史开始日期回溯补生成脏数据(issue #135):从未生成过(lastGenerated
-    // 为 null)的周期账单,基准不早于今天零点,只面向未来生成,不补创建之前的历史。
-    final todayStart = DateTime(now.year, now.month, now.day);
+    // 为 null)的周期账单,基准不早于今天零点,只生成"今天"这一笔,不补历史。
+    final todayStart = DateTime(nowTs.year, nowTs.month, nowTs.day);
     final rawBase = lastGenerated ?? recurring.startDate;
-    final baseDate = lastGenerated == null && rawBase.isBefore(todayStart)
-        ? todayStart
-        : rawBase;
+    final baseDate =
+        firstGen && rawBase.isBefore(todayStart) ? todayStart : rawBase;
 
     DateTime nextDate;
     switch (frequency) {
       case RecurringFrequency.daily:
-        nextDate = baseDate.add(Duration(days: interval));
+        // 首笔=基准日(含今天);之后=上次+interval 天
+        nextDate =
+            firstGen ? baseDate : baseDate.add(Duration(days: interval));
         break;
 
       case RecurringFrequency.weekly:
-        nextDate = baseDate.add(Duration(days: 7 * interval));
+        nextDate =
+            firstGen ? baseDate : baseDate.add(Duration(days: 7 * interval));
         break;
 
       case RecurringFrequency.monthly:
-        // 月度重复：使用指定的日期
+        // 月度重复：落在指定的"几号"。首笔取基准月当月,之后推进 interval 个月。
         final targetDay = recurring.dayOfMonth ?? baseDate.day;
-        var year = baseDate.year;
-        var month = baseDate.month + interval;
-
-        // 处理月份溢出
-        while (month > 12) {
-          month -= 12;
-          year += 1;
+        DateTime buildMonthly(int year, int month) {
+          while (month > 12) {
+            month -= 12;
+            year += 1;
+          }
+          // 处理不存在的日期（如2月30日）
+          final daysInMonth = DateTime(year, month + 1, 0).day;
+          final day = targetDay > daysInMonth ? daysInMonth : targetDay;
+          return DateTime(year, month, day);
         }
 
-        // 处理不存在的日期（如2月30日）
-        final daysInMonth = DateTime(year, month + 1, 0).day;
-        final day = targetDay > daysInMonth ? daysInMonth : targetDay;
-
-        nextDate = DateTime(year, month, day);
+        nextDate = buildMonthly(baseDate.year, baseDate.month + (firstGen ? 0 : interval));
+        // 首笔:若当月目标日早于基准(本月已过)→ 顺延一个 interval 月,避免回溯
+        if (firstGen && nextDate.isBefore(baseDate)) {
+          nextDate = buildMonthly(baseDate.year, baseDate.month + interval);
+        }
         break;
 
       case RecurringFrequency.yearly:
         // 年度重复
         final targetMonth = recurring.monthOfYear ?? baseDate.month;
         final targetDay = recurring.dayOfMonth ?? baseDate.day;
-        var year = baseDate.year + interval;
+        DateTime buildYearly(int year) {
+          // 处理闰年2月29日
+          final daysInMonth = DateTime(year, targetMonth + 1, 0).day;
+          final day = targetDay > daysInMonth ? daysInMonth : targetDay;
+          return DateTime(year, targetMonth, day);
+        }
 
-        // 处理闰年2月29日
-        final daysInMonth = DateTime(year, targetMonth + 1, 0).day;
-        final day = targetDay > daysInMonth ? daysInMonth : targetDay;
-
-        nextDate = DateTime(year, targetMonth, day);
+        nextDate = buildYearly(baseDate.year + (firstGen ? 0 : interval));
+        // 首笔:若当年目标日早于基准(今年已过)→ 顺延 interval 年
+        if (firstGen && nextDate.isBefore(baseDate)) {
+          nextDate = buildYearly(baseDate.year + interval);
+        }
         break;
     }
 
-    // 如果下一次日期还没到，返回null
-    if (nextDate.isAfter(now)) {
+    // 如果下一次日期还没到，返回null(注意:当天 00:00 <= now,故"今天"会通过)
+    if (nextDate.isAfter(nowTs)) {
+      logger.info(_tag,
+          'calc id=${recurring.id} freq=${frequency.value} interval=$interval firstGen=$firstGen base=$baseDate → next=$nextDate 尚未到期(>now=$nowTs),本次不生成');
       return null;
     }
 
     // 如果超过结束日期，返回null
     if (recurring.endDate != null && nextDate.isAfter(recurring.endDate!)) {
+      logger.info(_tag,
+          'calc id=${recurring.id} next=$nextDate 超过结束日期 ${recurring.endDate},不生成');
       return null;
     }
 
+    logger.info(_tag,
+        'calc id=${recurring.id} freq=${frequency.value} interval=$interval firstGen=$firstGen base=$baseDate lastGen=$lastGenerated → 生成 next=$nextDate');
     return nextDate;
   }
 
   /// 生成待处理的交易记录
   Future<List<Transaction>> generatePendingTransactions() async {
-    print('🔧 [RecurringTransactionService] 开始生成待处理的交易记录');
+    final nowStr = DateTime.now().toString();
+    logger.info(_tag, '开始扫描周期交易 (now=$nowStr)');
 
-    print('🔧 [RecurringTransactionService] 正在获取所有账本...');
     final ledgers = await repository.getAllLedgers();
-    print('✅ [RecurringTransactionService] 获取到 ${ledgers.length} 个账本');
+    logger.info(_tag, '获取到 ${ledgers.length} 个账本');
 
     final generatedTransactions = <Transaction>[];
 
     for (final ledger in ledgers) {
-      print('🔧 [RecurringTransactionService] 处理账本: ${ledger.name} (id=${ledger.id})');
-
       // 获取所有启用的周期交易
-      print('🔧 [RecurringTransactionService] 正在获取周期交易...');
       final allRecurring = await repository.getAllRecurringTransactions();
-      print('✅ [RecurringTransactionService] 获取到 ${allRecurring.length} 个周期交易');
-
       final recurringList = allRecurring
           .where((r) => r.ledgerId == ledger.id && r.enabled)
           .toList();
-      print('📋 [RecurringTransactionService] 账本 ${ledger.name} 中有 ${recurringList.length} 个启用的周期交易');
+      if (recurringList.isEmpty) continue;
+      logger.info(_tag,
+          '账本「${ledger.name}」(id=${ledger.id}) 有 ${recurringList.length} 个启用的周期交易');
 
       for (final recurring in recurringList) {
-        print('🔧 [RecurringTransactionService] 处理周期交易: id=${recurring.id}');
+        logger.info(_tag,
+            '处理周期交易 id=${recurring.id} freq=${recurring.frequency} interval=${recurring.interval} start=${recurring.startDate} end=${recurring.endDate} lastGen=${recurring.lastGeneratedDate}');
         // 循环生成所有缺失的交易记录
         var currentRecurring = recurring;
+        var loopGuard = 0;
         while (true) {
+          // 防御:任何情况下单条周期交易一次扫描不应生成上千笔 —— 拦截死循环
+          if (++loopGuard > 1000) {
+            logger.warning(_tag,
+                '周期交易 id=${recurring.id} 单次生成超过 1000 笔,强制中止以防死循环');
+            break;
+          }
           final nextDate = calculateNextDate(currentRecurring);
           if (nextDate == null) break;
+
+          logger.info(_tag,
+              '周期交易 id=${currentRecurring.id} 生成一笔: happenedAt=$nextDate amount=${currentRecurring.amount} type=${currentRecurring.type}');
 
           // 生成交易记录
           final transactionId = await repository.addTransaction(

--- a/test/services/data/recurring_transaction_service_test.dart
+++ b/test/services/data/recurring_transaction_service_test.dart
@@ -1,9 +1,13 @@
 // RecurringTransactionService 生成逻辑回归测试。
 //
-// 锁死 issue #135:历史开始日期不再回溯补生成脏数据。
+// 锁死两件事:
+//  1. issue #135:历史开始日期不回溯补生成脏数据(从未生成只产出"今天"一笔)。
+//  2. 2026-06「每天周期不生效」修复:从未生成过的周期账单首笔落在"今天"(含今天),
+//     而非被推到明天导致永远不触发。
 
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:beecount/data/db.dart';
 import 'package:beecount/data/repositories/local/local_repository.dart';
@@ -17,6 +21,9 @@ void main() {
   late int ledgerId;
 
   setUp(() async {
+    // LoggerService(被周期服务调用)内部走 SharedPreferences,单测需提供 mock,
+    // 否则 logger.info 触发 MissingPluginException 让测试在完成后异步失败。
+    SharedPreferences.setMockInitialValues({});
     db = BeeDatabase.forTesting(NativeDatabase.memory());
     repo = LocalRepository(db);
     ledgerId = await repo.createLedger(name: 'test', currency: 'CNY');
@@ -26,10 +33,19 @@ void main() {
     await db.close();
   });
 
-  test('历史开始日期 + 从未生成 → 不回溯补历史账单(issue #135)', () async {
-    // daily 周期账单,开始日期在 30 天前,lastGeneratedDate 为 null。
-    // 修复前:会从 startDate 一路补到今天(约 30 笔脏数据);
-    // 修复后:基准锁定今天零点,daily 第一笔落在明天(未来),本次不生成。
+  // 断言某 DateTime 是"今天"(本地零点)。
+  void expectIsToday(DateTime d) {
+    final now = DateTime.now();
+    expect(d.year, now.year);
+    expect(d.month, now.month);
+    expect(d.day, now.day);
+  }
+
+  test('历史开始日期(30天前)+ 从未生成 → 只产出今天一笔,不回溯补历史(#135 + 含今天)',
+      () async {
+    // 修复前(老 bug):base 锁今天、daily 首笔=明天 → isAfter(now) → 一笔都不生成,
+    // 且 lastGeneratedDate 永远为 null → 永久卡死("每天周期不生效")。
+    // 修复后:首笔=基准日(今天),生成且仅生成"今天"这一笔,不补 30 天历史。
     await repo.addRecurringTransaction(
       ledgerId: ledgerId,
       type: 'expense',
@@ -42,12 +58,30 @@ void main() {
     final service = RecurringTransactionService(repo);
     final generated = await service.generatePendingTransactions();
 
-    expect(generated, isEmpty);
+    expect(generated, hasLength(1)); // 仅今天,不是 30 笔,也不是 0 笔
+    expectIsToday(generated.first.happenedAt);
   });
 
-  test('已生成过(lastGeneratedDate 非空)→ 正常 catch-up 不受影响', () async {
-    // 开始 30 天前、昨天生成过一笔的 daily 账单:应正常补出"今天"这一笔,
-    // 证明历史保护只拦"从未生成"的回溯,不误伤正常的错过补齐。
+  test('开始日期=昨天 + 从未生成 → 今天打开生成今天一笔(用户反馈场景)', () async {
+    // 用户反馈:起始时间设为昨天,今天打开无法生成 —— 同一根因。
+    // 修复后:生成"今天"这一笔(昨天那笔按 #135 不回溯)。
+    await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now().subtract(const Duration(days: 1)),
+    );
+
+    final service = RecurringTransactionService(repo);
+    final generated = await service.generatePendingTransactions();
+
+    expect(generated, hasLength(1));
+    expectIsToday(generated.first.happenedAt);
+  });
+
+  test('已生成过(lastGeneratedDate=昨天)→ 正常补出今天一笔', () async {
     final id = await repo.addRecurringTransaction(
       ledgerId: ledgerId,
       type: 'expense',
@@ -66,5 +100,41 @@ void main() {
 
     // 昨天 → 今天一笔(daily);明天还没到,停在这。
     expect(generated, hasLength(1));
+    expectIsToday(generated.first.happenedAt);
+  });
+
+  test('今天已生成过(lastGeneratedDate=今天)→ 不重复生成', () async {
+    final id = await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now().subtract(const Duration(days: 30)),
+    );
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    await repo.updateLastGeneratedDate(id, today);
+
+    final service = RecurringTransactionService(repo);
+    final generated = await service.generatePendingTransactions();
+
+    expect(generated, isEmpty); // 今天已生成,明天才下一笔
+  });
+
+  test('开始日期在未来(明天)→ 今天不生成', () async {
+    await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now().add(const Duration(days: 1)),
+    );
+
+    final service = RecurringTransactionService(repo);
+    final generated = await service.generatePendingTransactions();
+
+    expect(generated, isEmpty); // 未来开始,首笔在明天
   });
 }


### PR DESCRIPTION
## 问题(用户反馈)

「每天」周期记账无法生效;补充场景:起始日期设为昨天、今天打开也不生成。

## 根因

`calculateNextDate` 对**从未生成过**(`lastGeneratedDate == null`)的周期账单,基准日被 #135 反回溯逻辑钳到「今天零点」,却仍执行 `base + interval` → daily 首笔算成**明天**,`nextDate.isAfter(now)` → 返回 null,一笔不生成;又因从未生成,`lastGeneratedDate` 永远为 null → **永久卡死**。起始日=昨天同理(昨天 < 今天零点 → 钳到今天 → +1 天 = 明天 → null)。

## 修复

1. **首笔包含今天**:从未生成过时,首笔 = 基准日**本身**(不再 `+interval`)。基准日仍受 #135 保护(不早于今天零点),所以:
   - 既「包含今天」(daily/weekly 首笔落今天,月/年首笔落当期目标日,`<= now` 即生成),
   - 又「不回溯补历史」(起始日在过去只产出**今天一笔**,不补 30 天)。
   - 已生成过的照旧 `上次生成日 + interval`,行为不变。
   - 月/年:首笔若当期目标日已过则顺延一个 interval 周期,避免回溯。
2. **详细日志辅助排查**:`print` 全部改为 `logger`(进应用内日志中心、可导出),并补充每条周期账单的决策日志 —— `calc id=… freq=… firstGen=… base=… → 生成/不生成(原因)`,外加单次生成 >1000 笔的死循环防御。

## 测试

`recurring_transaction_service_test.dart` 扩为 5 例,锁死:
- 起始 30 天前 + 从未生成 → **恰好 1 笔、日期为今天**(既非 0 也非 30);
- **起始=昨天 + 从未生成 → 今天 1 笔**(用户反馈场景);
- 已生成=昨天 → 补今天 1 笔;
- 已生成=今天 → 不重复;
- 起始=明天 → 不生成。

`flutter test` 276 通过(唯一失败 `bill_creation_service_test` 账户重名,main 上同样失败、无关);analyze 无新增问题。

> 注:起始日在过去的周期账单首笔统一落「今天」(昨天及更早不回溯,延续 #135)。