### PR TITLE
feat: 货币列表扩充至全量 ISO 4217(151 种)

### DIFF
--- a/lib/utils/currencies.dart
+++ b/lib/utils/currencies.dart
@@ -7,74 +7,185 @@ class CurrencyInfo {
   const CurrencyInfo(this.code, this.name);
 }
 
-/// 货币定义：code + symbol，单一数据源
-class _Def {
+/// 货币定义：code + symbol + 英文名（单一数据源）。
+/// 英文名来自 ISO 4217 / 汇率源（fawaz currency-api,覆盖全部 151 币),作为
+/// 长尾币种的兜底显示名;主流币种另有本地化名覆盖(见 [_buildNameMap])。
+/// symbol 长尾币种回退为 code。
+class _Cur {
   final String code;
   final String symbol;
-  const _Def(this.code, this.symbol);
+  final String enName;
+  const _Cur(this.code, this.symbol, this.enName);
 }
 
-/// 所有支持的货币（唯一定义处，新增货币只需在此追加）
-const List<_Def> _kCurrencyDefs = [
-  // 东亚
-  _Def('CNY', '¥'),
-  _Def('JPY', '¥'),
-  _Def('KRW', '₩'),
-  _Def('HKD', 'HK\$'),
-  _Def('TWD', 'NT\$'),
-  // 东南亚
-  _Def('SGD', 'S\$'),
-  _Def('MYR', 'RM'),
-  _Def('THB', '฿'),
-  _Def('IDR', 'Rp'),
-  _Def('PHP', '₱'),
-  _Def('VND', '₫'),
-  _Def('MMK', 'K'),
-  // 南亚
-  _Def('INR', '₹'),
-  _Def('PKR', '₨'),
-  _Def('BDT', '৳'),
-  _Def('LKR', 'Rs'),
-  // 中亚
-  _Def('KZT', '₸'),
-  // 西亚 / 中东
-  _Def('AED', 'د.إ'),
-  _Def('SAR', '﷼'),
-  _Def('ILS', '₪'),
-  _Def('TRY', '₺'),
-  // 欧洲
-  _Def('EUR', '€'),
-  _Def('GBP', '£'),
-  _Def('CHF', 'CHF'),
-  _Def('SEK', 'kr'),
-  _Def('NOK', 'kr'),
-  _Def('DKK', 'kr'),
-  _Def('PLN', 'zł'),
-  _Def('CZK', 'Kč'),
-  _Def('HUF', 'Ft'),
-  _Def('RUB', '₽'),
-  _Def('BYN', 'Br'),
-  _Def('UAH', '₴'),
-  // 北美
-  _Def('USD', '\$'),
-  _Def('CAD', 'C\$'),
-  _Def('MXN', 'MX\$'),
-  // 南美
-  _Def('BRL', 'R\$'),
-  _Def('ARS', '\$'),
-  _Def('CLP', '\$'),
-  _Def('COP', '\$'),
-  _Def('PEN', 'S/'),
-  // 大洋洲
-  _Def('AUD', 'A\$'),
-  _Def('NZD', 'NZ\$'),
-  // 非洲
-  _Def('ZAR', 'R'),
-  _Def('EGP', 'E£'),
-  _Def('NGN', '₦'),
+/// 所有支持的货币（唯一定义处,按地区分组;新增货币只需在此追加一行）。
+/// 覆盖 ISO 4217 通行币种,全部在汇率源 fawaz currency-api 有报价。
+const List<_Cur> _kCurrencyDefs = [
+  // eastAsia
+  _Cur('CNY', '¥', 'Chinese Yuan'),
+  _Cur('JPY', '¥', 'Japanese Yen'),
+  _Cur('KRW', '₩', 'South Korean Won'),
+  _Cur('HKD', 'HK\$', 'Hong Kong Dollar'),
+  _Cur('TWD', 'NT\$', 'New Taiwan Dollar'),
+  _Cur('MOP', 'MOP\$', 'Macau Pataca'),
+  _Cur('MNT', '₮', 'Mongolian Tughrik'),
+  _Cur('KPW', 'KPW', 'North Korean Won'),
+  // southeastAsia
+  _Cur('SGD', 'S\$', 'Singapore Dollar'),
+  _Cur('MYR', 'RM', 'Malaysian Ringgit'),
+  _Cur('THB', '฿', 'Thai Baht'),
+  _Cur('IDR', 'Rp', 'Indonesian Rupiah'),
+  _Cur('PHP', '₱', 'Philippine Peso'),
+  _Cur('VND', '₫', 'Vietnamese Dong'),
+  _Cur('MMK', 'K', 'Myanmar Kyat'),
+  _Cur('KHR', '៛', 'Cambodian Riel'),
+  _Cur('LAK', '₭', 'Lao Kip'),
+  _Cur('BND', 'BND', 'Bruneian Dollar'),
+  // southAsia
+  _Cur('INR', '₹', 'Indian Rupee'),
+  _Cur('PKR', '₨', 'Pakistani Rupee'),
+  _Cur('BDT', '৳', 'Bangladeshi Taka'),
+  _Cur('LKR', 'Rs', 'Sri Lankan Rupee'),
+  _Cur('NPR', '₨', 'Nepalese Rupee'),
+  _Cur('BTN', 'BTN', 'Bhutanese Ngultrum'),
+  _Cur('MVR', 'MVR', 'Maldivian Rufiyaa'),
+  _Cur('AFN', 'AFN', 'Afghan Afghani'),
+  // centralAsia
+  _Cur('KZT', '₸', 'Kazakhstani Tenge'),
+  _Cur('UZS', 'UZS', 'Uzbekistani Som'),
+  _Cur('TJS', 'TJS', 'Tajikistani Somoni'),
+  _Cur('TMT', 'TMT', 'Turkmenistani Manat'),
+  _Cur('KGS', 'KGS', 'Kyrgyzstani Som'),
+  // middleEast
+  _Cur('AED', 'د.إ', 'Emirati Dirham'),
+  _Cur('SAR', '﷼', 'Saudi Arabian Riyal'),
+  _Cur('ILS', '₪', 'Israeli Shekel'),
+  _Cur('TRY', '₺', 'Turkish Lira'),
+  _Cur('QAR', '﷼', 'Qatari Riyal'),
+  _Cur('KWD', 'د.ك', 'Kuwaiti Dinar'),
+  _Cur('BHD', '.د.ب', 'Bahraini Dinar'),
+  _Cur('OMR', '﷼', 'Omani Rial'),
+  _Cur('JOD', 'د.ا', 'Jordanian Dinar'),
+  _Cur('LBP', 'LBP', 'Lebanese Pound'),
+  _Cur('IQD', 'IQD', 'Iraqi Dinar'),
+  _Cur('IRR', 'IRR', 'Iranian Rial'),
+  _Cur('YER', 'YER', 'Yemeni Rial'),
+  _Cur('SYP', 'SYP', 'Syrian Pound'),
+  _Cur('GEL', '₾', 'Georgian Lari'),
+  _Cur('AMD', '֏', 'Armenian Dram'),
+  _Cur('AZN', '₼', 'Azerbaijan Manat'),
+  // europe
+  _Cur('EUR', '€', 'Euro'),
+  _Cur('GBP', '£', 'British Pound'),
+  _Cur('CHF', 'CHF', 'Swiss Franc'),
+  _Cur('SEK', 'kr', 'Swedish Krona'),
+  _Cur('NOK', 'kr', 'Norwegian Krone'),
+  _Cur('DKK', 'kr', 'Danish Krone'),
+  _Cur('PLN', 'zł', 'Polish Zloty'),
+  _Cur('CZK', 'Kč', 'Czech Koruna'),
+  _Cur('HUF', 'Ft', 'Hungarian Forint'),
+  _Cur('RUB', '₽', 'Russian Ruble'),
+  _Cur('BYN', 'Br', 'Belarusian Ruble'),
+  _Cur('UAH', '₴', 'Ukrainian Hryvnia'),
+  _Cur('RON', 'lei', 'Romanian Leu'),
+  _Cur('BGN', 'лв', 'Bulgarian Lev'),
+  _Cur('RSD', 'RSD', 'Serbian Dinar'),
+  _Cur('ISK', 'kr', 'Icelandic Krona'),
+  _Cur('MDL', 'MDL', 'Moldovan Leu'),
+  _Cur('ALL', 'ALL', 'Albanian Lek'),
+  _Cur('MKD', 'MKD', 'Macedonian Denar'),
+  _Cur('BAM', 'BAM', 'Bosnian Convertible Mark'),
+  _Cur('GIP', 'GIP', 'Gibraltar Pound'),
+  // northAmerica
+  _Cur('USD', '\$', 'US Dollar'),
+  _Cur('CAD', 'C\$', 'Canadian Dollar'),
+  _Cur('MXN', 'MX\$', 'Mexican Peso'),
+  // centralAmericaCaribbean
+  _Cur('GTQ', 'GTQ', 'Guatemalan Quetzal'),
+  _Cur('HNL', 'HNL', 'Honduran Lempira'),
+  _Cur('NIO', 'NIO', 'Nicaraguan Cordoba'),
+  _Cur('CRC', 'CRC', 'Costa Rican Colon'),
+  _Cur('PAB', 'PAB', 'Panamanian Balboa'),
+  _Cur('DOP', 'DOP', 'Dominican Peso'),
+  _Cur('CUP', 'CUP', 'Cuban Peso'),
+  _Cur('JMD', 'J\$', 'Jamaican Dollar'),
+  _Cur('TTD', 'TT\$', 'Trinidadian Dollar'),
+  _Cur('BSD', 'BSD', 'Bahamian Dollar'),
+  _Cur('BBD', 'BBD', 'Barbadian or Bajan Dollar'),
+  _Cur('BZD', 'BZD', 'Belizean Dollar'),
+  _Cur('HTG', 'HTG', 'Haitian Gourde'),
+  _Cur('XCD', 'EC\$', 'East Caribbean Dollar'),
+  _Cur('KYD', 'KYD', 'Caymanian Dollar'),
+  _Cur('AWG', 'AWG', 'Aruban or Dutch Guilder'),
+  _Cur('ANG', 'ANG', 'Dutch Guilder'),
+  _Cur('BMD', 'BMD', 'Bermudian Dollar'),
+  // southAmerica
+  _Cur('BRL', 'R\$', 'Brazilian Real'),
+  _Cur('ARS', '\$', 'Argentine Peso'),
+  _Cur('CLP', '\$', 'Chilean Peso'),
+  _Cur('COP', '\$', 'Colombian Peso'),
+  _Cur('PEN', 'S/', 'Peruvian Sol'),
+  _Cur('UYU', '\$U', 'Uruguayan Peso'),
+  _Cur('PYG', '₲', 'Paraguayan Guarani'),
+  _Cur('BOB', 'Bs', 'Bolivian Bolíviano'),
+  _Cur('VES', 'VES', 'Venezuelan Bolívar'),
+  _Cur('GYD', 'GYD', 'Guyanese Dollar'),
+  _Cur('SRD', 'SRD', 'Surinamese Dollar'),
+  // oceania
+  _Cur('AUD', 'A\$', 'Australian Dollar'),
+  _Cur('NZD', 'NZ\$', 'New Zealand Dollar'),
+  _Cur('FJD', 'FJ\$', 'Fijian Dollar'),
+  _Cur('PGK', 'PGK', 'Papua New Guinean Kina'),
+  _Cur('SBD', 'SBD', 'Solomon Islander Dollar'),
+  _Cur('TOP', 'TOP', 'Tongan Pa\'anga'),
+  _Cur('VUV', 'VUV', 'Ni-Vanuatu Vatu'),
+  _Cur('WST', 'WST', 'Samoan Tala'),
+  _Cur('XPF', '₣', 'CFP Franc'),
+  // africa
+  _Cur('ZAR', 'R', 'South African Rand'),
+  _Cur('EGP', 'E£', 'Egyptian Pound'),
+  _Cur('NGN', '₦', 'Nigerian Naira'),
+  _Cur('KES', 'KSh', 'Kenyan Shilling'),
+  _Cur('GHS', '₵', 'Ghanaian Cedi'),
+  _Cur('MAD', 'DH', 'Moroccan Dirham'),
+  _Cur('DZD', 'DZD', 'Algerian Dinar'),
+  _Cur('TND', 'TND', 'Tunisian Dinar'),
+  _Cur('LYD', 'LYD', 'Libyan Dinar'),
+  _Cur('ETB', 'ETB', 'Ethiopian Birr'),
+  _Cur('UGX', 'USh', 'Ugandan Shilling'),
+  _Cur('TZS', 'TSh', 'Tanzanian Shilling'),
+  _Cur('RWF', 'RWF', 'Rwandan Franc'),
+  _Cur('XAF', 'XAF', 'Central African CFA Franc'),
+  _Cur('XOF', 'XOF', 'West African CFA Franc'),
+  _Cur('MUR', '₨', 'Mauritian Rupee'),
+  _Cur('BWP', 'BWP', 'Botswana Pula'),
+  _Cur('NAD', 'N\$', 'Namibian Dollar'),
+  _Cur('ZMW', 'ZMW', 'Zambian Kwacha'),
+  _Cur('MWK', 'MWK', 'Malawian Kwacha'),
+  _Cur('MZN', 'MZN', 'Mozambican Metical'),
+  _Cur('AOA', 'AOA', 'Angolan Kwanza'),
+  _Cur('CDF', 'CDF', 'Congolese Franc'),
+  _Cur('GMD', 'GMD', 'Gambian Dalasi'),
+  _Cur('GNF', 'GNF', 'Guinean Franc'),
+  _Cur('LRD', 'LRD', 'Liberian Dollar'),
+  _Cur('SLE', 'SLE', 'Sierra Leonean Leone'),
+  _Cur('SDG', 'SDG', 'Sudanese Pound'),
+  _Cur('SSP', 'SSP', 'South Sudanese Pound'),
+  _Cur('SOS', 'SOS', 'Somali Shilling'),
+  _Cur('DJF', 'DJF', 'Djiboutian Franc'),
+  _Cur('ERN', 'ERN', 'Eritrean Nakfa'),
+  _Cur('BIF', 'BIF', 'Burundian Franc'),
+  _Cur('CVE', 'CVE', 'Cape Verdean Escudo'),
+  _Cur('STN', 'STN', 'Sao Tomean Dobra'),
+  _Cur('SCR', 'SCR', 'Seychellois Rupee'),
+  _Cur('KMF', 'KMF', 'Comorian Franc'),
+  _Cur('LSL', 'LSL', 'Basotho Loti'),
+  _Cur('SZL', 'SZL', 'Swazi Lilangeni'),
+  _Cur('MGA', 'MGA', 'Malagasy Ariary'),
+  _Cur('MRU', 'MRU', 'Mauritanian Ouguiya'),
 ];
 
-/// 货币代码列表（自动派生，无需手动维护）
+/// 货币代码列表（自动派生,无需手动维护）
 final List<String> kCurrencyCodes =
     _kCurrencyDefs.map((d) => d.code).toList();
 
@@ -83,35 +194,42 @@ final Map<String, String> _symbolMap = {
   for (final d in _kCurrencyDefs) d.code: d.symbol,
 };
 
-/// 获取本地化的货币信息列表
+/// 英文名查找表（自动派生,长尾币种的兜底显示名）
+final Map<String, String> _enNameMap = {
+  for (final d in _kCurrencyDefs) d.code: d.enName,
+};
+
+/// 获取本地化的货币信息列表。
+/// 名称优先用本地化覆盖(主流币种,见 [_buildNameMap]),长尾币种回退英文名。
 List<CurrencyInfo> getCurrencies(BuildContext context) {
-  final nameMap = _buildNameMap(context);
+  final overrides = _buildNameMap(context);
   return _kCurrencyDefs
-      .map((d) => CurrencyInfo(d.code, nameMap[d.code] ?? d.code))
+      .map((d) => CurrencyInfo(d.code, overrides[d.code] ?? d.enName))
       .toList();
 }
 
 String displayCurrency(String code, BuildContext context) {
-  final currencies = getCurrencies(context);
-  final m = currencies.where((c) => c.code == code).toList();
-  if (m.isEmpty) return code;
-  return '${m.first.name} (${m.first.code})';
+  final name = getCurrencyName(code, context);
+  return '$name ($code)';
 }
 
-/// 获取指定货币代码的本地化名称
+/// 获取指定货币代码的本地化名称(无本地化覆盖时回退英文名,再回退 code)。
 String getCurrencyName(String code, BuildContext context) {
-  final currencies = getCurrencies(context);
-  final m = currencies.where((c) => c.code == code).toList();
-  if (m.isEmpty) return code;
-  return m.first.name;
+  final overrides = _buildNameMap(context);
+  final upper = code.toUpperCase();
+  return overrides[upper] ?? _enNameMap[upper] ?? code;
 }
 
-/// 获取币种符号
+/// 获取币种的英文名(不依赖 context;长尾币种兜底名)。未知 code 回退自身。
+String currencyEnglishName(String code) =>
+    _enNameMap[code.toUpperCase()] ?? code;
+
+/// 获取币种符号(长尾币种回退为 code)
 String getCurrencySymbol(String code) {
   return _symbolMap[code.toUpperCase()] ?? code;
 }
 
-/// l10n 名称映射（新增货币需在此和 arb 文件各加一行）
+/// l10n 本地化名称覆盖映射(仅主流币种;长尾币种用英文名兜底,无需在此登记)。
 Map<String, String> _buildNameMap(BuildContext context) {
   final l10n = AppLocalizations.of(context);
   return {

--- a/test/utils/currencies_test.dart
+++ b/test/utils/currencies_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:beecount/utils/currencies.dart';
+
+void main() {
+  group('currencies 全量 ISO 4217', () {
+    test('覆盖全部币种且含 issue#273 请求的 KES/XAF/XOF', () {
+      expect(kCurrencyCodes.length, 151);
+      expect(kCurrencyCodes, containsAll(['KES', 'XAF', 'XOF']));
+      // 原有主流币种仍在
+      expect(kCurrencyCodes, containsAll(['CNY', 'USD', 'EUR', 'JPY', 'GBP']));
+    });
+
+    test('code 无重复', () {
+      expect(kCurrencyCodes.toSet().length, kCurrencyCodes.length);
+    });
+
+    test('英文名兜底表覆盖长尾币种,未知 code 回退自身', () {
+      expect(currencyEnglishName('KES'), 'Kenyan Shilling');
+      expect(currencyEnglishName('XOF'), 'West African CFA Franc');
+      expect(currencyEnglishName('kes'), 'Kenyan Shilling'); // 大小写不敏感
+      expect(currencyEnglishName('ZZZ'), 'ZZZ'); // 未知回退 code
+    });
+
+    test('符号:已知币种给符号,长尾币种回退 code', () {
+      expect(getCurrencySymbol('USD'), '\$');
+      expect(getCurrencySymbol('CNY'), '¥');
+      expect(getCurrencySymbol('KES'), 'KSh');
+      expect(getCurrencySymbol('BWP'), 'BWP'); // 无专属符号,回退 code
+      expect(getCurrencySymbol('ZZZ'), 'ZZZ'); // 未知回退 code
+    });
+  });
+}


### PR DESCRIPTION
Closes #273

## 背景
#273 反馈币种不全(缺 KES 等),并希望支持自定义币种。按讨论结论:**补齐全量币种,不做自定义币种**。

## 改动
- 币种从 45 种扩充到 **151 种**,覆盖通行 ISO 4217(含 KES、XAF、XOF 等),按地区分组。
- 单一数据源 `_kCurrencyDefs`(code + symbol + 英文名)。主流币种保留原有中文 / 繁中本地化名;长尾币种用标准英文名兜底;符号缺失时回退 code。
- 汇率源 fawaz currency-api 已覆盖全部 151 种,折算正常(无新增网络依赖)。
- 公开 API(`getCurrencies` / `getCurrencySymbol` / `kCurrencyCodes` / `displayCurrency`)签名不变,调用方无需改动。

## 不做
- 自定义币种(按 issue 讨论结论排除)。

## 测试
- 新增 `test/utils/currencies_test.dart`:数量 / 去重 / 英文名兜底 / 符号回退,4/4 通过。
- `flutter analyze` 无新增 issue(与 main 基线持平 838)。

> Web 端同步 PR:TNT-Likely/BeeCount-Cloud#55