### PR TITLE
fix: 升级 image_cropper 至 10.0.0，修复 Android 15 裁切按钮被状态栏遮挡

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,7 +14,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "com.tntlikely.beecount"
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = 36
     // Keep in sync with plugins' required NDK to avoid build warnings/errors.
     ndkVersion = "27.0.12077973"
 
@@ -208,4 +208,7 @@ flutter {
 dependencies {
     // Java language desugaring support for older Android devices.
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+
+    // Required by uCrop 2.2.11 (bundled with image_cropper 10.0.0) for downloading image URIs
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -122,3 +122,7 @@
 # TensorFlow Lite - 暂时注释掉本地模型依赖，只使用云端API
 -dontwarn org.tensorflow.lite.**
 -dontwarn org.tensorflow.lite.gpu.**
+
+# OkHttp - required by uCrop 2.2.11 (image_cropper 10.0.0)
+-dontwarn okhttp3.**
+-keep class okhttp3.** { *; }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -771,10 +771,10 @@ packages:
     dependency: "direct main"
     description:
       name: image_cropper
-      sha256: fe37d9a129411486e0d93089b61bd326d05b89e78ad4981de54b560725bf5bd5
+      sha256: d104cc1f90b0d38ac309f7ec240b8f55f2c6e76d1bfae05e23917bfea631e725
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "10.0.0+1"
   image_cropper_for_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   home_widget: ^0.7.0
   image_picker: ^1.1.2
   flutter_image_compress: ^2.3.0
-  image_cropper: 8.0.2
+  image_cropper: ^10.0.0
   gbk_codec: ^0.4.0
   app_links: ^6.4.1
   record: ^5.1.2
@@ -92,7 +92,7 @@ dev_dependencies:
 dependency_overrides:
   # Fix record_linux compatibility issue (we target iOS/Android only)
   record_platform_interface: 1.2.0
-  # Fix image_cropper compatibility with Flutter 3.27.3
+  # Pin to 7.1.0 because 7.2.0 requires Flutter >= 3.27.6 (Color.toARGB32)
   image_cropper_platform_interface: 7.1.0
 
 # adaptive_* 三个素材由 scripts/gen_adaptive_icons.py 生成(几何取自 assets/logo.svg);


### PR DESCRIPTION
## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 代码重构
- [ ] 性能优化
- [ ] 其他

## 变更说明

升级 `image_cropper` 8.0.2 → 10.0.0（底层 uCrop 从 2.2.8 升级至 2.2.11），uCrop 2.2.11 已原生支援 Android 15 强制 edge-to-edge，不再需要额外适配。

同时更新以下依赖：
- `compileSdk` 提升至 36（`image_cropper` 10.0.0 要求）
- 新增 `okhttp:4.12.0` 依赖及 proguard keep 规则（uCrop 2.2.11 使用 OkHttp 下载网络图片）
- 保留 `image_cropper_platform_interface: 7.1.0` override

  image_cropper 10.0.0 宣告需 ^7.2.0，但 7.1.0→7.2.0 的变更只有：

  - 新增 `statusBarLight`/`navBarLight` 可选参数（向后兼容）
  - `settings.dart` 序列化颜色时将 `.value` 改为 `.toARGB32()`

  两者回传的 ARGB 整数完全相同（后者只是 Flutter 3.27.6 新增的别名），7.1.0 已有 10.0.0 需要的所有 API，override 安全无影响。

## 相关 Issue

Closes #337

## 测试情况

- [x] 已在 Android 上测试（API 35 模拟器，debug + release 均验证）
- [ ] 已在 iOS 上测试
- [ ] 添加了单元测试
- [ ] 添加了集成测试

## 截图

环境为Android 15模拟器
<img width="532" height="1013" alt="image" src="https://github.com/user-attachments/assets/8cd04f6c-ea77-4fc7-ac0b-734b72b5f3f7" />

## 检查清单
- [x] 代码遵循项目规范
- [ ] 已运行 `dart format` 格式化代码
- [x] 已运行 `flutter analyze` 无警告
- [ ] 已更新相关文档
- [x] 提交信息符合规范