### PR TITLE
feat(分类管理): 实现拖拽排序自动滚动功能

### DIFF
--- a/lib/pages/category/category_manage_page.dart
+++ b/lib/pages/category/category_manage_page.dart
@@ -651,33 +651,26 @@ class _CategoryGridViewState extends ConsumerState<_CategoryGridView> {
       );
     }
 
-    return ListView(
+    return ReorderableGridView.builder(
       padding: const EdgeInsets.all(16),
-      children: [
-        ReorderableGridView.builder(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          padding: EdgeInsets.zero,
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 4,
-            crossAxisSpacing: 12,
-            mainAxisSpacing: 12,
-            childAspectRatio: 1,
-          ),
-          itemCount: topLevelCategories.length,
-          onReorder: (oldIndex, newIndex) {
-            _onReorderTopLevel(oldIndex, newIndex, topLevelCategories);
-          },
-          itemBuilder: (context, index) {
-            final item = topLevelCategories[index];
-            return _CategoryCard(
-              key: ValueKey(item.category.id),
-              item: item,
-              onTap: () => _onCategoryTap(item),
-            );
-          },
-        ),
-      ],
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 4,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+        childAspectRatio: 1,
+      ),
+      itemCount: topLevelCategories.length,
+      onReorder: (oldIndex, newIndex) {
+        _onReorderTopLevel(oldIndex, newIndex, topLevelCategories);
+      },
+      itemBuilder: (context, index) {
+        final item = topLevelCategories[index];
+        return _CategoryCard(
+          key: ValueKey(item.category.id),
+          item: item,
+          onTap: () => _onCategoryTap(item),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## 问题描述
分类管理页面拖动排序时无法自动翻屏幕，只能拖到屏幕边缘后手动滑动屏幕再继续拖动，用户体验不佳。

## 解决方案
- 移除外层 `ListView` 包裹，让 `ReorderableGridView` 直接可滚动
- 移除 `shrinkWrap: true` 和 `physics: NeverScrollableScrollPhysics()` 限制
- 调整 padding 配置，保持原有边距效果

## 测试
- [x] 拖拽分类图标到屏幕边缘时自动滚动
- [x] 拖拽排序功能正常工作
- [x] 视觉效果与原来保持一致

## 变更文件
- `lib/pages/category/category_manage_page.dart`