### PR TITLE
feat(搜索): 搜索结果页新增收支汇总展示

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -192,6 +192,8 @@
   "searchBatchChangeCategorySuccess": "Successfully changed category for {count} transactions",
   "searchBatchChangeCategoryFailed": "Change category failed: {error}",
   "searchResultsCount": "{count} results",
+  "searchSummaryIncome": "Income",
+  "searchSummaryExpense": "Expense",
   "searchFilterTitle": "Filter",
   "searchAmountFilter": "Amount Filter",
   "searchDateFilter": "Date Filter",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -852,6 +852,18 @@ abstract class AppLocalizations {
   /// **'{count} results'**
   String searchResultsCount(Object count);
 
+  /// No description provided for @searchSummaryIncome.
+  ///
+  /// In en, this message translates to:
+  /// **'Income'**
+  String get searchSummaryIncome;
+
+  /// No description provided for @searchSummaryExpense.
+  ///
+  /// In en, this message translates to:
+  /// **'Expense'**
+  String get searchSummaryExpense;
+
   /// No description provided for @searchFilterTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -425,6 +425,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get searchSummaryIncome => 'Income';
+
+  @override
+  String get searchSummaryExpense => 'Expense';
+
+  @override
   String get searchFilterTitle => 'Filter';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -425,6 +425,12 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get searchSummaryIncome => '收入';
+
+  @override
+  String get searchSummaryExpense => '支出';
+
+  @override
   String get searchFilterTitle => '筛选';
 
   @override
@@ -7313,6 +7319,12 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
   String searchResultsCount(Object count) {
     return '共 $count 條結果';
   }
+
+  @override
+  String get searchSummaryIncome => '收入';
+
+  @override
+  String get searchSummaryExpense => '支出';
 
   @override
   String get searchFilterTitle => '篩選';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -255,6 +255,8 @@
       }
     }
   },
+  "searchSummaryIncome": "收入",
+  "searchSummaryExpense": "支出",
   "searchFilterTitle": "筛选",
   "searchAmountFilter": "金额筛选",
   "searchDateFilter": "时间筛选",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -1744,6 +1744,8 @@
   "searchNoResults": "未找到符合的結果",
   "searchNotSet": "未設定",
   "searchResultsCount": "共 {count} 條結果",
+  "searchSummaryIncome": "收入",
+  "searchSummaryExpense": "支出",
   "searchSelectAll": "全選",
   "searchSelectedCount": "已選擇 {count} 項",
   "searchStartDate": "開始日期",

--- a/lib/pages/transaction/search_page.dart
+++ b/lib/pages/transaction/search_page.dart
@@ -10,6 +10,7 @@ import '../../utils/category_utils.dart';
 import '../../l10n/app_localizations.dart';
 import '../../utils/transaction_edit_utils.dart';
 import '../../utils/format_utils.dart';
+import '../../utils/ui_scale_extensions.dart';
 import '../../providers/database_providers.dart';
 import '../../widgets/category_icon.dart';
 import 'category_detail_page.dart';
@@ -37,6 +38,10 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   DateTime? _startDate;
   DateTime? _endDate;
   bool _hasScheduledSearch = false; // 防止重复调度搜索
+
+  // 缓存汇总金额，避免每次 build() 重复计算
+  double _totalExpense = 0.0;
+  double _totalIncome = 0.0;
 
   // 批量操作相关
   bool _isBatchMode = false;
@@ -69,6 +74,8 @@ class _SearchPageState extends ConsumerState<SearchPage> {
         _startDate == null && _endDate == null) {
       setState(() {
         _searchResults = [];
+        _totalExpense = 0.0;
+        _totalIncome = 0.0;
         _isSearching = false;
         _hasScheduledSearch = false;
       });
@@ -133,6 +140,12 @@ class _SearchPageState extends ConsumerState<SearchPage> {
 
     setState(() {
       _searchResults = results;
+      _totalExpense = results
+          .where((e) => e.t.type == 'expense')
+          .fold(0.0, (sum, e) => sum + e.t.amount.abs());
+      _totalIncome = results
+          .where((e) => e.t.type == 'income')
+          .fold(0.0, (sum, e) => sum + e.t.amount.abs());
       _isSearching = false;
     });
   }
@@ -598,7 +611,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     return Text(
       '$label ${formatBalance(amount, currencyCode)}',
       style: TextStyle(
-        fontSize: 12,
+        fontSize: 12.0.scaled(context, ref),
         color: color,
       ),
       maxLines: 1,
@@ -850,31 +863,35 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                                     color: BeeTokens.textTertiary(context),
                                   ),
                             ),
