### PR TITLE
Fix transaction seconds and Android widget rendering

### DIFF
--- a/android/app/src/main/kotlin/com/tntlikely/beecount/BeeCountWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/beecount/BeeCountWidgetProvider.kt
@@ -5,9 +5,9 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.os.Build
 import android.util.Log
 import android.widget.RemoteViews
 import es.antonborri.home_widget.HomeWidgetProvider
@@ -38,7 +38,7 @@ class BeeCountWidgetProvider : HomeWidgetProvider() {
                         val file = File(imagePath)
                         Log.d(TAG, "File exists: ${file.exists()}, size: ${if(file.exists()) file.length() else 0}")
 
-                        val bitmap = BitmapFactory.decodeFile(imagePath)
+                        val bitmap = loadWidgetBitmap(imagePath)
                         if (bitmap != null) {
                             Log.d(TAG, "Bitmap decoded successfully: ${bitmap.width}x${bitmap.height}")
                             setImageViewBitmap(R.id.widget_image, bitmap)
@@ -95,5 +95,27 @@ class BeeCountWidgetProvider : HomeWidgetProvider() {
         intent.data = Uri.parse(url)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
         return intent
+    }
+
+    private fun loadWidgetBitmap(imagePath: String): Bitmap? {
+        val bounds = BitmapFactory.Options().apply {
+            inJustDecodeBounds = true
+        }
+        BitmapFactory.decodeFile(imagePath, bounds)
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+        val maxWidth = 600
+        val maxHeight = 300
+        var sampleSize = 1
+        while (bounds.outWidth / sampleSize > maxWidth ||
+            bounds.outHeight / sampleSize > maxHeight
+        ) {
+            sampleSize *= 2
+        }
+
+        val options = BitmapFactory.Options().apply {
+            inSampleSize = sampleSize
+        }
+        return BitmapFactory.decodeFile(imagePath, options)
     }
 }

--- a/android/app/src/main/res/layout/beecount_widget.xml
+++ b/android/app/src/main/res/layout/beecount_widget.xml
@@ -2,22 +2,21 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background">
 
     <!--
-        scaleType=fitCenter:
-          按 Flutter 渲染图(364x182, 2:1) 的原比例完整显示,不裁减。用户在
-          桌面把 widget 横向拉宽后,view 宽高比偏离 2:1,fitCenter 会让图片
-          居中 + 留透明空白(letterbox),而不是像 centerCrop 那样切顶/底
-          内容。
-        曾经用过 fitXY(变形拉伸) 和 centerCrop(裁减),前者难看后者切内容,
-        都不如 fitCenter 直观。
+        scaleType=fitXY:
+          Android 各桌面给同一个小部件的实际宽高比并不完全一致。fitCenter
+          会在小米桌面等偏高的容器里留下上下空白；centerCrop 又会裁掉内容。
+          这里让渲染图完整填满宿主区域，避免白边或透明占位。
     -->
     <ImageView
         android:id="@+id/widget_image"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scaleType="fitCenter"
+        android:background="@drawable/widget_background"
+        android:scaleType="fitXY"
         android:contentDescription="Widget content" />
 
     <!-- 透明点击层：左右各半，左侧支出，右侧收入 -->

--- a/lib/providers/theme_providers.dart
+++ b/lib/providers/theme_providers.dart
@@ -61,7 +61,10 @@ final primaryColorInitProvider = FutureProvider<void>((ref) async {
     ref.read(primaryColorProvider.notifier).state = Color(saved);
   }
   ref.listen<Color>(primaryColorProvider, (prev, next) async {
-    final colorValue = (next.a * 255).toInt() << 24 | (next.r * 255).toInt() << 16 | (next.g * 255).toInt() << 8 | (next.b * 255).toInt();
+    final colorValue = (next.a * 255).toInt() << 24 |
+        (next.r * 255).toInt() << 16 |
+        (next.g * 255).toInt() << 8 |
+        (next.b * 255).toInt();
     await prefs.setInt('primaryColor', colorValue);
     // Update widget with new theme color
     try {
@@ -88,8 +91,7 @@ final primaryColorInitProvider = FutureProvider<void>((ref) async {
         if (cloudProvider == null) return;
         final hex = _colorToHex(next);
         await cloudProvider.updateMyProfileThemeColor(hex: hex);
-        logger.info(
-            'theme_providers', 'primary color pushed to server: $hex');
+        logger.info('theme_providers', 'primary color pushed to server: $hex');
       } catch (e) {
         logger.warning(
             'theme_providers', 'push primary color failed (non-blocking): $e');
@@ -176,10 +178,10 @@ final compactAmountInitProvider = FutureProvider<void>((ref) async {
   });
 });
 
-// 显示交易时间Provider（默认不显示）
+// 显示交易时间Provider（默认显示到秒）
 // false = 只显示日期
-// true = 显示日期和时间（时:分）
-final showTransactionTimeProvider = StateProvider<bool>((ref) => false);
+// true = 在明细行显示交易时间（时:分:秒）
+final showTransactionTimeProvider = StateProvider<bool>((ref) => true);
 
 // 显示交易时间持久化初始化
 final showTransactionTimeInitProvider = FutureProvider<void>((ref) async {
@@ -262,11 +264,11 @@ void _pushAppearanceToCloud(Ref ref) {
         'note_display_mode': ref.read(noteDisplayModeProvider),
       };
       await cloudProvider.updateMyProfileAppearance(appearance: appearance);
-      logger.info('theme_providers',
-          'pushed appearance to server: $appearance');
+      logger.info(
+          'theme_providers', 'pushed appearance to server: $appearance');
     } catch (e, st) {
-      logger.warning('theme_providers',
-          'push appearance failed (non-blocking): $e', st);
+      logger.warning(
+          'theme_providers', 'push appearance failed (non-blocking): $e', st);
     }
   }());
 }
@@ -353,8 +355,8 @@ void _pushDisplayNameToCloud(Ref ref, String name) {
       await cloudProvider.updateMyProfileDisplayName(displayName: trimmed);
       logger.info('theme_providers', 'display name pushed to server: $trimmed');
     } catch (e, st) {
-      logger.warning('theme_providers',
-          'push display name failed (non-blocking): $e', st);
+      logger.warning(
+          'theme_providers', 'push display name failed (non-blocking): $e', st);
     }
   }());
 }

