### PR TITLE
fix: 洞察页日均/月均/年均按已发生单位数计算(原按有记账单位数,高估)

### DIFF
--- a/lib/pages/main/analytics_page.dart
+++ b/lib/pages/main/analytics_page.dart
@@ -14,6 +14,7 @@ import '../../l10n/app_localizations.dart';
 import '../../services/export/share_poster_service.dart';
 import '../../data/db.dart' as db;
 import '../../utils/month_range.dart';
+import '../../utils/analytics_average.dart';
 
 class AnalyticsPage extends ConsumerStatefulWidget {
   const AnalyticsPage({super.key});
@@ -774,7 +775,7 @@ class _AnalyticsPageState extends ConsumerState<AnalyticsPage> {
                         isExpense: _type == 'expense',
                         isBalance: _type == 'balance',
                         total: sum,
-                        avg: _computeAverage(filteredSeriesRaw, _scope),
+                        avg: computeSeriesAverage(filteredSeriesRaw),
                         expenseColor: Theme.of(context).colorScheme.primary,
                         incomeColor: Theme.of(context).colorScheme.primary,
                       ),
@@ -933,46 +934,6 @@ String _currentPeriodLabel(
     default:
       return '${selMonth.year}-${selMonth.month.toString().padLeft(2, '0')}';
   }
-}
-
-double _computeAverage(dynamic seriesRaw, String scope) {
-  if (seriesRaw is List<({DateTime day, double total})>) {
-    if (seriesRaw.isEmpty) return 0;
-
-    // 过滤出有数据的天数(金额>0)
-    final nonZeroDays = seriesRaw.where((e) => e.total > 0).toList();
-    if (nonZeroDays.isEmpty) return 0;
-
-    final sum = seriesRaw.fold<double>(0, (a, b) => a + b.total);
-    // 月度视角：按实际有记账的天数计算平均值
-    return sum / nonZeroDays.length;
-  }
-
-  if (seriesRaw is List<({DateTime month, double total})>) {
-    if (seriesRaw.isEmpty) return 0;
-
-    // 过滤出有数据的月份(金额>0)
-    final nonZeroMonths = seriesRaw.where((e) => e.total > 0).toList();
-    if (nonZeroMonths.isEmpty) return 0;
-
-    final sum = seriesRaw.fold<double>(0, (a, b) => a + b.total);
-    // 年度视角：按实际有记账的月份计算平均值
-    return sum / nonZeroMonths.length;
-  }
-
-  if (seriesRaw is List<({int year, double total})>) {
-    if (seriesRaw.isEmpty) return 0;
-
-    // 过滤出有数据的年份(金额>0)
-    final nonZeroYears = seriesRaw.where((e) => e.total > 0).toList();
-    if (nonZeroYears.isEmpty) return 0;
-
-    final sum = seriesRaw.fold<double>(0, (a, b) => a + b.total);
-    // 全部视角：按实际有记账的年份计算平均值
-    return sum / nonZeroYears.length;
-  }
-
-  return 0;
 }
 
 // 加载分类数据并聚合

--- a/lib/utils/analytics_average.dart
+++ b/lib/utils/analytics_average.dart
@@ -1,0 +1,34 @@
+/// 洞察页"日均 / 月均 / 年均"的统一求值(issue 修复)。
+///
+/// 口径:分母用**已发生的单位数**,而不是"有记账的单位数"。
+///
+/// 调用方传入的 `seriesRaw` 应已按时间范围裁剪到"已发生"区间
+/// (见 analytics_page 的 filteredSeriesRaw:当前周期的天序列只到今天、
+/// 当前年的月序列只到当前月、年序列只到当前年)——因此本函数直接对其
+/// **全长**取平均:零值单位(没花钱的那天/那月)照样计入分母,把均值拉低,
+/// 这才是用户期望的"日/月/年平均花费"。旧实现误用"金额>0 的单位数"做分母,
+/// 会系统性高估(例如本月过了 30 天、只在 10 天有消费,会按 10 天平均)。
+///
+/// 支持三种序列形状:按天 / 按月 / 按年(Dart record 结构化匹配)。
+/// 空序列返回 0;形状无法识别返回 0。
+double computeSeriesAverage(dynamic seriesRaw) {
+  if (seriesRaw is List<({DateTime day, double total})>) {
+    if (seriesRaw.isEmpty) return 0;
+    final sum = seriesRaw.fold<double>(0, (a, b) => a + b.total);
+    return sum / seriesRaw.length; // ÷ 已发生天数
+  }
+
+  if (seriesRaw is List<({DateTime month, double total})>) {
+    if (seriesRaw.isEmpty) return 0;
+    final sum = seriesRaw.fold<double>(0, (a, b) => a + b.total);
+    return sum / seriesRaw.length; // ÷ 已发生月数
+  }
+
+  if (seriesRaw is List<({int year, double total})>) {
+    if (seriesRaw.isEmpty) return 0;
+    final sum = seriesRaw.fold<double>(0, (a, b) => a + b.total);
+    return sum / seriesRaw.length; // ÷ 已发生年数(年份跨度)
+  }
+
+  return 0;
+}

