### PR TITLE
fix: CSV 导入非 ISO 日期按本地时间解析,修复 +8 小时偏差

### DIFF
--- a/lib/utils/date_parser.dart
+++ b/lib/utils/date_parser.dart
@@ -78,7 +78,12 @@ class DateParser {
     }
   }
 
-  /// 尝试使用常见日期格式解析
+  /// 尝试使用常见日期格式解析。
+  ///
+  /// 这些格式都是**无时区信息的裸墙钟时间**(斜杠分隔、单数字月份、MM/dd/yyyy 等,
+  /// 过不了 DateTime.parse),按口径一律解析为**本地时间**(`parse` 默认 utc=false)。
+  /// 切勿用 `parse(str, /*utc=*/true)` 强标 UTC —— 那会让 CSV 导入的本地时间在
+  /// 本地(如 UTC+8)展示时整体 +8 小时(历史 bug)。
   static DateTime? _tryParseCommonFormats(String dateStr) {
     final formats = [
       'yyyy-MM-dd HH:mm:ss',
@@ -99,7 +104,8 @@ class DateParser {
 
     for (final format in formats) {
       try {
-        return DateFormat(format).parse(dateStr, true);
+        // utc=false(默认):按本地墙钟解析,不做时区偏移。
+        return DateFormat(format).parse(dateStr);
       } catch (_) {
         // 继续尝试下一个格式
       }

--- a/test/utils/date_parser_test.dart
+++ b/test/utils/date_parser_test.dart
@@ -3,12 +3,13 @@ import 'package:beecount/utils/date_parser.dart';
 
 /// DateParser 单测。
 ///
-/// 断言的是**当前线上实现**的行为(非某个理想化版本):
-/// - ISO 8601 路径走 `DateTime.parse(...).toLocal()` → 结果为本地时区(isUtc=false);
+/// 解析口径(原则:**除非串里显式带 UTC 标记,否则一律按本地墙钟解析**):
+/// - ISO 8601 路径走 `DateTime.parse(...).toLocal()`:带 Z/offset → 转本地保留
+///   时刻;无时区 → 本地(isUtc=false);
 /// - 中文日期路径走 `DateTime(...)` 构造 → 本地时区;
-/// - 常见格式路径走 `DateFormat(fmt).parse(str, /*utc=*/true)` → 结果带 UTC 标记
-///   (字面年月日时分原样保留,只是 isUtc=true)。这是 #314 在云端按客户端时区
-///   换算后,App 侧保持的解析口径。
+/// - 常见格式路径走 `DateFormat(fmt).parse(str)` → 本地时间(isUtc=false)。
+///   这些格式都是无时区的裸墙钟,必须当本地;否则 CSV 导入会被当成 UTC 而 +8h
+///   (历史 bug:单数字月份 `2026-6-25` 等过不了 DateTime.parse,曾被强标 UTC)。
 void main() {
   group('DateParser.parse — 空与兜底', () {
     final fallback = DateTime(2020, 1, 2, 3, 4, 5);
@@ -79,23 +80,23 @@ void main() {
     });
   });
 
-  group('常见格式(字面分量保留,带 UTC 标记)', () {
+  group('常见格式(无 UTC 标记 → 本地时间)', () {
     test('yyyy/MM/dd', () {
       final d = DateParser.parse('2024/11/05');
       expect(d.year, 2024);
       expect(d.month, 11);
       expect(d.day, 5);
-      expect(d.isUtc, isTrue);
+      expect(d.isUtc, isFalse);
     });
 
-    test('yyyy/MM/dd HH:mm — 分量原样,不做时区偏移', () {
+    test('yyyy/MM/dd HH:mm — 分量原样,本地时区不偏移', () {
       final d = DateParser.parse('2024/08/29 23:16');
       expect(d.year, 2024);
       expect(d.month, 8);
       expect(d.day, 29);
       expect(d.hour, 23);
       expect(d.minute, 16);
-      expect(d.isUtc, isTrue);
+      expect(d.isUtc, isFalse);
     });
 
     test('yyyy-MM-dd HH:mm:ss', () {
@@ -104,6 +105,36 @@ void main() {
       expect(d.day, 29);
       expect(d.hour, 23);
       expect(d.second, 5);
+      expect(d.isUtc, isFalse);
+    });
+  });
+
+  group('回归:无 UTC 标记一律本地,不产生 8h 偏移(CSV 导入)', () {
+    test('单数字月份 2026-6-25 00:00 → 本地,且与零填充同一时刻', () {
+      final single = DateParser.parse('2026-6-25 00:00');
+      final padded = DateParser.parse('2026-06-25 00:00');
+      expect(single.isUtc, isFalse);
+      expect(single.year, 2026);
+      expect(single.month, 6);
+      expect(single.day, 25);
+      expect(single.hour, 0);
+      // 关键:两种写法必须解析成同一时刻(修复前差整 8 小时 = 480 分钟)
+      expect(single.difference(padded), Duration.zero);
+    });
+
+    test('单数字月份月末晚间不跨月 2025-9-30 23:45', () {
+      final d = DateParser.parse('2025-9-30 23:45');
+      expect(d.isUtc, isFalse);
+      expect(d.month, 9);
+      expect(d.day, 30);
+      expect(d.hour, 23);
+      expect(d.minute, 45);
+    });
+
+    test('斜杠格式同样本地 2024/08/29 23:16', () {
+      final d = DateParser.parse('2024/08/29 23:16');
+      expect(d.isUtc, isFalse);
+      expect(d.hour, 23);
     });
   });
 }


### PR DESCRIPTION
## 背景
用户反馈某 CSV(`日期` 列形如 `2026-6-25 00:00`,非零填充、单数字月份)导入后时间整体 **+8 小时**,其他文件正常;并疑似"记账丢失"。

## 根因
`DateParser` 三条解析路径时区口径不一致:
- ISO 路径 `DateTime.parse(s).toLocal()` → 本地;
- 中文路径 `DateTime(...)` → 本地;
- **常见格式路径 `DateFormat(fmt).parse(s, /*utc=*/true)` → 强标 UTC**(问题所在)。

Dart 的 `DateTime.parse` 要求月/日必须 2 位,`2026-6-25`(单数字月)过不了 ISO 路径 → 掉进常见格式路径被当成 UTC → 本地(UTC+8)展示时 +8h。同文件里 10/11/12 月(两位)能走 ISO 路径,所以是"同一文件部分偏移"。实测两种写法解析结果差 **480 分钟 = 整 8 小时**。

"记账丢失"为**连带现象**:870 笔时间 ≥16:00,+8h 后跨到次日,单数字月份月末还会跨月,于是在原月份"看不到了"。实际**未丢**——用户已验证导入 1204 笔与 CSV 对得上(交易导入无去重、无按内容跳过)。

## 修复
常见格式路径去掉 `utc:true`,按**本地墙钟**解析,与 ISO/中文路径统一。口径:**除非串显式带 UTC 标记(Z/offset,只走 ISO 路径),否则一律本地**。仅 import 侧受影响(`DateParser` 唯一运行期消费方是 CSV 导入)。

## 验证(TDD)
- 先改测试断言为本地语义 → RED(5 条 `Expected:false Actual:true`,旧代码强标 UTC)。
- 改 `date_parser.dart` 后 → date_parser 测试 **16/16 通过**;关键回归 `单数字月份.difference(零填充) == Duration.zero`(修复前 480 分钟)。
- 全量 `flutter test`:299 通过,1 条 `sync_engine_e2e`(WS 防抖计时)flaky、与本改动无关、单跑 27/27 通过。
- `flutter analyze` 改动文件:0 问题。

## 注意(发版后)
本修复只保证**今后**导入正确;**已经导入**的那批(+8h 已落库)不会自动回正,需"删除该批 + 重新导入"。
