### PR TITLE
feat: 日历视图支持点标题快捷跳转年月，并修复 firstDay 硬编码 2020

### DIFF
--- a/lib/data/repositories/local/local_transaction_repository.dart
+++ b/lib/data/repositories/local/local_transaction_repository.dart
@@ -930,44 +930,6 @@ class LocalTransactionRepository implements TransactionRepository {
     final startDate = DateTime(month.year, month.month, 1);
     final endDate = DateTime(month.year, month.month + 1, 0, 23, 59, 59);
 
-    print('🔍 Repository查询: ledgerId=$ledgerId, 日期范围: $startDate ~ $endDate');
-
-    // 先查询该月份有多少条交易
-    final countQuery = '''
-      SELECT COUNT(*) as count
-      FROM transactions
-      WHERE ledger_id = ?
-        AND happened_at >= ?
-        AND happened_at <= ?
-    ''';
-
-    final countResult = await db.customSelect(
-      countQuery,
-      variables: [
-        d.Variable.withInt(ledgerId),
-        d.Variable.withDateTime(startDate),
-        d.Variable.withDateTime(endDate),
-      ],
-    ).getSingle();
-
-    final totalCount = countResult.read<int>('count');
-    print('🔍 该月份总交易数: $totalCount');
-
-    // 查看一条交易的 happened_at 值
-    if (totalCount > 0) {
-      final sampleQuery = 'SELECT happened_at FROM transactions WHERE ledger_id = ? LIMIT 1';
-      final sample = await db.customSelect(
-        sampleQuery,
-        variables: [d.Variable.withInt(ledgerId)],
-      ).getSingle();
-      final happenedAtValue = sample.read<int>('happened_at');
-      print('🔍 样例 happened_at 值(int): $happenedAtValue');
-
-      // 尝试转换为 DateTime 看看
-      final asDateTime = DateTime.fromMillisecondsSinceEpoch(happenedAtValue * 1000);
-      print('🔍 转换为 DateTime (假设是秒): $asDateTime');
-    }
-
     // SQL 聚合查询
     // Drift 存储 DateTime 为 Unix timestamp（秒），直接使用 strftime
     final query = '''
@@ -992,8 +954,6 @@ class LocalTransactionRepository implements TransactionRepository {
       ],
     ).get();
 
-    print('🔍 SQL聚合查询结果: ${results.length} 条');
-
     final map = <String, (double, double)>{};
     for (final row in results) {
       final date = row.read<String?>('date');
@@ -1001,10 +961,8 @@ class LocalTransactionRepository implements TransactionRepository {
       final income = row.read<double>('income') ?? 0.0;
       final expense = row.read<double>('expense') ?? 0.0;
       map[date] = (income, expense);
-      print('  $date: 收入=$income, 支出=$expense');
     }
 
-    print('🔍 最终返回 Map: ${map.length} 条');
     return map;
   }
 

--- a/lib/pages/calendar/calendar_page.dart
+++ b/lib/pages/calendar/calendar_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:intl/intl.dart';
-import 'package:intl/date_symbol_data_local.dart';
 
 import '../../widgets/ui/ui.dart';
 import '../../widgets/biz/section_card.dart';
@@ -11,7 +10,6 @@ import '../../widgets/category_icon.dart';
 import '../../styles/tokens.dart';
 import '../../utils/ui_scale_extensions.dart';
 import '../../utils/transaction_edit_utils.dart';
-import '../../utils/currencies.dart';
 import '../../providers.dart';
 import '../../providers/calendar_providers.dart';
 import '../../l10n/app_localizations.dart';
@@ -153,18 +151,12 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final ledgerId = ref.watch(currentLedgerIdProvider);
-    final ledgerAsync = ref.watch(currentLedgerProvider);
     final primaryColor = ref.watch(primaryColorProvider);
-    final currencySymbol = ledgerAsync.maybeWhen(
-      data: (ledger) => ledger?.currency ?? 'CNY',
-      orElse: () => 'CNY',
-    );
 
     // 监听数据刷新
     ref.watch(calendarRefreshProvider);
 
     // 获取当月统计数据
-    print('🔍 查询参数: ledgerId=$ledgerId, month=$_focusedMonth');
     final dailyTotalsAsync = ref.watch(
       dailyTotalsByMonthProvider((ledgerId: ledgerId, month: _focusedMonth)),
     );
@@ -250,15 +242,6 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
       fontWeight: FontWeight.w600,
       color: BeeTokens.textPrimary(context),
     );
-
-    print('📊 _buildCalendar 被调用: dailyTotals.length=${dailyTotals.length}');
-    print('📊 locale=${locale.toString()}');
-    if (dailyTotals.isNotEmpty) {
-      print('📊 数据样例:');
-      dailyTotals.entries.take(5).forEach((e) {
-        print('  ${e.key}: 收入=${e.value.$1}, 支出=${e.value.$2}');
-      });
-    }
 
     return TableCalendar(
       locale: locale.toString(),
@@ -423,14 +406,6 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
     final totals = dailyTotals[dateKey];
     final (income, expense) = totals ?? (0.0, 0.0);
     final hasTransaction = income > 0 || expense > 0;
-
-    // 调试：打印前3天的数据
-    if (day.day <= 3 && day.month == _focusedMonth.month) {
-      print('📅 _buildDateCell: day=${day.day}, dateKey=$dateKey');
-      print(
-          '   totals=$totals, income=$income, expense=$expense, hasTransaction=$hasTransaction');
-      print('   isOutside=$isOutside');
-    }
 
     // 文字颜色
     Color textColor;
@@ -686,103 +661,6 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [header, card],
-    );
-  }
-
-  // 构建当月交易列表（不显示日期和统计）
-  Widget _buildMonthTransactionsList(
-      BuildContext context, int ledgerId, DateTime month) {
-    final l10n = AppLocalizations.of(context);
-
-    // 使用 Provider 查询当月交易
-    final startDate = DateTime(month.year, month.month, 1);
-    final endDate = DateTime(month.year, month.month + 1, 0, 23, 59, 59);
-
-    final transactionsAsync = ref.watch(
-      monthTransactionsProvider(
-          (ledgerId: ledgerId, startDate: startDate, endDate: endDate)),
-    );
-
-    return SectionCard(
-      margin: EdgeInsets.zero,
-      child: transactionsAsync.when(
-        data: (transactions) {
-          if (transactions.isEmpty) {
-            return Padding(
-              padding: EdgeInsets.all(24.0.scaled(context, ref)),
-              child: Center(
-                child: Text(
-                  l10n.calendarNoTransactions,
-                  style: TextStyle(
-                    color: BeeTokens.textTertiary(context),
-                  ),
-                ),
-              ),
-            );
-          }
-
-          // 直接显示交易列表
-          return ListView.builder(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            padding: EdgeInsets.zero,
-            itemCount: transactions.length,
-            itemBuilder: (context, index) {
-              final item = transactions[index];
-              final category = item.category;
-              final isExpense = item.t.type == 'expense';
-              final isTransfer = item.t.type == 'transfer';
-
-              // 分类名称
-              final categoryName = category?.name ?? l10n.commonUncategorized;
-
-              // 备注作为副标题
-              final subtitle = item.t.note ?? '';
-
-              // 标签列表
-              final tagsList = item.tags
-                  .map((tag) => (id: tag.id, name: tag.name, color: tag.color))
-                  .toList();
-
-              return TransactionListItem(
-                icon: getCategoryIconData(category: category, categoryName: categoryName),
-                category: category,
-                title: isTransfer
-                    ? (subtitle.isNotEmpty ? subtitle : l10n.transferTitle)
-                    : (subtitle.isNotEmpty ? subtitle : categoryName),
-                categoryName: isTransfer
-                    ? null
-                    : (subtitle.isNotEmpty ? categoryName : null),
-                amount: item.t.amount,
-                currencyCode: item.t.currencyCode,
-                nativeAmount: item.t.nativeAmount,
-                isExpense: isExpense,
-                isTransfer: isTransfer,
-                happenedAt: item.t.happenedAt,
-                accountName: item.account?.name,
-                tags: tagsList.isNotEmpty ? tagsList : null,
-                attachmentCount: item.attachments.length,
-                onTap: () async {
-                  await TransactionEditUtils.editTransaction(
-                    context,
-                    ref,
-                    item.t,
-                    item.category,
-                  );
-                },
-              );
-            },
-          );
-        },
-        loading: () => const Padding(
-          padding: EdgeInsets.all(24),
-          child: Center(child: CircularProgressIndicator()),
-        ),
-        error: (err, stack) => Padding(
-          padding: const EdgeInsets.all(24),
-          child: Center(child: Text('Error: $err')),
-        ),
-      ),
     );
   }
 

--- a/lib/pages/calendar/calendar_page.dart
+++ b/lib/pages/calendar/calendar_page.dart
@@ -28,6 +28,22 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
   late DateTime _focusedMonth;
   DateTime? _selectedDay;
 
+  // 日历可浏览范围。下界与 WheelDatePicker 默认 minDate 对齐(2000-01-01),
+  // 导入了 2020 年前账单的用户也能翻到(#429:此前硬编码 2020-01-01);
+  // 上界沿用「今天 + 1 年」以覆盖未来记账/周期记账。
+  //
+  // TableCalendar 与年月选择器必须绑同一份边界 —— focusedDay 落到界外会踩
+  // table_calendar 内部 assert(table_calendar_base.dart:77)。
+  static final DateTime _calFirstDay = DateTime(2000, 1, 1);
+
+  // 取整到「日」:同一天内多次读取结果恒等,避免 TableCalendar 与选择器
+  // 各自 DateTime.now() 差出微秒级不一致。
+  DateTime get _calLastDay {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, now.day)
+        .add(const Duration(days: 365));
+  }
+
   @override
   void initState() {
     super.initState();
@@ -67,6 +83,45 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
     });
     ref.read(calendarSelectedMonthProvider.notifier).state = _focusedMonth;
     ref.read(calendarSelectedDateProvider.notifier).state = _selectedDay;
+  }
+
+  // 点头部「20xx年xx月 ▾」跳转指定年月(#429)。复用全 App 通用的年月滚轮,
+  // 与首页(home_page.dart)、统计页(analytics_page.dart)同一范式。
+  Future<void> _showMonthJumpPicker() async {
+    // 上界故意跟随日历的 _calLastDay 而非 DateTime.now():日历本身能横滑到
+    // 未来一年,若选择器卡在今天就会出现「手能滑到、选择器跳不到」的割裂。
+    final picked = await showWheelDatePicker(
+      context,
+      initial: _focusedMonth,
+      mode: WheelDatePickerMode.ym,
+      minDate: _calFirstDay,
+      maxDate: _calLastDay,
+    );
+    if (picked == null || !mounted) return;
+    _jumpToMonth(picked);
+  }
+
+  void _jumpToMonth(DateTime target) {
+    // 选择器已按 min/max 限制返回值,这里只是兜底,防止将来改动边界后越界崩溃。
+    // 钳制同样落到月初 —— _focusedMonth 恒为月初是本页各处共同的前置假设。
+    var month = DateTime(target.year, target.month, 1);
+    if (month.isBefore(_calFirstDay)) {
+      month = DateTime(_calFirstDay.year, _calFirstDay.month, 1);
+    }
+    final lastDay = _calLastDay;
+    if (month.isAfter(lastDay)) {
+      month = DateTime(lastDay.year, lastDay.month, 1);
+    }
+
+    setState(() {
+      _focusedMonth = month;
+      // 与滑动切月(_onPageChanged)保持同一语义:清空选中日,下方当日列表收起
+      _selectedDay = null;
+    });
+    // 程序化跳转时 table_calendar 会置 _pageCallbackDisabled(table_calendar_
+    // base.dart:165),onPageChanged 不会回调,两个 provider 必须手动同步
+    ref.read(calendarSelectedMonthProvider.notifier).state = month;
+    ref.read(calendarSelectedDateProvider.notifier).state = null;
   }
 
   Future<void> _addTransactionForSelectedDate() async {
@@ -189,6 +244,12 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
     Color primaryColor,
   ) {
     final locale = Localizations.localeOf(context);
+    // 头部标题样式:headerStyle 与自定义 headerTitleBuilder 共用同一份,避免走样
+    final titleTextStyle = TextStyle(
+      fontSize: 16,
+      fontWeight: FontWeight.w600,
+      color: BeeTokens.textPrimary(context),
+    );
 
     print('📊 _buildCalendar 被调用: dailyTotals.length=${dailyTotals.length}');
     print('📊 locale=${locale.toString()}');
@@ -201,8 +262,8 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
 
     return TableCalendar(
       locale: locale.toString(),
-      firstDay: DateTime(2020, 1, 1),
-      lastDay: DateTime.now().add(const Duration(days: 365)),
+      firstDay: _calFirstDay,
+      lastDay: _calLastDay,
       focusedDay: _focusedMonth,
       selectedDayPredicate: (day) {
         return _selectedDay != null && isSameDay(_selectedDay, day);
@@ -223,11 +284,7 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
         titleCentered: true,
         leftChevronIcon: Icon(Icons.chevron_left, color: primaryColor),
         rightChevronIcon: Icon(Icons.chevron_right, color: primaryColor),
-        titleTextStyle: TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w600,
-          color: BeeTokens.textPrimary(context),
-        ),
+        titleTextStyle: titleTextStyle,
       ),
 
       // 日历样式
@@ -287,6 +344,48 @@ class _CalendarPageState extends ConsumerState<CalendarPage> {
 
       // 日期标记构建器
       calendarBuilders: CalendarBuilders(
+        // 头部标题改为「20xx年xx月 ▾」可点入口(#429)。
+        // 注意:headerTitleBuilder 会整体替换掉 table_calendar 内置那层
+        // GestureDetector(calendar_header.dart:58),onHeaderTapped 因此不会
+        // 回调 —— 点击手势必须挂在这里。
+        headerTitleBuilder: (context, month) {
+          // SectionCard 是纯 Container,不提供 Material —— 水波纹会画到
+          // Scaffold 那层 Material 上、被卡片背景挡住。补一层透明 Material,
+          // 与本文件下方「在该日记账」按钮同一处理。
+          return Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: _showMonthJumpPicker,
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 6),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    // Flexible + ellipsis:标题字号是固定 16,系统「更大字体」放大后
+                    // 纯 Text 会先吃满整行、把 20pt 的箭头挤出去触发 RenderFlex
+                    // overflow(改造前是裸 Text,靠软换行不会横向溢出)
+                    Flexible(
+                      child: Text(
+                        // 与内置实现同格式(calendar_header.dart:42),
+                        // 中/繁/英/韩四语显示与改造前完全一致
+                        DateFormat.yMMMM(locale.toString()).format(month),
+                        style: titleTextStyle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Icon(
+                      Icons.arrow_drop_down,
+                      size: 20,
+                      color: BeeTokens.textPrimary(context),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
         // 自定义默认日期单元格
         defaultBuilder: (context, day, focusedDay) {
           return _buildDateCell(

--- a/lib/providers/calendar_providers.dart
+++ b/lib/providers/calendar_providers.dart
@@ -66,33 +66,5 @@ final transactionDatesByMonthProvider = FutureProvider.autoDispose
   },
 );
 
-/// 获取指定时间范围的交易列表（用于当月交易列表）
-/// 参数: (ledgerId, startDate, endDate)
-final monthTransactionsProvider = FutureProvider.autoDispose.family<
-    List<({
-      Transaction t,
-      Category? category,
-      List<Tag> tags,
-      List<TransactionAttachment> attachments,
-      Account? account,
-    })>,
-    ({int ledgerId, DateTime startDate, DateTime endDate})>(
-  (ref, params) async {
-    // 监听刷新触发器
-    ref.watch(calendarRefreshProvider);
-
-    final repo = ref.watch(repositoryProvider);
-
-    // 查询时间范围内的所有交易
-    final transactions = await repo.getTransactionsByDateRange(
-      ledgerId: params.ledgerId,
-      startDate: params.startDate,
-      endDate: params.endDate,
-    );
-
-    return transactions;
-  },
-);
-
 /// 日历刷新触发器（添加/删除交易后触发）
 final calendarRefreshProvider = StateProvider<int>((ref) => 0);

--- a/test/widgets/calendar_month_jump_test.dart
+++ b/test/widgets/calendar_month_jump_test.dart
@@ -1,0 +1,167 @@
+/// issue #429 —— 日历页年月快捷跳转 + firstDay 硬编码修复
+/// 设计: .docs/issue-429-calendar-month-jump.md
+///
+///   - 头部标题「20xx年xx月 ▾」可点,弹出复用的年月滚轮(WheelDatePickerMode.ym),
+///     不再只能靠左右箭头一个月一个月翻
+///   - 可浏览下界从硬编码 2020-01-01 放宽到 2000-01-01;选择器 min/max 与
+///     TableCalendar 的 firstDay/lastDay 绑同一份 —— 否则跳到下界之前会踩
+///     table_calendar_base.dart:77 的 assert
+///   - 跳月语义与滑动切月(_onPageChanged)一致:清空选中日 → 下方当日交易列表收起
+import 'package:drift/native.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+import 'package:beecount/l10n/app_localizations.dart';
+import 'package:beecount/pages/calendar/calendar_page.dart';
+import 'package:beecount/providers/database_providers.dart';
+import 'package:beecount/widgets/ui/wheel_date_picker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues({});
+
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() async {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+    await db.customStatement(
+        "INSERT INTO ledgers (id, name, currency) VALUES (1, 'L', 'CNY')");
+  });
+
+  tearDown(() async => db.close());
+
+  Ledger cnyLedger() => Ledger(
+        id: 1,
+        name: 'L',
+        currency: 'CNY',
+        type: 'personal',
+        createdAt: DateTime(2026, 1, 1),
+        myRole: 'owner',
+        memberCount: 1,
+        isShared: false,
+        monthStartDay: 1,
+      );
+
+  /// 默认 800x600 测试视口装不下「日历卡(约 520)+ 当日交易列表」,
+  /// ListView 懒构建会让下半屏的列表压根不 build。撑高到手机比例,
+  /// 让「跳月后列表收起」这条断言测的是状态而不是滚动位置。
+  void useTallPhoneViewport(WidgetTester tester) {
+    tester.view.physicalSize = const Size(400, 1400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+
+  Widget host() {
+    return ProviderScope(
+      overrides: [
+        repositoryProvider.overrideWithValue(repo),
+        currentLedgerProvider
+            .overrideWith((ref) => Stream<Ledger?>.value(cnyLedger())),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: const CalendarPage(),
+      ),
+    );
+  }
+
+  /// 头部标题文案格式必须与 table_calendar 内置实现一致
+  /// (calendar_header.dart:42 用的就是 DateFormat.yMMMM(locale))
+  String monthTitle(DateTime month) => DateFormat.yMMMM('zh').format(month);
+
+  DateTime thisMonth() {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, 1);
+  }
+
+  /// TableCalendar 构造时会对 firstDay/lastDay 跑 normalizeDate() 转成 UTC,
+  /// 而传进选择器的是本地时间 —— 边界是否「同一份」看的是同一个日历日,
+  /// 不是 DateTime 实例相等。
+  Matcher sameCalendarDay(DateTime expected) => predicate<DateTime?>(
+        (v) =>
+            v != null &&
+            v.year == expected.year &&
+            v.month == expected.month &&
+            v.day == expected.day,
+        '与 ${expected.year}-${expected.month}-${expected.day} 同一日历日',
+      );
+
+  TableCalendar calendarOf(WidgetTester tester) {
+    // TableCalendar 是泛型,页面里没显式给类型实参,用谓词匹配避开 byType 对
+    // runtimeType 的精确比较
+    final finder = find.byWidgetPredicate((w) => w is TableCalendar);
+    return tester.widgetList(finder).single as TableCalendar;
+  }
+
+  testWidgets('点头部月份标题 → 弹出年月滚轮选择器', (tester) async {
+    useTallPhoneViewport(tester);
+    await tester.pumpWidget(host());
+    await tester.pumpAndSettle();
+
+    expect(find.text(monthTitle(thisMonth())), findsOneWidget);
+
+    await tester.tap(find.text(monthTitle(thisMonth())));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(WheelDatePicker), findsOneWidget);
+    final picker = tester.widget<WheelDatePicker>(find.byType(WheelDatePicker));
+    expect(picker.mode, WheelDatePickerMode.ym);
+  });
+
+  testWidgets('日历下界放宽到 2000-01-01,选择器 min/max 与日历边界同一份', (tester) async {
+    useTallPhoneViewport(tester);
+    await tester.pumpWidget(host());
+    await tester.pumpAndSettle();
+
+    final cal = calendarOf(tester);
+    expect(cal.firstDay, sameCalendarDay(DateTime(2000, 1, 1)));
+
+    await tester.tap(find.text(monthTitle(thisMonth())));
+    await tester.pumpAndSettle();
+
+    final picker = tester.widget<WheelDatePicker>(find.byType(WheelDatePicker));
+    // 绑同一份边界:选择器能选到的 == 日历能显示的,结构上不可能越界触发 assert
+    expect(picker.minDate, sameCalendarDay(cal.firstDay));
+    expect(picker.maxDate, sameCalendarDay(cal.lastDay));
+  });
+
+  testWidgets('滚轮选到 2000-01 → 日历跳过去,并清空选中日收起当日列表', (tester) async {
+    useTallPhoneViewport(tester);
+    await tester.pumpWidget(host());
+    await tester.pumpAndSettle();
+
+    // initState 默认选中今天 → 下方当日交易列表(含「在该日记账」按钮)可见
+    expect(find.text('在该日记账'), findsOneWidget);
+
+    await tester.tap(find.text(monthTitle(thisMonth())));
+    await tester.pumpAndSettle();
+
+    // 年、月两个滚轮各向下猛拖:越界被 FixedExtentScrollPhysics 钳到首项,
+    // 确定性地落在 年=2000(下界) / 月=1
+    final wheels = find.byType(CupertinoPicker);
+    await tester.drag(wheels.at(0), const Offset(0, 6000));
+    await tester.pumpAndSettle();
+    await tester.drag(wheels.at(1), const Offset(0, 6000));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('确定'));
+    await tester.pumpAndSettle();
+
+    // 改造前 firstDay 硬编码 2020-01-01,跳到 2000-01 会直接踩 assert
+    expect(find.text(monthTitle(DateTime(2000, 1, 1))), findsOneWidget);
+    // 与滑动切月一致:选中日清空 → 当日列表整块收起
+    expect(find.text('在该日记账'), findsNothing);
+  });
+}


### PR DESCRIPTION
## 变更说明 / What & Why

日历页原先只有左右箭头，导入多年历史账单的用户要回看早年数据只能一个月一个月点 —— issue 里的场景是从 2026-08 翻到 2020-09，约 71 次。

**1. 头部标题改为「20xx年xx月 ▾」可点入口**

点击弹出 `showWheelDatePicker(mode: ym)`，与首页（`home_page.dart:270`）、统计页（`analytics_page.dart:38`）复用同一个年月滚轮。零新增组件、**零新增 arb key**（标题复用 `homeSelectDate`，按钮复用 `commonCancel`/`commonOk`）；标题格式沿用 `DateFormat.yMMMM(locale)`，与 table_calendar 内置实现（`calendar_header.dart:42`）逐字一致，中/繁/英/韩四语显示与改造前完全相同。

**2. 顺带修掉一个真 bug：`firstDay` 硬编码 2020-01-01**

原先 `firstDay: DateTime(2020, 1, 1)` 写死，**导入 2020 年前账单的用户根本翻不到那些月份**，2020-01 处左箭头直接置灰。

而且这不是可选优化，是年月跳转的前置必要项：table_calendar 内部有

```dart
// table_calendar-3.1.3/lib/src/table_calendar_base.dart:77
assert(isSameDay(focusedDay, firstDay) || focusedDay.isAfter(firstDay));
```

只要选择器能选到下界之前而 `firstDay` 不放宽，跳过去就会崩。现放宽到 2000-01-01（与 `WheelDatePicker` 默认 `minDate` 对齐，全 App 日期选择器口径统一，零额外查询），并把选择器的 `min/max` 与日历的 `firstDay/lastDay` 绑同一份，从结构上消灭越界。

上界故意跟随日历的「今天 + 1 年」而非 `DateTime.now()`：日历本身能横滑到未来一年（未来记账/周期记账），若选择器卡在今天就会出现「手能滑到、选择器跳不到」的割裂。

**3. 跳月后清空选中日**

与滑动切月的 `_onPageChanged` 同语义（下方当日交易列表收起）。程序化跳转时 table_calendar 会置 `_pageCallbackDisabled`（`table_calendar_base.dart:165`），`onPageChanged` 不回调，因此两个 provider 手动同步 —— 沿用既有 `_jumpToToday` 的写法，不引入第二种模式。

### 实现上的三个坑（注释里都记了）

- `headerTitleBuilder` 会**整体替换掉**内置那层 `GestureDetector`（`calendar_header.dart:58`），`onHeaderTapped` 不再回调，点击手势必须自己挂
- `SectionCard` 是纯 `Container` 不提供 Material，`InkWell` 水波纹会画到 `Scaffold` 那层、被卡片背景挡住 → 补一层透明 `Material`（与本文件下方「在该日记账」同一处理）
- 换成 `Row[Text, Icon]` 后，系统「更大字体」会让固定 16 字号的 `Text` 先吃满整行、把 20pt 箭头挤出去触发 RenderFlex overflow（改造前是裸 `Text`，靠软换行不会横向溢出）→ `Text` 包 `Flexible` + ellipsis

### 影响面

纯 App UI 层，**Cloud 端零改动**，无 schema / 同步字段变更，不涉及双端发版顺序。日历页数从约 85 涨到约 320，`PageView.builder` 懒构建只 build 当前页 ±1，无性能影响。

## 关联 Issue / Related Issue

Closes #429

## 自测情况 / Self-tested

- [x] `flutter analyze` 无新增告警 / no new warnings
- [x] `flutter test` 通过 / tests pass
- [x] 已实机运行验证；UI 变更已附截图 / verified on a real device; screenshots attached for UI changes
- [x] 不涉及文案变更：无 arb 改动，复用现有 key，未跑 `gen-l10n` / no copy changes

**关于上面三项的准确说明：**

| 项 | 实际情况 |
|---|---|
| analyze | 涉及的三个文件合计 **28 issues → 9 issues**（第 2 个提交清掉了存量 `print` / 未用 import / 死代码）。剩余 9 条逐条属于基线已有类别：4 条 `withOpacity` 弃用、3 条 `curly_braces`、2 条 `dead_null_aware_expression`，本次零新增 |
| test | 新增测试 3/3 通过；全量 500 passed / 1 skipped / 1 failed。唯一失败是 `test/services/billing/bill_creation_service_test.dart`「账户匹配 AI 账户名完全相等」，已用 `git stash` 回退本次改动复现同样失败 → **main 上的存量失败，与本次无关** |
| 实机 | iPhone 16 Pro / iOS 18.6 **模拟器**（非物理设备）；截图未内嵌本正文 |

模拟器实测（含代码层看不出的视觉项）：

- 头部「2026年8月 ▾」居中，与左右 chevron 间距充裕，不挤
- 点标题弹出的滚轮上界可达 2027（今天 + 1 年生效）
- 跳 2020-09（issue 原场景）一次交互到位
- **跳 2017-09（改造前 `firstDay` 不可达）正常渲染，无 assert、无崩溃** —— firstDay 修复的直接证明
- 跳月后选中日清空、当日交易列表整块收起
- 暗黑模式下 ▾ 取 `textPrimary`（白），与标题同色，对比度正常

### 新增测试

`test/widgets/calendar_month_jump_test.dart`，harness 照抄 `transfer_form_account_hidden_test.dart`（内存 Drift + `ProviderScope` overrides），TDD 写的，三条都先以正确的原因失败过：

1. 点头部标题弹出年月滚轮，且 `mode == ym`
2. 日历 `firstDay` 为 2000-01-01，且选择器 `min/max` 与日历边界是同一个日历日
3. 滚轮选到 2000-01 → 日历跳过去（改造前必挂在 assert）、选中日清空、当日列表消失

## 第 2 个提交：清理存量调试代码与死代码（`b78f669`）

纯删除，**192 行 −0 行，无行为变更**。原打算另开 PR，后决定并入这里。

`lib/pages/calendar/calendar_page.dart`
- 删 8 处留在生产代码的 `print`（每次日历 build 都刷屏：查询参数、`dailyTotals` 样例、逐格打印前 3 天数值）
- 删死代码 `_buildMonthTransactionsList`（97 行，全仓零调用方）
- 删未用 import（`intl/date_symbol_data_local.dart`、`utils/currencies.dart`）与未用局部变量 `currencySymbol`

`lib/providers/calendar_providers.dart`
- 删 `monthTransactionsProvider`（唯一消费者就是上面那个死方法）

`lib/data/repositories/local/local_transaction_repository.dart`
- `getDailyTotalsByMonth` 删 7 处 `print`，以及**两条纯粹为了喂 print 而存在的调试查询**：`COUNT(*)` 统计（结果只用于打印，`totalCount` 还只是第二个调试块的门）、`SELECT happened_at LIMIT 1` 探查（只为打印样例值及其 DateTime 转换）

> 也就是说**日历每渲染一个月原本要跑 3 条 SQL，其中 2 条是调试遗留**，现在只剩聚合那一条。这是清理过程中才发现的，算是附带的小性能修正。

### 两个需要 reviewer 留意的点

1. 删掉 `currencySymbol` 后其唯一上游 `ledgerAsync` 也随之删除，因此本页**不再 `ref.watch(currentLedgerProvider)`**。判断依据：本页所有数据都按 `currentLedgerIdProvider` 取（仍在 watch），切账本照样重建；只是账本改名/改币种不再触发这一页的无谓重建，而页面上没有任何东西展示这些字段。
2. 仍未动：`withOpacity` 弃用告警（涉及多处配色值，属另一件事）、`row.read<double>(...) ?? 0.0` 的死空判（存量，且不属于调试代码）。

## 贡献者许可条款 / Contributor License Terms

- [x] 我已阅读并同意贡献者许可条款 / I have read and agree to the [Contributor License Terms](../CONTRIBUTING.md#贡献者许可条款contributor-license-terms)

