### PR TITLE
fix: 修正Dart最低版本要求至3.6.0以符合CONTRIBUTING文件

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1962,5 +1962,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.6.1 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ^3.6.1
+  sdk: ^3.6.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
## 问题
文档`CONTRIBUTING_ZH.md` 中明确写着环境配置支援 Dart SDK: 3.6.0 或更高版本。
但目前 `pubspec.yaml` 里硬限制了 `environment.sdk: ^3.6.1`。

这导致完全按照文档装了 Dart 3.6.0 环境的新开发者在跑 flutter pub get 时会直接报错中断。

## 改动
修改 `pubspec.yaml`，将 Dart SDK 最低要求从 `^3.6.1` 下调至 `^3.6.0`，以保持代码限制与文档指引完全一致。

## 测试
* 在本地 Dart 3.6.0 环境下执行 `flutter build apk`，已确认无语法与编译相容问题（项目并未依赖 3.6.1 的 Patch 特性）。
* 产出的 APK 已在 Android 模拟器中安装并实际测试过，各项基础功能皆能正常运行，向下相容完全安全。