### PR TITLE
Show transaction time down to seconds

### DIFF
--- a/lib/providers/theme_providers.dart
+++ b/lib/providers/theme_providers.dart
@@ -176,10 +176,10 @@ final compactAmountInitProvider = FutureProvider<void>((ref) async {
   });
 });
 
-// 显示交易时间Provider（默认不显示）
+// 显示交易时间Provider（默认显示到秒）
 // false = 只显示日期
-// true = 显示日期和时间（时:分）
-final showTransactionTimeProvider = StateProvider<bool>((ref) => false);
+// true = 在明细行显示交易时间（时:分:秒）
+final showTransactionTimeProvider = StateProvider<bool>((ref) => true);
 
 // 显示交易时间持久化初始化
 final showTransactionTimeInitProvider = FutureProvider<void>((ref) async {

--- a/lib/providers/theme_providers.dart
+++ b/lib/providers/theme_providers.dart
@@ -176,10 +176,10 @@ final compactAmountInitProvider = FutureProvider<void>((ref) async {
   });
 });
 
-// 显示交易时间Provider（默认显示到秒）
+// 显示交易时间Provider（默认不显示）
 // false = 只显示日期
 // true = 在明细行显示交易时间（时:分:秒）
-final showTransactionTimeProvider = StateProvider<bool>((ref) => true);
+final showTransactionTimeProvider = StateProvider<bool>((ref) => false);
 
 // 显示交易时间持久化初始化
 final showTransactionTimeInitProvider = FutureProvider<void>((ref) async {

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -359,19 +359,8 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
         initial: _date,
         maxDate: DateTime.now(),
       );
-      if (res != null) {
-        final merged = DateTime(
-          res.year,
-          res.month,
-          res.day,
-          _date.hour,
-          _date.minute,
-          _date.second,
-        );
-        final now = DateTime.now();
-        // 只改日期时保留原来的时分秒；如果新日期是今天且时间超过当前时间，回退到现在。
-        setState(() => _date = merged.isAfter(now) ? now : merged);
-      }
+      // res（选择结果）已经包含用户选定的年、月、日、时、分、秒。
+      if (res != null) setState(() => _date = res);
     } else {
       // 普通模式，只选择日期
       final res = await showWheelDatePicker(

--- a/lib/widgets/biz/amount_editor_sheet.dart
+++ b/lib/widgets/biz/amount_editor_sheet.dart
@@ -359,7 +359,19 @@ class _AmountEditorSheetState extends ConsumerState<AmountEditorSheet> {
         initial: _date,
         maxDate: DateTime.now(),
       );
-      if (res != null) setState(() => _date = res);
+      if (res != null) {
+        final merged = DateTime(
+          res.year,
+          res.month,
+          res.day,
+          _date.hour,
+          _date.minute,
+          _date.second,
+        );
+        final now = DateTime.now();
+        // 只改日期时保留原来的时分秒；如果新日期是今天且时间超过当前时间，回退到现在。
+        setState(() => _date = merged.isAfter(now) ? now : merged);
+      }
     } else {
       // 普通模式，只选择日期
       final res = await showWheelDatePicker(

--- a/lib/widgets/biz/transaction_list_item.dart
+++ b/lib/widgets/biz/transaction_list_item.dart
@@ -25,13 +25,13 @@ class TransactionListItem extends ConsumerWidget {
   final String? ledgerName; // 账本名称（仅"全部账本"模式下显示标签）
   final VoidCallback? onDelete; // 删除回调
   final String? accountName; // 账户名称，用于显示
-  final DateTime? happenedAt; // 交易时间，用于显示时分
+  final DateTime? happenedAt; // 交易时间，用于显示时分秒
 
   // 批量选择模式相关
   final bool isSelectionMode; // 是否处于选择模式
   final bool isSelected; // 是否被选中
   final VoidCallback? onSelectionChanged; // 选中状态改变回调
-  final bool showFullDate; // 是否显示完整日期（年-月-日 时:分）
+  final bool showFullDate; // 是否显示完整日期（年-月-日 时:分:秒）
 
   // 标签相关
   final List<({int id, String name, String? color})>? tags; // 关联的标签
@@ -122,7 +122,7 @@ class TransactionListItem extends ConsumerWidget {
         // 完整日期模式
         parts.add(
           '${happenedAt!.year}-${happenedAt!.month.toString().padLeft(2, '0')}-${happenedAt!.day.toString().padLeft(2, '0')} '
-          '${happenedAt!.hour.toString().padLeft(2, '0')}:${happenedAt!.minute.toString().padLeft(2, '0')}',
+          '${happenedAt!.hour.toString().padLeft(2, '0')}:${happenedAt!.minute.toString().padLeft(2, '0')}:${happenedAt!.second.toString().padLeft(2, '0')}',
         );
       } else if (ref.watch(showTransactionTimeProvider) &&
           (happenedAt!.hour != 0 || happenedAt!.minute != 0 || happenedAt!.second != 0)) {


### PR DESCRIPTION
## Summary
- Show transaction time down to seconds by default.
- Include seconds in full-date transaction rows.
- Preserve the existing time when only changing the transaction date, clamping future timestamps back to now.

## Verification
- `flutter pub get`
- `flutter build apk --debug --flavor dev -t lib/main.dart`