### PR TITLE
feat: 云同步页新增同步说明(增量/全量/断点续传/排查)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2822,6 +2822,16 @@
   "cloudCollabScopeDeniedAction": "Set ALLOW_APP_RW_SCOPES=true in server .env, restart the service, then sign in again.",
 
   "syncHealthTitle": "Sync status",
+  "cloudSyncHelpTitle": "How sync works · Why it sometimes stalls",
+  "cloudSyncHelpModesTitle": "Three sync modes",
+  "cloudSyncHelpModesBody": "• Incremental (automatic, everyday): after you add or edit an entry, only that change is uploaded/downloaded automatically — fast, no manual action. This is what runs all the time.\n• Full upload: the first time you enable cloud sync, or when the cloud has no data for this ledger yet, all local data is pushed to the cloud at once.\n• Full download: on a new device, after a reinstall, or when local is empty, all data is pulled down from the cloud.",
+  "cloudSyncHelpWhenFullTitle": "When does a full sync happen?",
+  "cloudSyncHelpWhenFullBody": "A full sync only triggers automatically when one side is empty (first enabling cloud sync / new device / reinstall / after clearing local or cloud data). As long as both sides have data, sync stays incremental and never restarts on its own. To force a full re-sync, you must first clear the data on the corresponding side.",
+  "cloudSyncHelpStuckTitle": "Why sync sometimes stalls",
+  "cloudSyncHelpStuckBody": "• Full upload/download does NOT support resume: if the network drops or the app is killed in the background, it starts over from scratch instead of continuing. For large data, use a stable network (Wi-Fi recommended) and let it finish without switching away.\n• Incremental sync is resume-safe and unaffected in everyday use.",
+  "cloudSyncHelpTroubleshootTitle": "Troubleshooting",
+  "cloudSyncHelpTroubleshootBody": "• First, pull down on this page to run a Deep Check and compare local vs cloud.\n• Still stuck? Open the Log Center to view sync logs (including failure reasons) for reporting.",
+  "cloudSyncHelpOpenLogCenter": "Open Log Center",
   "syncHealthCheckFailed": "Check failed: {msg}",
   "@syncHealthCheckFailed": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11952,6 +11952,66 @@ abstract class AppLocalizations {
   /// **'Sync status'**
   String get syncHealthTitle;
 
+  /// No description provided for @cloudSyncHelpTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'How sync works · Why it sometimes stalls'**
+  String get cloudSyncHelpTitle;
+
+  /// No description provided for @cloudSyncHelpModesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Three sync modes'**
+  String get cloudSyncHelpModesTitle;
+
+  /// No description provided for @cloudSyncHelpModesBody.
+  ///
+  /// In en, this message translates to:
+  /// **'• Incremental (automatic, everyday): after you add or edit an entry, only that change is uploaded/downloaded automatically — fast, no manual action. This is what runs all the time.\n• Full upload: the first time you enable cloud sync, or when the cloud has no data for this ledger yet, all local data is pushed to the cloud at once.\n• Full download: on a new device, after a reinstall, or when local is empty, all data is pulled down from the cloud.'**
+  String get cloudSyncHelpModesBody;
+
+  /// No description provided for @cloudSyncHelpWhenFullTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'When does a full sync happen?'**
+  String get cloudSyncHelpWhenFullTitle;
+
+  /// No description provided for @cloudSyncHelpWhenFullBody.
+  ///
+  /// In en, this message translates to:
+  /// **'A full sync only triggers automatically when one side is empty (first enabling cloud sync / new device / reinstall / after clearing local or cloud data). As long as both sides have data, sync stays incremental and never restarts on its own. To force a full re-sync, you must first clear the data on the corresponding side.'**
+  String get cloudSyncHelpWhenFullBody;
+
+  /// No description provided for @cloudSyncHelpStuckTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Why sync sometimes stalls'**
+  String get cloudSyncHelpStuckTitle;
+
+  /// No description provided for @cloudSyncHelpStuckBody.
+  ///
+  /// In en, this message translates to:
+  /// **'• Full upload/download does NOT support resume: if the network drops or the app is killed in the background, it starts over from scratch instead of continuing. For large data, use a stable network (Wi-Fi recommended) and let it finish without switching away.\n• Incremental sync is resume-safe and unaffected in everyday use.'**
+  String get cloudSyncHelpStuckBody;
+
+  /// No description provided for @cloudSyncHelpTroubleshootTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Troubleshooting'**
+  String get cloudSyncHelpTroubleshootTitle;
+
+  /// No description provided for @cloudSyncHelpTroubleshootBody.
+  ///
+  /// In en, this message translates to:
+  /// **'• First, pull down on this page to run a Deep Check and compare local vs cloud.\n• Still stuck? Open the Log Center to view sync logs (including failure reasons) for reporting.'**
+  String get cloudSyncHelpTroubleshootBody;
+
+  /// No description provided for @cloudSyncHelpOpenLogCenter.
+  ///
+  /// In en, this message translates to:
+  /// **'Open Log Center'**
+  String get cloudSyncHelpOpenLogCenter;
+
   /// No description provided for @syncHealthCheckFailed.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6273,6 +6273,36 @@ class AppLocalizationsEn extends AppLocalizations {
   String get syncHealthTitle => 'Sync status';
 
   @override
+  String get cloudSyncHelpTitle => 'How sync works · Why it sometimes stalls';
+
+  @override
+  String get cloudSyncHelpModesTitle => 'Three sync modes';
+
+  @override
+  String get cloudSyncHelpModesBody => '• Incremental (automatic, everyday): after you add or edit an entry, only that change is uploaded/downloaded automatically — fast, no manual action. This is what runs all the time.\n• Full upload: the first time you enable cloud sync, or when the cloud has no data for this ledger yet, all local data is pushed to the cloud at once.\n• Full download: on a new device, after a reinstall, or when local is empty, all data is pulled down from the cloud.';
+
+  @override
+  String get cloudSyncHelpWhenFullTitle => 'When does a full sync happen?';
+
+  @override
+  String get cloudSyncHelpWhenFullBody => 'A full sync only triggers automatically when one side is empty (first enabling cloud sync / new device / reinstall / after clearing local or cloud data). As long as both sides have data, sync stays incremental and never restarts on its own. To force a full re-sync, you must first clear the data on the corresponding side.';
+
+  @override
+  String get cloudSyncHelpStuckTitle => 'Why sync sometimes stalls';
+
+  @override
+  String get cloudSyncHelpStuckBody => '• Full upload/download does NOT support resume: if the network drops or the app is killed in the background, it starts over from scratch instead of continuing. For large data, use a stable network (Wi-Fi recommended) and let it finish without switching away.\n• Incremental sync is resume-safe and unaffected in everyday use.';
+
+  @override
+  String get cloudSyncHelpTroubleshootTitle => 'Troubleshooting';
+
+  @override
+  String get cloudSyncHelpTroubleshootBody => '• First, pull down on this page to run a Deep Check and compare local vs cloud.\n• Still stuck? Open the Log Center to view sync logs (including failure reasons) for reporting.';
+
+  @override
+  String get cloudSyncHelpOpenLogCenter => 'Open Log Center';
+
+  @override
   String syncHealthCheckFailed(String msg) {
     return 'Check failed: $msg';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6273,6 +6273,36 @@ class AppLocalizationsZh extends AppLocalizations {
   String get syncHealthTitle => '同步状态';
 
   @override
+  String get cloudSyncHelpTitle => '同步说明 · 为什么有时同步不动？';
+
+  @override
+  String get cloudSyncHelpModesTitle => '三种同步方式';
+
+  @override
+  String get cloudSyncHelpModesBody => '• 增量同步（日常自动）：记一笔 / 改一笔后，只把这条变化自动上传下载，快、无需手动操作 —— 平时一直在跑的就是它。\n• 全量上传：首次开启云同步、或云端还没有这个账本的数据时，把本地全部数据一次性推上云。\n• 全量下载：换新设备、重装、或本地为空时，从云端把全部数据拉下来。';
+
+  @override
+  String get cloudSyncHelpWhenFullTitle => '什么时候才会走全量？';
+
+  @override
+  String get cloudSyncHelpWhenFullBody => '全量只在某一端数据为空时才会自动触发（首次开启云同步 / 换新设备 / 重装 / 清空了本地或云端数据）。只要两端都有数据，之后一直走增量，不会无故重来。想强制重新全量同步，得先清空对应端的数据。';
+
+  @override
+  String get cloudSyncHelpStuckTitle => '为什么有时同步不动 / 卡住';
+
+  @override
+  String get cloudSyncHelpStuckBody => '• 全量上传 / 下载不支持断点续传：中途断网、或 App 被切到后台被系统杀掉，会从头重来，不会接着传。数据多时请用稳定网络（建议 Wi-Fi）耐心等它跑完，别中途切走。\n• 增量同步是断点安全的，日常同步不受影响。';
+
+  @override
+  String get cloudSyncHelpTroubleshootTitle => '排查办法';
+
+  @override
+  String get cloudSyncHelpTroubleshootBody => '• 先在本页下拉做一次「深度检测」，对比本地与云端差异。\n• 仍有问题，去「日志中心」查看同步日志（含失败原因），方便反馈。';
+
+  @override
+  String get cloudSyncHelpOpenLogCenter => '打开日志中心';
+
+  @override
   String syncHealthCheckFailed(String msg) {
     return '检测失败：$msg';
   }
@@ -13048,6 +13078,36 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get syncHealthTitle => '同步狀態';
+
+  @override
+  String get cloudSyncHelpTitle => '同步說明 · 為什麼有時同步不動？';
+
+  @override
+  String get cloudSyncHelpModesTitle => '三種同步方式';
+
+  @override
+  String get cloudSyncHelpModesBody => '• 增量同步（日常自動）：記一筆 / 改一筆後，只把這條變化自動上傳下載，快、無需手動操作 —— 平時一直在跑的就是它。\n• 全量上傳：首次開啟雲同步、或雲端還沒有這個帳本的資料時，把本機全部資料一次性推上雲。\n• 全量下載：換新裝置、重裝、或本機為空時，從雲端把全部資料拉下來。';
+
+  @override
+  String get cloudSyncHelpWhenFullTitle => '什麼時候才會走全量？';
+
+  @override
+  String get cloudSyncHelpWhenFullBody => '全量只在某一端資料為空時才會自動觸發（首次開啟雲同步 / 換新裝置 / 重裝 / 清空了本機或雲端資料）。只要兩端都有資料，之後一直走增量，不會無故重來。想強制重新全量同步，得先清空對應端的資料。';
+
+  @override
+  String get cloudSyncHelpStuckTitle => '為什麼有時同步不動 / 卡住';
+
+  @override
+  String get cloudSyncHelpStuckBody => '• 全量上傳 / 下載不支援斷點續傳：中途斷網、或 App 被切到背景被系統清掉，會從頭重來，不會接著傳。資料多時請用穩定網路（建議 Wi-Fi）耐心等它跑完，別中途切走。\n• 增量同步是斷點安全的，日常同步不受影響。';
+
+  @override
+  String get cloudSyncHelpTroubleshootTitle => '排查辦法';
+
+  @override
+  String get cloudSyncHelpTroubleshootBody => '• 先在本頁下拉做一次「深度檢測」，對比本機與雲端差異。\n• 仍有問題，去「日誌中心」查看同步日誌（含失敗原因），方便回報。';
+
+  @override
+  String get cloudSyncHelpOpenLogCenter => '開啟日誌中心';
 
   @override
   String syncHealthCheckFailed(String msg) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2769,6 +2769,16 @@
   "cloudCollabScopeDeniedAction": "请在服务端 .env 或部署环境中设置 ALLOW_APP_RW_SCOPES=true，重启服务后重新登录 App。",
 
   "syncHealthTitle": "同步状态",
+  "cloudSyncHelpTitle": "同步说明 · 为什么有时同步不动？",
+  "cloudSyncHelpModesTitle": "三种同步方式",
+  "cloudSyncHelpModesBody": "• 增量同步（日常自动）：记一笔 / 改一笔后，只把这条变化自动上传下载，快、无需手动操作 —— 平时一直在跑的就是它。\n• 全量上传：首次开启云同步、或云端还没有这个账本的数据时，把本地全部数据一次性推上云。\n• 全量下载：换新设备、重装、或本地为空时，从云端把全部数据拉下来。",
+  "cloudSyncHelpWhenFullTitle": "什么时候才会走全量？",
+  "cloudSyncHelpWhenFullBody": "全量只在某一端数据为空时才会自动触发（首次开启云同步 / 换新设备 / 重装 / 清空了本地或云端数据）。只要两端都有数据，之后一直走增量，不会无故重来。想强制重新全量同步，得先清空对应端的数据。",
+  "cloudSyncHelpStuckTitle": "为什么有时同步不动 / 卡住",
+  "cloudSyncHelpStuckBody": "• 全量上传 / 下载不支持断点续传：中途断网、或 App 被切到后台被系统杀掉，会从头重来，不会接着传。数据多时请用稳定网络（建议 Wi-Fi）耐心等它跑完，别中途切走。\n• 增量同步是断点安全的，日常同步不受影响。",
+  "cloudSyncHelpTroubleshootTitle": "排查办法",
+  "cloudSyncHelpTroubleshootBody": "• 先在本页下拉做一次「深度检测」，对比本地与云端差异。\n• 仍有问题，去「日志中心」查看同步日志（含失败原因），方便反馈。",
+  "cloudSyncHelpOpenLogCenter": "打开日志中心",
   "syncHealthCheckFailed": "检测失败：{msg}",
   "@syncHealthCheckFailed": {
     "placeholders": {

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -2472,6 +2472,16 @@
   "cloudCollabScopeDeniedAction": "請在伺服器 .env 或部署環境設定 ALLOW_APP_RW_SCOPES=true，重啟服務後重新登入 App。",
 
   "syncHealthTitle": "同步狀態",
+  "cloudSyncHelpTitle": "同步說明 · 為什麼有時同步不動？",
+  "cloudSyncHelpModesTitle": "三種同步方式",
+  "cloudSyncHelpModesBody": "• 增量同步（日常自動）：記一筆 / 改一筆後，只把這條變化自動上傳下載，快、無需手動操作 —— 平時一直在跑的就是它。\n• 全量上傳：首次開啟雲同步、或雲端還沒有這個帳本的資料時，把本機全部資料一次性推上雲。\n• 全量下載：換新裝置、重裝、或本機為空時，從雲端把全部資料拉下來。",
+  "cloudSyncHelpWhenFullTitle": "什麼時候才會走全量？",
+  "cloudSyncHelpWhenFullBody": "全量只在某一端資料為空時才會自動觸發（首次開啟雲同步 / 換新裝置 / 重裝 / 清空了本機或雲端資料）。只要兩端都有資料，之後一直走增量，不會無故重來。想強制重新全量同步，得先清空對應端的資料。",
+  "cloudSyncHelpStuckTitle": "為什麼有時同步不動 / 卡住",
+  "cloudSyncHelpStuckBody": "• 全量上傳 / 下載不支援斷點續傳：中途斷網、或 App 被切到背景被系統清掉，會從頭重來，不會接著傳。資料多時請用穩定網路（建議 Wi-Fi）耐心等它跑完，別中途切走。\n• 增量同步是斷點安全的，日常同步不受影響。",
+  "cloudSyncHelpTroubleshootTitle": "排查辦法",
+  "cloudSyncHelpTroubleshootBody": "• 先在本頁下拉做一次「深度檢測」，對比本機與雲端差異。\n• 仍有問題，去「日誌中心」查看同步日誌（含失敗原因），方便回報。",
+  "cloudSyncHelpOpenLogCenter": "開啟日誌中心",
   "syncHealthCheckFailed": "檢測失敗：{msg}",
   "@syncHealthCheckFailed": {
     "placeholders": {

--- a/lib/pages/cloud/beecount_cloud_sync_page.dart
+++ b/lib/pages/cloud/beecount_cloud_sync_page.dart
@@ -12,6 +12,7 @@ import '../../l10n/app_localizations.dart';
 import '../../cloud/sync/sync_engine.dart';
 import '../../services/system/logger_service.dart';
 import '../auth/login_page.dart';
+import '../settings/log_center_page.dart';
 
 /// BeeCount Cloud 专属同步页
 ///
@@ -193,6 +194,11 @@ class _BeeCountCloudSyncPageState extends ConsumerState<BeeCountCloudSyncPage> {
                         SectionCard(
                           child: _buildHealthSection(context),
                         ),
+                        const SizedBox(height: 8),
+                        // Section 3: 同步说明(折叠) — 解释增量/全量、断点续传、排查
+                        SectionCard(
+                          child: _buildSyncHelpSection(context),
+                        ),
                         // BeeCount Cloud server 版本号,底部弱展示。
                         // 跟 web header 的 vX.Y.Z 对齐,方便确认 server 哪版。
                         // 通过 provider 监听,server 升级后跟着 sync ticker 自
@@ -284,6 +290,85 @@ class _BeeCountCloudSyncPageState extends ConsumerState<BeeCountCloudSyncPage> {
         );
         ref.read(syncStatusRefreshProvider.notifier).state++;
       },
+    );
+  }
+
+  /// 同步说明(可折叠):增量/全量、何时走全量、断点续传、排查入口。
+  Widget _buildSyncHelpSection(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Theme(
+      // 去掉 ExpansionTile 默认的上下分割线,贴合 SectionCard 风格
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        tilePadding: EdgeInsets.zero,
+        childrenPadding: const EdgeInsets.only(bottom: 4),
+        leading: Icon(Icons.help_outline,
+            color: BeeTokens.iconSecondary(context)),
+        title: Text(
+          l10n.cloudSyncHelpTitle,
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            color: BeeTokens.textPrimary(context),
+          ),
+        ),
+        children: [
+          _helpBlock(context, l10n.cloudSyncHelpModesTitle,
+              l10n.cloudSyncHelpModesBody),
+          _helpBlock(context, l10n.cloudSyncHelpWhenFullTitle,
+              l10n.cloudSyncHelpWhenFullBody),
+          _helpBlock(context, l10n.cloudSyncHelpStuckTitle,
+              l10n.cloudSyncHelpStuckBody),
+          _helpBlock(context, l10n.cloudSyncHelpTroubleshootTitle,
+              l10n.cloudSyncHelpTroubleshootBody),
+          const SizedBox(height: 4),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const LogCenterPage()),
+              ),
+              style: TextButton.styleFrom(
+                foregroundColor: ref.watch(primaryColorProvider),
+                padding: EdgeInsets.zero,
+                minimumSize: const Size(0, 36),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              icon: const Icon(Icons.article_outlined, size: 18),
+              label: Text(l10n.cloudSyncHelpOpenLogCenter),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 同步说明里的一段:加粗小标题 + 正文(正文里用 \n 分条)。
+  Widget _helpBlock(BuildContext context, String title, String body) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: BeeTokens.textPrimary(context),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            body,
+            style: TextStyle(
+              fontSize: 12.5,
+              height: 1.5,
+              color: BeeTokens.textSecondary(context),
+            ),
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
## 背景
经常有人问「为什么无法同步 / 同步不动」。在 BeeCount Cloud 同步页加一段说明,把同步机制和排查路径讲清楚,减少重复答疑。

## 改动
- 同步页「同步状态」卡片下方新增一张**可折叠** SectionCard(`ExpansionTile`,默认收起),标题「同步说明 · 为什么有时同步不动?」。内容分四段:
  - **三种同步方式**:增量(日常自动)/ 全量上传 / 全量下载。
  - **什么时候才会走全量**:只在某一端数据为空时触发(首次开启 / 换机 / 重装 / 清空数据);两端都有数据则一直走增量;想强制全量须先清空对应端数据。
  - **为什么有时卡住**:全量上传 / 下载**不支持断点续传**,中途断网或被后台杀掉会从头重来,大数据量请用稳定网络等它跑完;增量是断点安全的。
  - **排查办法**:先在本页下拉做「深度检测」对比差异;仍有问题去**日志中心**看同步日志 —— 附「打开日志中心」按钮直达。
- 文案三语(zh / zh_TW / en),`flutter gen-l10n` 生成。

## 范围
- 仅 App(`lib/pages/cloud/beecount_cloud_sync_page.dart` + l10n);Web 端不涉及。纯说明文案,不改任何同步逻辑。

## 验证
- `flutter analyze` 改动文件无新增 issue(仅 2 条既有 `use_build_context_synchronously`,在不相关的重新登录路径)。
- 纯 UI/文案,按仓库惯例不加 widget 测试;需真机展开查看 + 点「打开日志中心」验证跳转。