### PR TITLE
docs: 商业授权公示与贡献者许可条款（CLA）落地

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## 变更说明 / What & Why
+
+<!-- 这个 PR 做了什么、为什么这么做 / What does this PR do, and why -->
+
+## 关联 Issue / Related Issue
+
+<!-- 例如 Closes #123；没有可删除本节 / e.g. Closes #123; remove this section if none -->
+
+## 自测情况 / Self-tested
+
+- [ ] `flutter analyze` 无新增告警 / no new warnings
+- [ ] `flutter test` 通过 / tests pass
+- [ ] 已实机运行验证；UI 变更已附截图 / verified on a real device; screenshots attached for UI changes
+- [ ] 涉及文案变更：已更新 `lib/l10n/*.arb` 并用 Flutter 3.27.3 运行 `flutter gen-l10n` / for copy changes: arb files updated and `flutter gen-l10n` run with Flutter 3.27.3
+
+## 贡献者许可条款 / Contributor License Terms
+
+- [ ] 我已阅读并同意贡献者许可条款 / I have read and agree to the [Contributor License Terms](../CONTRIBUTING.md#贡献者许可条款contributor-license-terms)

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -1,0 +1,55 @@
+# BeeCount 商业授权 / Commercial License
+
+中文 | [English](#english)
+
+BeeCount 及 [BeeCount-Cloud](https://github.com/TNT-Likely/BeeCount-Cloud) 对个人使用、学习研究免费（见 [LICENSE](LICENSE)）。**任何商业使用均需购买商业授权**，包括：作为产品或服务提供给客户、在盈利性组织中使用、基于源码开发商业产品、集成进商业软件、提供付费云服务（SaaS）。
+
+## 授权模式
+
+一次性买断指定版本（git tag）源码，针对已交付版本**永久有效**；按现状（AS IS）交付、自行维护。版本更新、技术支持、部署协助、定制开发等为可选增值服务，价格随报价单提供。
+
+## 定价
+
+| 档位 | 适用场景 | 价格（一次性） |
+|---|---|---|
+| **内部使用授权** | 一个组织内部使用（含自部署云端），不对外提供 | **¥1,999** |
+| **商业产品授权（单产品）** | 发布 1 款自有品牌商业 App（可闭源、可上架、可收费），含配套云端 | **¥9,999** |
+| **SaaS / OEM / 多产品** | 付费云服务、白标转售、多产品线复用 | **¥29,999 起**，面谈 |
+
+## 商业授权包含什么
+
+- ✅ 指定版本完整源码（App + Cloud），一次交付、永久使用
+- ✅ 商业使用权（按档位范围）
+- ✅ 闭源权：豁免「修改版必须开源」义务
+- ✅ 以自有品牌发布二进制产物（App Store / Google Play / 国内商店）
+- ❌ 不含版本更新与技术支持——可作为增值服务单独购买
+- ❌ 不含「BeeCount / 蜜蜂记账」名称、图标与商标——需更名换标发布
+- ❌ 不含源码转售 / 再许可权
+- ℹ️ 第三方开源依赖按其各自协议授权（见 [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md)）
+
+## 购买流程
+
+1. 邮件联系 **sunxiaoyes@outlook.com**，说明使用场景（内部使用 / 发布产品 / SaaS）与主体信息；
+2. 收到正式报价单（含增值服务价目，30 天有效）→ 电子签署《软件商业授权许可合同》；
+3. 付款后 3 个工作日内交付：指定版本源码包（zip + SHA256）+ 授权证书 + 第三方组件清单；
+4. 可开具发票。
+
+> 价格可能随版本演进调整，以邮件报价单为准；已签约客户不受影响。
+
+---
+
+## English
+
+BeeCount and [BeeCount-Cloud](https://github.com/TNT-Likely/BeeCount-Cloud) are free for personal use, learning and research (see [LICENSE_EN](LICENSE_EN)). **Any commercial use requires a paid commercial license**, including: offering it to customers as a product or service, using it within a for-profit organization, building commercial products on the source code, integrating it into commercial software, or operating a paid cloud service (SaaS).
+
+**Model**: one-time purchase of the source code at a specified git tag, perpetual for delivered versions, delivered AS IS and self-maintained. Updates, technical support, deployment help and custom development are optional paid add-ons, quoted on request.
+
+| Tier | Use case | Price (one-time) |
+|---|---|---|
+| **Internal Use** | Within one organization (incl. self-hosted cloud), no external offering | **$299** |
+| **Commercial Product (single)** | Ship 1 closed-source app under your own brand, incl. companion cloud backend | **$1,399** |
+| **SaaS / OEM / Multi-product** | Paid cloud service, white-label resale, multiple products | **from $3,999**, negotiable |
+
+The "BeeCount" trademark is not included — products must ship under your own brand. Third-party dependencies remain under their own licenses (see [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md)).
+
+Contact **sunxiaoyes@outlook.com** with your use case for a formal quote (incl. add-on pricing) and a contract sample. Prices may change over time; the emailed quote prevails, and existing licensees are unaffected.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# 贡献指南 / Contributing
+
+感谢你对蜜蜂记账的关注！完整的开发环境、代码规范与提交流程请见 [docs/contributing/CONTRIBUTING_ZH.md](docs/contributing/CONTRIBUTING_ZH.md)（[English](docs/contributing/CONTRIBUTING_EN.md)）。提交 PR 前，请阅读并同意下方贡献者许可条款（PR 模板中有确认勾选框）。
+
+## 贡献者许可条款（Contributor License Terms）
+
+BeeCount 采用「免费非商用 + 付费商业授权」的双许可模式（见 [LICENSE](LICENSE)）。为使该模式可持续，向本仓库提交贡献（PR / patch / 翻译等）即表示你同意：
+
+1. 你的贡献以仓库 [LICENSE](LICENSE) 授权；
+2. 你授予项目维护者（sunxiao / [TNT-Likely](https://github.com/TNT-Likely)）一项**非独占、永久、不可撤销、免费、全球范围**的权利，可以任何条款（包括商业许可条款）使用、修改、分发及**再许可**你的贡献；
+3. 你确认贡献是你的原创作品，或你有权按上述条款提交。
+
+你保留自己贡献的著作权，这不是版权转让。若不同意上述条款，请不要提交贡献。
+
+---
+
+## Contributing (English)
+
+Thanks for your interest in BeeCount! For development setup, code style and the full PR workflow, see [docs/contributing/CONTRIBUTING_EN.md](docs/contributing/CONTRIBUTING_EN.md). Please read and agree to the Contributor License Terms below before submitting a PR (the PR template includes a confirmation checkbox).
+
+### Contributor License Terms
+
+BeeCount is dual-licensed: free for non-commercial use, paid license for commercial use (see [LICENSE_EN](LICENSE_EN)). By submitting a contribution (PR / patch / translation, etc.) to this repository, you agree that:
+
+1. Your contribution is licensed under the repository [LICENSE](LICENSE_EN);
+2. You grant the project maintainer (sunxiao / [TNT-Likely](https://github.com/TNT-Likely)) a **non-exclusive, perpetual, irrevocable, royalty-free, worldwide** right to use, modify, distribute and **sublicense** your contribution under any terms, including commercial license terms;
+3. Your contribution is your original work, or you have the right to submit it under these terms.
+
+You retain the copyright of your contribution — this is not a copyright assignment. If you do not agree with these terms, please do not submit contributions.

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ BeeCount 软件许可协议
 
 版本 1.0，生效日期：2025-01-29
 
-版权所有 (c) 2024-2025 BeeCount 开发者
+版权所有 (c) 2024-2026 sunxiao（GitHub: TNT-Likely）
 
 ## 授权范围
 
@@ -30,8 +30,9 @@ BeeCount 软件许可协议
 
 ### 商业许可获取
 
-如需商业使用，请联系开发者获取商业许可：
-- GitHub: https://github.com/TNT-Likely/BeeCount
+商业许可由著作权人以书面许可合同形式签发。价格与购买流程见 [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md)。如需商业使用，请联系：
+
+- 邮箱：sunxiaoyes@outlook.com
 - Issues: https://github.com/TNT-Likely/BeeCount/issues
 
 ## 使用条款

--- a/LICENSE_EN
+++ b/LICENSE_EN
@@ -5,7 +5,7 @@ BeeCount Software License Agreement
 
 Version 1.0, Effective Date: January 29, 2025
 
-Copyright (c) 2024-2025 BeeCount Developers
+Copyright (c) 2024-2026 sunxiao (GitHub: TNT-Likely)
 
 ## Grant of Rights
 
@@ -30,8 +30,9 @@ The following cases are considered commercial use and require a paid commercial 
 
 ### Obtaining a Commercial License
 
-For commercial use, please contact the developers:
-- GitHub: https://github.com/TNT-Likely/BeeCount
+Commercial licenses are granted by the copyright holder in the form of a written license agreement. See [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md) for pricing and process. For commercial use, please contact:
+
+- Email: sunxiaoyes@outlook.com
 - Issues: https://github.com/TNT-Likely/BeeCount/issues
 
 ## Terms of Use

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ A: 使用自己的服务器 / Storage / Bucket,WebDAV 和 S3 建议 HTTPS 加密
 - 基于本软件开发商业产品
 - 提供基于本软件的付费云服务
 
-如需商业授权,请通过 [GitHub Issues](https://github.com/TNT-Likely/BeeCount/issues) 联系。详见 [LICENSE](LICENSE)。
+商业授权价格与购买流程见 [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md)，或邮件联系 **sunxiaoyes@outlook.com**。详见 [LICENSE](LICENSE)。
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -358,7 +358,7 @@ This project uses the **Business Source License (BSL)**.
 - Building commercial products on top of this software
 - Offering paid cloud services based on this software
 
-For commercial licensing, please contact via [GitHub Issues](https://github.com/TNT-Likely/BeeCount/issues). See [LICENSE](LICENSE) for details.
+For commercial licensing pricing and process, see [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md) or contact **sunxiaoyes@outlook.com**. See [LICENSE_EN](LICENSE_EN) for details.
 
 </details>
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,29 @@
+# 第三方组件声明 / Third-Party Notices
+
+本仓库源码**不包含（vendor）任何第三方库的源代码**。所有第三方依赖由 `pubspec.yaml` / `pubspec.lock` 声明，在构建时经 pub 从官方源获取，各自按其原始开源协议授权，与本项目的 [LICENSE](LICENSE)（双许可）相互独立。使用、分发或基于本项目二次开发时，请一并遵守下列组件各自的协议。
+
+`packages/` 目录下的 `flutter_ai_kit*` 与 `flutter_cloud_sync*` 系列为本项目自研组件，属许可软件本体、受项目 LICENSE 约束，**不属于第三方组件**。
+
+> 以下清单基于各包发布物中的 LICENSE 文本核验（2026-07 整理，共 51 个第三方直接依赖，**无 GPL / LGPL / AGPL 项**）。传递依赖可用 `flutter pub deps` 查看；如与上游申明不符，以上游为准。
+>
+> **English**: This repository does **not vendor** any third-party source code. All dependencies are declared in `pubspec.yaml` / `pubspec.lock` and fetched by pub at build time under their own licenses, independent of this project's dual [LICENSE](LICENSE_EN). Packages under `packages/` (`flutter_ai_kit*`, `flutter_cloud_sync*`) are first-party components covered by the project LICENSE. The list below was verified against each package's published LICENSE text (as of 2026-07, 51 direct third-party dependencies, **no GPL / LGPL / AGPL**); upstream prevails in case of discrepancy.
+
+## 直接依赖 / Direct dependencies
+
+**Flutter SDK / flutter_localizations** — BSD-3-Clause
+
+**MIT（20）**
+archive · country_flags · csv · dio · drift · excel · file_picker · fl_chart · flutter_image_compress · flutter_list_view · flutter_riverpod · flutter_svg · gbk_codec · in_app_review · permission_handler · reorderable_grid_view · sqlite3_flutter_libs · supabase_flutter · uuid · yaml
+
+**BSD-3-Clause（26）**
+collection · connectivity_plus · crypto · flutter_local_notifications · gal · home_widget · http · image_cropper · in_app_purchase · in_app_purchase_storekit · intl · jovial_svg · local_auth · open_filex · package_info_plus · path · path_provider · qr_flutter · quick_actions · record · share_plus · shared_preferences · url_launcher · visibility_detector · webview_flutter · webview_flutter_wkwebview
+
+**Apache-2.0（4）**
+app_links · decimal · image_picker · table_calendar
+
+**BSD-2-Clause（1）**
+timezone
+
+---
+
+如发现本清单与上游实际协议不符，欢迎提 Issue 指正。

--- a/docs/contributing/CONTRIBUTING_EN.md
+++ b/docs/contributing/CONTRIBUTING_EN.md
@@ -702,9 +702,9 @@ git push origin docs/improve-supabase-guide
 
 All contributors will be recorded in the project's contributor list. Significant contributions will be specially acknowledged in Release Notes.
 
-## License
+## License & Contributor License Terms
 
-By contributing code, you agree that your contributions will be licensed under the project's [MIT License](../../LICENSE).
+This project is dual-licensed: free for non-commercial use, paid license for commercial use (see [LICENSE_EN](../../LICENSE_EN)). By submitting a contribution (code / translation / docs, etc.), you agree to the [Contributor License Terms in the root CONTRIBUTING.md](../../CONTRIBUTING.md#contributor-license-terms): your contribution is licensed under the repository LICENSE, and you grant the project maintainer the right to sublicense it, including under commercial license terms; you retain the copyright of your contribution.
 
 ---
 

--- a/docs/contributing/CONTRIBUTING_ZH.md
+++ b/docs/contributing/CONTRIBUTING_ZH.md
@@ -703,9 +703,9 @@ git push origin docs/improve-supabase-guide
 
 所有贡献者都会被记录在项目的贡献者列表中。重大贡献会在 Release Notes 中特别感谢。
 
-## 许可证
+## 许可证与贡献者许可条款
 
-通过贡献代码，你同意你的贡献将按照项目的 [MIT License](../../LICENSE) 进行许可。
+本项目采用「个人免费、商业付费」的双许可模式（见 [LICENSE](../../LICENSE)）。通过提交贡献（代码/翻译/文档等），你同意根目录 [CONTRIBUTING.md 中的贡献者许可条款](../../CONTRIBUTING.md#贡献者许可条款contributor-license-terms)：你的贡献以仓库 LICENSE 授权，同时授予项目维护者含商业许可在内的再许可权利；你保留自己贡献的著作权。
 
 ---
 


### PR DESCRIPTION
## 变更说明

商业授权体系在仓库侧的公示与制度落地：

**新增**
- `COMMERCIAL_LICENSE.md`：商业授权公示页（中英），三档定价 + 授权范围说明 + 购买流程；增值服务价格随报价单提供，不在页面公示
- `CONTRIBUTING.md`（根目录）：中英双语贡献者许可条款（CLA）——贡献者保留著作权，授予维护者含商业许可在内的再许可权利；GitHub 会在 PR/issue 界面自动提示此文件
- `.github/PULL_REQUEST_TEMPLATE.md`：中英对照 PR 模板，含自测清单（analyze / test / 实机截图 / gen-l10n 版本要求）与 CLA 确认勾选框
- `THIRD-PARTY-NOTICES.md`：51 个第三方直接依赖的协议清单（逐包 LICENSE 文本核验，全为 MIT/BSD/Apache 系，无 GPL/LGPL）；`packages/` 自研组件归属说明

**修改**
- `LICENSE` / `LICENSE_EN`：版权行署名 `sunxiao（GitHub: TNT-Likely）`、年份补至 2026；「商业许可获取」补充书面合同签发方式、联系邮箱与 COMMERCIAL_LICENSE.md 链接
- `README.md` / `README_EN.md`：开源协议段落链接商业授权公示页与联系邮箱
- `docs/contributing/CONTRIBUTING_ZH.md` / `_EN.md`：修正末尾「贡献按 MIT License 许可」的历史错误表述（项目并非 MIT），改为与根目录 CLA 一致的双许可表述

## 自测情况

- 纯文档变更，无代码改动；所有站内链接（LICENSE / COMMERCIAL_LICENSE / THIRD-PARTY-NOTICES / docs/contributing）已核对