--- a/lib/widget/home_widget_view.dart
+++ b/lib/widget/home_widget_view.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 
 /// Flutter widget that will be rendered as the home screen widget
@@ -44,32 +43,22 @@ class HomeWidgetView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // For Android, add top/bottom padding to achieve 2:1 ratio (364x182)
-    // iOS uses natural 364x169 size
-    final isAndroid = Platform.isAndroid;
-    final verticalPadding = isAndroid ? (182 - 169) / 2 : 0.0; // 6.5 pixels top and bottom
-
     return Container(
       width: width,
       height: height,
-      color: Colors.transparent, // Transparent background for padding area
-      padding: EdgeInsets.symmetric(vertical: verticalPadding),
-      child: Container(
-        width: 364,
-        height: 169, // Always render content at 364x169
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              themeColor,
-              Color.lerp(themeColor, Colors.black, 0.15)!,
-            ],
-          ),
-          borderRadius: BorderRadius.circular(16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            themeColor,
+            Color.lerp(themeColor, Colors.black, 0.15)!,
+          ],
         ),
-        padding: const EdgeInsets.all(12),
-        child: Column(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Column(
         children: [
           // Header
           Row(
@@ -172,7 +161,6 @@ class HomeWidgetView extends StatelessWidget {
             ),
           ),
         ],
-        ),
       ),
     );
   }
@@ -258,5 +246,4 @@ class HomeWidgetView extends StatelessWidget {
       ),
     );
   }
-
 }