--- a/test/utils/analytics_average_test.dart
+++ b/test/utils/analytics_average_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:beecount/utils/analytics_average.dart';
+
+/// 洞察页"日均/月均/年均"求值口径(issue 修复)。
+///
+/// 口径:分母用**已发生的单位数**(零值单位也计入),不是"有记账的单位数"。
+/// 调用方传入的序列已按时间范围裁到"已发生"区间(当前周期到今天/当前月/当前年),
+/// 本函数直接对全长取平均。
+void main() {
+  group('computeSeriesAverage — 按已发生单位数平均(含零值单位)', () {
+    test('按天:零消费的天也计入分母(核心回归)', () {
+      final series = <({DateTime day, double total})>[
+        (day: DateTime(2026, 6, 1), total: 100),
+        (day: DateTime(2026, 6, 2), total: 0),
+        (day: DateTime(2026, 6, 3), total: 0),
+        (day: DateTime(2026, 6, 4), total: 0),
+        (day: DateTime(2026, 6, 5), total: 0),
+      ];
+      // 5 天已发生、仅 1 天有记账:应为 100/5=20,而非旧口径 100/1=100
+      expect(computeSeriesAverage(series), 20);
+    });
+
+    test('按天:空序列返回 0', () {
+      expect(computeSeriesAverage(<({DateTime day, double total})>[]), 0);
+    });
+
+    test('按天:全零序列返回 0(0/2)', () {
+      final series = <({DateTime day, double total})>[
+        (day: DateTime(2026, 6, 1), total: 0),
+        (day: DateTime(2026, 6, 2), total: 0),
+      ];
+      expect(computeSeriesAverage(series), 0);
+    });
+
+    test('按月:除以月数(空月计入)', () {
+      final series = <({DateTime month, double total})>[
+        (month: DateTime(2026, 1, 1), total: 300),
+        (month: DateTime(2026, 2, 1), total: 0),
+        (month: DateTime(2026, 3, 1), total: 0),
+      ];
+      expect(computeSeriesAverage(series), 100); // 300/3,非 300/1
+    });
+
+    test('按年:除以年份跨度(空年计入)', () {
+      final series = <({int year, double total})>[
+        (year: 2024, total: 1200),
+        (year: 2025, total: 0),
+        (year: 2026, total: 0),
+      ];
+      expect(computeSeriesAverage(series), 400); // 1200/3,非 1200/1
+    });
+
+    test('结余口径:净额可为负(净额/已发生天数)', () {
+      final series = <({DateTime day, double total})>[
+        (day: DateTime(2026, 6, 1), total: -60),
+        (day: DateTime(2026, 6, 2), total: 0),
+      ];
+      expect(computeSeriesAverage(series), -30); // -60/2
+    });
+
+    test('未知形状返回 0', () {
+      expect(computeSeriesAverage(<int>[1, 2, 3]), 0);
+    });
+  });
+}


### PR DESCRIPTION
## 背景
洞察页"日均收入/支出"(及月均/年均)用**有记账的单位数**做分母,导致高估:本月已过 30 天、只在 10 天有消费共 3000,会显示日均 300(=3000/10),而真实节奏应是 100(=3000/30)。没花钱的日子本应把均值拉低。

## 根因
`analytics_page.dart` 的 `_computeAverage` 对每种序列都先 `where((e) => e.total > 0)` 再除以这个"非零子集"的长度。

## 修复
对 `filteredSeriesRaw` **全长**取平均(零值单位计入分母)。关键:`filteredSeriesRaw` 本就已按时间裁到"已发生"区间(见 `analytics_page.dart:663-685`):
- 月视角:天序列 = `[start, today+1)` → 长度 = 已发生天数(当前周期到今天、历史周期到周期末);
- 年视角:当前年只保留 `月 ≤ 当前月标签`(尊重自定义每月起始日)→ 已发生月数;
- 全部视角:只保留 `年 ≤ 今年` → 已发生年份跨度。

所以本质是分母用错,改用全长即对。三视角口径统一,旧"有记账单位数"实现删除。

## 实现
- 抽出 `lib/utils/analytics_average.dart` 的 `computeSeriesAverage`(便于单测,page 内私有函数无法跨库测)。
- `analytics_page` 改调它并删 `_computeAverage`。

## 验证(TDD)
- RED:先写 7 条断言(核心:5 天仅 1 天有账 → 100/5=20 而非 100/1=100)→ 编译失败。
- GREEN:建 util 后 **7/7 通过**。
- 全量 `flutter test`:**307 通过**,仅 `sync_engine_e2e`(WS 1s 防抖)flaky、与本改动无关、单跑 27/27 通过。
- `flutter analyze` 改动文件:0 问题。