-                            const SizedBox(width: 8),
-                            // 支出汇总
-                            Flexible(
-                              child: _buildSummaryChip(
-                                label: l10n.searchSummaryExpense,
-                                amount: _searchResults
-                                    .where((e) => e.t.type == 'expense')
-                                    .fold(0.0, (sum, e) => sum + e.t.amount.abs()),
-                                color: BeeTokens.expenseColor(context, ref),
-                                currencyCode: currencyCode,
+                            SizedBox(width: 8.0.scaled(context, ref)),
+                            // 支出/收入汇总：Expanded 占满剩余空间，内层 Flexible(loose) 让 chip 正常取自然宽度，超长时截断而非溢出
+                            Expanded(
+                              child: Row(
+                                children: [
+                                  // 支出汇总
+                                  Flexible(
+                                    fit: FlexFit.loose,
+                                    child: _buildSummaryChip(
+                                      label: l10n.searchSummaryExpense,
+                                      amount: _totalExpense,
+                                      color: BeeTokens.expenseColor(context, ref),
+                                      currencyCode: currencyCode,
+                                    ),
+                                  ),
+                                  SizedBox(width: 6.0.scaled(context, ref)),
+                                  // 收入汇总
+                                  Flexible(
+                                    fit: FlexFit.loose,
+                                    child: _buildSummaryChip(
+                                      label: l10n.searchSummaryIncome,
+                                      amount: _totalIncome,
+                                      color: BeeTokens.incomeColor(context, ref),
+                                      currencyCode: currencyCode,
+                                    ),
+                                  ),
+                                ],
                               ),
                             ),
-                            const SizedBox(width: 6),
-                            // 收入汇总
-                            Flexible(
-                              child: _buildSummaryChip(
-                                label: l10n.searchSummaryIncome,
-                                amount: _searchResults
-                                    .where((e) => e.t.type == 'income')
-                                    .fold(0.0, (sum, e) => sum + e.t.amount),
-                                color: BeeTokens.incomeColor(context, ref),
-                                currencyCode: currencyCode,
-                              ),
-                            ),
-                            const Spacer(),
                             TextButton(
                               onPressed: _toggleBatchMode,
                               style: TextButton.styleFrom(

--- a/lib/pages/transaction/search_page.dart
+++ b/lib/pages/transaction/search_page.dart
@@ -9,6 +9,8 @@ import '../../styles/tokens.dart';
 import '../../utils/category_utils.dart';
 import '../../l10n/app_localizations.dart';
 import '../../utils/transaction_edit_utils.dart';
+import '../../utils/format_utils.dart';
+import '../../providers/database_providers.dart';
 import '../../widgets/category_icon.dart';
 import 'category_detail_page.dart';
 
@@ -591,13 +593,17 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     required String label,
     required double amount,
     required Color color,
+    required String currencyCode,
   }) {
     return Text(
-      '$label ${amount.toStringAsFixed(2)}',
+      '$label ${formatBalance(amount, currencyCode)}',
       style: TextStyle(
         fontSize: 12,
         color: color,
       ),
+      maxLines: 1,
+      softWrap: false,
+      overflow: TextOverflow.ellipsis,
     );
   }
 
@@ -607,6 +613,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     final ledgerId = ref.watch(currentLedgerIdProvider);
     final hide = ref.watch(hideAmountsProvider);
     final l10n = AppLocalizations.of(context);
+    final currencyCode = ref.watch(currentLedgerProvider).valueOrNull?.currency ?? 'CNY';
 
     return Scaffold(
       backgroundColor: BeeTokens.scaffoldBackground(context),
@@ -845,21 +852,27 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                             ),
                             const SizedBox(width: 8),
                             // 支出汇总
-                            _buildSummaryChip(
-                              label: l10n.searchSummaryExpense,
-                              amount: _searchResults
-                                  .where((e) => e.t.type == 'expense')
-                                  .fold(0.0, (sum, e) => sum + e.t.amount.abs()),
-                              color: BeeTokens.expenseColor(context, ref),
+                            Flexible(
+                              child: _buildSummaryChip(
+                                label: l10n.searchSummaryExpense,
+                                amount: _searchResults
+                                    .where((e) => e.t.type == 'expense')
+                                    .fold(0.0, (sum, e) => sum + e.t.amount.abs()),
+                                color: BeeTokens.expenseColor(context, ref),
+                                currencyCode: currencyCode,
+                              ),
                             ),
                             const SizedBox(width: 6),
                             // 收入汇总
-                            _buildSummaryChip(
-                              label: l10n.searchSummaryIncome,
-                              amount: _searchResults
-                                  .where((e) => e.t.type == 'income')
-                                  .fold(0.0, (sum, e) => sum + e.t.amount),
-                              color: BeeTokens.incomeColor(context, ref),
+                            Flexible(
+                              child: _buildSummaryChip(
+                                label: l10n.searchSummaryIncome,
+                                amount: _searchResults
+                                    .where((e) => e.t.type == 'income')
+                                    .fold(0.0, (sum, e) => sum + e.t.amount),
+                                color: BeeTokens.incomeColor(context, ref),
+                                currencyCode: currencyCode,
+                              ),
                             ),
                             const Spacer(),
                             TextButton(

--- a/lib/pages/transaction/search_page.dart
+++ b/lib/pages/transaction/search_page.dart
@@ -586,6 +586,21 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     }
   }
 
+  /// 构建收入/支出汇总标签
+  Widget _buildSummaryChip({
+    required String label,
+    required double amount,
+    required Color color,
+  }) {
+    return Text(
+      '$label ${amount.toStringAsFixed(2)}',
+      style: TextStyle(
+        fontSize: 12,
+        color: color,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final repo = ref.watch(repositoryProvider);
@@ -827,6 +842,24 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                                   ?.copyWith(
                                     color: BeeTokens.textTertiary(context),
                                   ),
+                            ),
+                            const SizedBox(width: 8),
+                            // 支出汇总
+                            _buildSummaryChip(
+                              label: l10n.searchSummaryExpense,
+                              amount: _searchResults
+                                  .where((e) => e.t.type == 'expense')
+                                  .fold(0.0, (sum, e) => sum + e.t.amount.abs()),
+                              color: BeeTokens.expenseColor(context, ref),
+                            ),
+                            const SizedBox(width: 6),
+                            // 收入汇总
+                            _buildSummaryChip(
+                              label: l10n.searchSummaryIncome,
+                              amount: _searchResults
+                                  .where((e) => e.t.type == 'income')
+                                  .fold(0.0, (sum, e) => sum + e.t.amount),
+                              color: BeeTokens.incomeColor(context, ref),
                             ),
                             const Spacer(),
                             TextButton(

--- a/lib/pages/transaction/search_page.dart
+++ b/lib/pages/transaction/search_page.dart
@@ -9,7 +9,6 @@ import '../../styles/tokens.dart';
 import '../../utils/category_utils.dart';
 import '../../l10n/app_localizations.dart';
 import '../../utils/transaction_edit_utils.dart';
-import '../../utils/format_utils.dart';
 import '../../utils/ui_scale_extensions.dart';
 import '../../providers/database_providers.dart';
 import '../../widgets/category_icon.dart';
@@ -606,17 +605,23 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     required String label,
     required double amount,
     required Color color,
-    required String currencyCode,
   }) {
-    return Text(
-      '$label ${formatBalance(amount, currencyCode)}',
-      style: TextStyle(
-        fontSize: 12.0.scaled(context, ref),
-        color: color,
-      ),
-      maxLines: 1,
-      softWrap: false,
-      overflow: TextOverflow.ellipsis,
+    final style = TextStyle(fontSize: 12.0.scaled(context, ref), color: color);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // label 固定展示，金额部分由 AmountText 处理隐藏/单位/币种
+        Text('$label ', style: style),
+        Flexible(
+          child: AmountText(
+            value: amount,
+            signed: false,
+            showCurrency: true,
+            useCompactFormat: true,
+            style: style,
+          ),
+        ),
+      ],
     );
   }
 
@@ -626,7 +631,6 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     final ledgerId = ref.watch(currentLedgerIdProvider);
     final hide = ref.watch(hideAmountsProvider);
     final l10n = AppLocalizations.of(context);
-    final currencyCode = ref.watch(currentLedgerProvider).valueOrNull?.currency ?? 'CNY';
 
     return Scaffold(
       backgroundColor: BeeTokens.scaffoldBackground(context),
@@ -875,7 +879,6 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                                       label: l10n.searchSummaryExpense,
                                       amount: _totalExpense,
                                       color: BeeTokens.expenseColor(context, ref),
-                                      currencyCode: currencyCode,
                                     ),
                                   ),
                                   SizedBox(width: 6.0.scaled(context, ref)),
@@ -886,7 +889,6 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                                       label: l10n.searchSummaryIncome,
                                       amount: _totalIncome,
                                       color: BeeTokens.incomeColor(context, ref),
-                                      currencyCode: currencyCode,
                                     ),
                                   ),
                                 ],


### PR DESCRIPTION
## 功能说明

在搜索结果页「共 N 条结果」右侧新增支出和收入的汇总金额，帮助用户在搜索特定关键词（如分类、备注）后，快速了解该范围内的整体收支情况，无需手动逐条累加。

## 效果截图

<img width="988" height="2108" alt="Screenshot 2026-07-06 at 22-14-25 — iPhone 16 Pro Max" src="https://github.com/user-attachments/assets/099cf18f-2ba6-422a-a800-7e48fd3ba9f5" />



## 改动说明

- 搜索结果统计行新增支出/收入实时汇总，基于当前筛选结果动态计算
- 支出在前、收入在后，颜色复用项目现有收支颜色体系（BeeTokens.expenseColor / incomeColor）
- 新增 `searchSummaryIncome`、`searchSummaryExpense` 多语言文案，覆盖简体中文、繁体中文、英文