--- a/lib/widget/widget_manager.dart
+++ b/lib/widget/widget_manager.dart
@@ -91,10 +91,11 @@ class WidgetManager {
       // iOS uses 364x169 (2.15:1), Android needs 2:1 ratio
       // For Android, we'll render at 364x169 then add padding to make it 364x182 (2:1)
       final widgetSize = Platform.isIOS
-          ? const Size(364, 169)  // iOS systemMedium
+          ? const Size(364, 169) // iOS systemMedium
           : const Size(364, 182); // Android 2:1 ratio (364/2=182)
 
-      print('📱 Widget rendering - Platform: ${Platform.isIOS ? "iOS" : "Android"}, Size: ${widgetSize.width}x${widgetSize.height}, Ratio: ${(widgetSize.width / widgetSize.height).toStringAsFixed(2)}:1');
+      print(
+          '📱 Widget rendering - Platform: ${Platform.isIOS ? "iOS" : "Android"}, Size: ${widgetSize.width}x${widgetSize.height}, Ratio: ${(widgetSize.width / widgetSize.height).toStringAsFixed(2)}:1');
 
       print('🎨 开始渲染小组件...');
       await HomeWidget.renderFlutterWidget(
@@ -116,7 +117,9 @@ class WidgetManager {
         ),
         key: 'widgetImage',
         logicalSize: widgetSize,
-        pixelRatio: 4.0, // @4x for high resolution
+        // RemoteViews 会通过 Binder 传递位图；过大的 @4x 图在部分小米桌面上会更新失败，
+        // 表现为小部件占位但透明。1.5x 保持清晰度，同时把位图控制在安全大小内。
+        pixelRatio: 1.5,
       );
       print('✅ 小组件渲染完成');
 

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -368,7 +368,18 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
         mode: WheelDatePickerMode.ymd,
         maxDate: DateTime.now(),
       );
-      if (res != null) setState(() => _date = res);
+      if (res != null) {
+        final merged = DateTime(
+          res.year,
+          res.month,
+          res.day,
+          _date.hour,
+          _date.minute,
+          _date.second,
+        );
+        final now = DateTime.now();
+        setState(() => _date = merged.isAfter(now) ? now : merged);
+      }
     }
   }
 
@@ -420,7 +431,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
 
     // 如果备注框有焦点且键盘弹出，固定增加100的padding
-    final extraPadding = (_noteFieldHasFocus && keyboardHeight > 0) ? 100.0 : 0.0;
+    final extraPadding =
+        (_noteFieldHasFocus && keyboardHeight > 0) ? 100.0 : 0.0;
 
     double parsed() => double.tryParse(_amountStr) ?? 0.0;
 
@@ -487,8 +499,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     // 运算符键:同时显示「加减」与「乘除」两组运算符;当前激活的一组用主色高亮、
     // 另一组用次级色弱化(主次区分,也作为"长按可切到乘除"的提示)。单击应用激活
     // 运算符,长按切换加减 ↔ 乘除。
-    Widget opKey(String addSubOp, String mulDivOp, bool isMul,
-        VoidCallback onToggle) {
+    Widget opKey(
+        String addSubOp, String mulDivOp, bool isMul, VoidCallback onToggle) {
       final activeOp = isMul ? mulDivOp : addSubOp;
       // 激活的运算符与数字键完全一致(字号 18 / w600),保证视觉粗细相同 —— 字号
       // 更大即使同 weight 笔画也会更粗。未激活更小(14)+ 灰色以分主次。
@@ -543,7 +555,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     }
 
     String fmtDate(DateTime d) => '${d.year}/${d.month}/${d.day}';
-    String fmtTime(DateTime d) => '${d.hour.toString().padLeft(2, '0')}:${d.minute.toString().padLeft(2, '0')}:${d.second.toString().padLeft(2, '0')}';
+    String fmtTime(DateTime d) =>
+        '${d.hour.toString().padLeft(2, '0')}:${d.minute.toString().padLeft(2, '0')}:${d.second.toString().padLeft(2, '0')}';
     final showTime = ref.watch(showTransactionTimeProvider);
 
     return SafeArea(
@@ -580,7 +593,9 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                           final r1 = s.contains('.')
                               ? s.replaceFirst(RegExp(r'0+$'), '')
                               : s;
-                          return r1.endsWith('.') ? r1.substring(0, r1.length - 1) : r1;
+                          return r1.endsWith('.')
+                              ? r1.substring(0, r1.length - 1)
+                              : r1;
                         })(),
                         style: text.titleMedium?.copyWith(
                           fontWeight: FontWeight.w500,
@@ -631,7 +646,9 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                           final r1 = s.contains('.')
                               ? s.replaceFirst(RegExp(r'0+$'), '')
                               : s;
-                          return r1.endsWith('.') ? r1.substring(0, r1.length - 1) : r1;
+                          return r1.endsWith('.')
+                              ? r1.substring(0, r1.length - 1)
+                              : r1;
                         })(),
                         style: text.titleMedium?.copyWith(
                           fontWeight: FontWeight.w600,
@@ -673,7 +690,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                               onNotePicked: (note) {
                                 setState(() {
                                   _noteCtrl.text = note;
-                                  _noteCtrl.selection = TextSelection.fromPosition(
+                                  _noteCtrl.selection =
+                                      TextSelection.fromPosition(
                                     TextPosition(offset: note.length),
                                   );
                                 });
@@ -753,14 +771,16 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                                       Text(
                                         fmtDate(_date),
                                         style: text.labelSmall?.copyWith(
-                                            color: BeeTokens.textPrimary(context),
+                                            color:
+                                                BeeTokens.textPrimary(context),
                                             fontWeight: FontWeight.w600),
                                       ),
                                       const SizedBox(height: 2),
                                       Text(
                                         fmtTime(_date),
                                         style: text.labelSmall?.copyWith(
-                                            color: BeeTokens.textSecondary(context),
+                                            color: BeeTokens.textSecondary(
+                                                context),
                                             fontWeight: FontWeight.w500),
                                       ),
                                     ],
@@ -800,12 +820,15 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
 
                 // 判断是否处于运算模式
                 final isInCalcMode = _op != null;
-                final isEnabled = (isInCalcMode ? true : total.abs() > 0) && !_isSubmitting;
+                final isEnabled =
+                    (isInCalcMode ? true : total.abs() > 0) && !_isSubmitting;
 
                 return Padding(
                   padding: const EdgeInsets.all(6),
                   child: Material(
-                    color: isEnabled ? primary : BeeTokens.surfaceDisabled(context),
+                    color: isEnabled
+                        ? primary
+                        : BeeTokens.surfaceDisabled(context),
                     borderRadius: BorderRadius.circular(12),
                     child: InkWell(
                       borderRadius: BorderRadius.circular(12),
@@ -850,13 +873,19 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
                                   height: 20,
                                   child: CircularProgressIndicator(
                                     strokeWidth: 2,
-                                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                        Colors.white),
                                   ),
                                 )
                               : Text(
-                                  isInCalcMode ? '=' : AppLocalizations.of(context).commonFinish,
+                                  isInCalcMode
+                                      ? '='
+                                      : AppLocalizations.of(context)
+                                          .commonFinish,
                                   style: TextStyle(
-                                      color: isEnabled ? Colors.white : BeeTokens.textTertiary(context),
+                                      color: isEnabled
+                                          ? Colors.white
+                                          : BeeTokens.textTertiary(context),
                                       fontSize: isInCalcMode ? 24 : 16,
                                       fontWeight: FontWeight.w700),
                                 ),
@@ -942,13 +971,13 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     final allTags = allTagsAsync.valueOrNull ?? [];
 
     // 获取已选中的标签详情
-    final selectedTags = allTags
-        .where((t) => _selectedTagIds.contains(t.id))
-        .toList();
+    final selectedTags =
+        allTags.where((t) => _selectedTagIds.contains(t.id)).toList();
 
     // 获取附件数量
     if (widget.editingTransactionId != null) {
-      final attachmentsAsync = ref.watch(transactionAttachmentsProvider(widget.editingTransactionId!));
+      final attachmentsAsync = ref
+          .watch(transactionAttachmentsProvider(widget.editingTransactionId!));
       // 同样使用 valueOrNull 避免闪烁
       final attachments = attachmentsAsync.valueOrNull ?? [];
       final totalCount = attachments.length + _pendingAttachments.length;
@@ -1058,7 +1087,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     );
   }
 
-  Widget _buildRowContent(List<Tag> selectedTags, int attachmentCount, List<TransactionAttachment> savedAttachments) {
+  Widget _buildRowContent(List<Tag> selectedTags, int attachmentCount,
+      List<TransactionAttachment> savedAttachments) {
     final l10n = AppLocalizations.of(context);
     final hasAttachments = attachmentCount > 0;
 
@@ -1174,7 +1204,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
     ];
   }
 
-  Future<void> _handleAttachmentTap(List<TransactionAttachment> savedAttachments) async {
+  Future<void> _handleAttachmentTap(
+      List<TransactionAttachment> savedAttachments) async {
     final totalCount = savedAttachments.length + _pendingAttachments.length;
 
     if (totalCount == 0) {
@@ -1243,7 +1274,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
               title: Text(l10n.attachmentChooseFromGallery),
               onTap: () async {
                 Navigator.pop(context);
-                final files = await service.pickFromGallery(maxCount: 9 - _pendingAttachments.length);
+                final files = await service.pickFromGallery(
+                    maxCount: 9 - _pendingAttachments.length);
                 if (files.isNotEmpty && mounted) {
                   if (widget.editingTransactionId != null) {
                     // 编辑模式：直接保存

--- a/lib/widgets/biz/transaction_list_item.dart
+++ b/lib/widgets/biz/transaction_list_item.dart
@@ -31,7 +31,7 @@ class TransactionListItem extends ConsumerWidget {
   final bool isSelectionMode; // 是否处于选择模式
   final bool isSelected; // 是否被选中
   final VoidCallback? onSelectionChanged; // 选中状态改变回调
-  final bool showFullDate; // 是否显示完整日期（年-月-日 时:分）
+  final bool showFullDate; // 是否显示完整日期（年-月-日 时:分:秒）
 
   // 标签相关
   final List<({int id, String name, String? color})>? tags; // 关联的标签
@@ -45,34 +45,33 @@ class TransactionListItem extends ConsumerWidget {
   final bool excludeFromBudget; // 不计入预算:第二行显示「不计预算」标签
 
   const TransactionListItem({
-      super.key,
-      required this.icon,
-      this.category,
-      required this.title,
-      required this.amount,
-      required this.isExpense,
-      this.isTransfer = false,
-      this.isAdjustment = false,
-      this.hide,
-      this.onTap,
-      this.onCategoryTap,
-      this.categoryName,
-      this.ledgerName,
-      this.onDelete,
-      this.accountName,
-      this.happenedAt,
-      this.isSelectionMode = false,
-      this.isSelected = false,
-      this.onSelectionChanged,
-      this.showFullDate = false,
-      this.tags,
-      this.onTagTap,
-      this.attachmentCount = 0,
-      this.onAttachmentTap,
-      this.excludeFromStats = false,
-      this.excludeFromBudget = false,
+    super.key,
+    required this.icon,
+    this.category,
+    required this.title,
+    required this.amount,
+    required this.isExpense,
+    this.isTransfer = false,
+    this.isAdjustment = false,
+    this.hide,
+    this.onTap,
+    this.onCategoryTap,
+    this.categoryName,
+    this.ledgerName,
+    this.onDelete,
+    this.accountName,
+    this.happenedAt,
+    this.isSelectionMode = false,
+    this.isSelected = false,
+    this.onSelectionChanged,
+    this.showFullDate = false,
+    this.tags,
+    this.onTagTap,
+    this.attachmentCount = 0,
+    this.onAttachmentTap,
+    this.excludeFromStats = false,
+    this.excludeFromBudget = false,
   });
-
 
   /// 检查是否有次要信息需要显示（时间、账户或附件）
   bool _hasSecondaryInfo(WidgetRef ref) {
@@ -82,7 +81,9 @@ class TransactionListItem extends ConsumerWidget {
     // 显示时间（设置开启 + 有数据 + 不是00:00:00）
     final showTime = ref.watch(showTransactionTimeProvider) &&
         happenedAt != null &&
-        (happenedAt!.hour != 0 || happenedAt!.minute != 0 || happenedAt!.second != 0);
+        (happenedAt!.hour != 0 ||
+            happenedAt!.minute != 0 ||
+            happenedAt!.second != 0);
 
     return showTime ||
         accountName != null ||
@@ -122,10 +123,12 @@ class TransactionListItem extends ConsumerWidget {
         // 完整日期模式
         parts.add(
           '${happenedAt!.year}-${happenedAt!.month.toString().padLeft(2, '0')}-${happenedAt!.day.toString().padLeft(2, '0')} '
-          '${happenedAt!.hour.toString().padLeft(2, '0')}:${happenedAt!.minute.toString().padLeft(2, '0')}',
+          '${happenedAt!.hour.toString().padLeft(2, '0')}:${happenedAt!.minute.toString().padLeft(2, '0')}:${happenedAt!.second.toString().padLeft(2, '0')}',
         );
       } else if (ref.watch(showTransactionTimeProvider) &&
-          (happenedAt!.hour != 0 || happenedAt!.minute != 0 || happenedAt!.second != 0)) {
+          (happenedAt!.hour != 0 ||
+              happenedAt!.minute != 0 ||
+              happenedAt!.second != 0)) {
         // 完整时间模式（HH:mm:ss）
         parts.add(
           '${happenedAt!.hour.toString().padLeft(2, '0')}:${happenedAt!.minute.toString().padLeft(2, '0')}:${happenedAt!.second.toString().padLeft(2, '0')}',
@@ -139,9 +142,9 @@ class TransactionListItem extends ConsumerWidget {
     }
 
     final textStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
-      color: BeeTokens.textTertiary(context),
-      fontSize: 11,
-    );
+          color: BeeTokens.textTertiary(context),
+          fontSize: 11,
+        );
 
     // 构建附件图标部件（可点击）
     Widget buildAttachmentWidget() {
@@ -176,7 +179,8 @@ class TransactionListItem extends ConsumerWidget {
       if (excludeFromStats)
         _flagChip(context, AppLocalizations.of(context).txFlagExcludedTag),
       if (excludeFromBudget)
-        _flagChip(context, AppLocalizations.of(context).txFlagBudgetExcludedTag),
+        _flagChip(
+            context, AppLocalizations.of(context).txFlagBudgetExcludedTag),
     ];
 
     // 如果只有附件 / 标签，没有时间·账户文字
@@ -279,9 +283,13 @@ class TransactionListItem extends ConsumerWidget {
                                   if (composed.parenNote != null)
                                     TextSpan(
                                       text: '  (${composed.parenNote})',
-                                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                        color: BeeTokens.textSecondary(context),
-                                      ),
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .bodySmall
+                                          ?.copyWith(
+                                            color: BeeTokens.textSecondary(
+                                                context),
+                                          ),
                                     ),
                                 ],
                               ),
@@ -294,9 +302,12 @@ class TransactionListItem extends ConsumerWidget {
                         if (ledgerName != null && ledgerName!.isNotEmpty) ...[
                           const SizedBox(width: 6),
                           Container(
-                            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 2),
                             decoration: BoxDecoration(
-                              color: ref.watch(primaryColorProvider).withValues(alpha: 0.1),
+                              color: ref
+                                  .watch(primaryColorProvider)
+                                  .withValues(alpha: 0.1),
                               borderRadius: BorderRadius.circular(4),
                             ),
                             child: Text(
@@ -331,7 +342,9 @@ class TransactionListItem extends ConsumerWidget {
                 AmountText(
                     value: isAdjustment
                         ? amount // adjustment 直接显示原始值（含正负）
-                        : isExpense ? -amount : amount,
+                        : isExpense
+                            ? -amount
+                            : amount,
                     hide: hide,
                     signed: !isTransfer, // 转账不显示正负号
                     decimals: 2,
@@ -383,10 +396,11 @@ class TransactionListItem extends ConsumerWidget {
         confirmDismiss: (direction) async {
           // 显示确认对话框
           return await AppDialog.confirm<bool>(
-            context,
-            title: '确认删除',
-            message: '确定要删除这笔交易吗？此操作无法撤销。',
-          ) ?? false;
+                context,
+                title: '确认删除',
+                message: '确定要删除这笔交易吗？此操作无法撤销。',
+              ) ??
+              false;
         },
         onDismissed: (direction) {
           onDelete!();


### PR DESCRIPTION
## Summary
- Show transaction time down to seconds by default and preserve time when editing only the date.
- Reduce Android widget bitmap size and downsample native decoding to avoid transparent widgets on MIUI.
- Remove Android widget letterboxing by rendering the widget image full-height and fitting it to the host bounds.

## Verification
- Built dev debug APK successfully.
- Installed and tested on Xiaomi 2211133C via USB.
- Confirmed transaction list shows HH:mm:ss.
- Confirmed MIUI desktop widget displays, updates, and no longer has transparent/white letterbox areas.