### PR TITLE
fix: 共享账本 Editor 的标签「最近使用」不再等于「全部标签」(#443)

### DIFF
--- a/lib/providers/tag_providers.dart
+++ b/lib/providers/tag_providers.dart
@@ -4,7 +4,6 @@ import '../data/repositories/local/local_repository.dart';
 import '../utils/shared_ledger_picker_filter.dart';
 import 'database_providers.dart';
 import 'shared_ledger_providers.dart';
-import 'sync_providers.dart' show currentLedgerIdProvider;
 
 /// 标签列表刷新触发器
 final tagListRefreshProvider = StateProvider<int>((ref) => 0);
@@ -81,15 +80,28 @@ final batchTransactionTagsProvider = FutureProvider.family<Map<int, List<Tag>>, 
 });
 
 /// §7 共享账本 picker 用:最近使用 tags 按当前 ledger 过滤后的版本。
+///
+/// 两条分支各走各的取数,**不共用** `filterTagsForLedger`(#443):
+/// - 单人账本 / Owner → 主表 `getRecentlyUsedTags`(tags ⨝ transaction_tags)。
+/// - 共享账本 Editor → `recentSharedTagsForLedger`,从 TransactionTagOverrides
+///   取。Editor 的 tag 关联不在主表,而 `filterTagsForLedger` 又是"丢弃入参返回
+///   全量 mirror"的语义,把 recent 子集喂给它会被放大成全量,「最近使用」于是
+///   跟「全部标签」一字不差。
 final recentTagsForCurrentLedgerProvider = FutureProvider<List<Tag>>((ref) async {
   ref.watch(tagListRefreshProvider);
   ref.watch(sharedResourceRefreshProvider);
   final repo = ref.watch(repositoryProvider);
-  final recent = await repo.getRecentlyUsedTags(limit: 10);
-  if (repo is! LocalRepository) return recent;
+  if (repo is! LocalRepository) return repo.getRecentlyUsedTags(limit: 10);
   final ledgerId = ref.watch(currentLedgerIdProvider);
   final ctx = await repo.db.loadLedgerPickerContext(ledgerId);
-  return repo.db.filterTagsForLedger(recent, ctx);
+  if (ctx != null && ctx.isEditorInShared && ctx.ledgerSyncId != null) {
+    return repo.db.recentSharedTagsForLedger(
+      ledgerId: ledgerId,
+      ledgerSyncId: ctx.ledgerSyncId!,
+      limit: 10,
+    );
+  }
+  return repo.getRecentlyUsedTags(limit: 10);
 });
 
 /// 最近使用的标签 Provider

--- a/lib/utils/shared_ledger_picker_filter.dart
+++ b/lib/utils/shared_ledger_picker_filter.dart
@@ -13,7 +13,7 @@
 /// Synthetic id 规则:`_syntheticIdForSyncId(syncId)` 一律负数,稳定可复现。
 library;
 
-import 'package:drift/drift.dart' show OrderingTerm;
+import 'package:drift/drift.dart' show OrderingTerm, Variable;
 
 import '../data/db.dart';
 
@@ -138,6 +138,12 @@ extension SharedLedgerPickerFilter on BeeDatabase {
   }
 
   /// 拿 picker 用的 tags。规则同 categories。
+  ///
+  /// ⚠️ Editor 分支**整个丢弃入参 `all`**、返回该账本的全量 mirror tags —— 这是
+  /// "完全替换"语义(见文件头 §7),所以 `all` 只能传主表**全量**列表。传子集
+  /// (如「最近使用」的 10 条)会被静默放大成全量,#443 就是这么来的:
+  /// 「最近使用」区块拿到了跟「全部标签」一模一样的内容。子集场景请改用
+  /// [recentSharedTagsForLedger] 这类专用取数。
   Future<List<Tag>> filterTagsForLedger(
     List<Tag> all,
     LedgerPickerContext? ctx,
@@ -149,6 +155,53 @@ extension SharedLedgerPickerFilter on BeeDatabase {
           ..where((t) => t.ledgerSyncId.equals(ctx.ledgerSyncId!)))
         .get();
     return shared.map(_sharedTagAsMain).toList();
+  }
+
+  /// 共享账本 Editor 视角的「最近使用」tags(#443)。
+  ///
+  /// 不能复用 `getRecentlyUsedTags`:那边查的是 `tags` ⨝ `transaction_tags` 主表
+  /// 关联,而 Editor 记账时 tag 关联落在 [TransactionTagOverrides](按
+  /// `tag_sync_id`),主表里一条都没有 —— 直接用会永远是空。
+  ///
+  /// 这里从 override 表 join **当前账本**的 transactions,按 `MAX(happened_at)`
+  /// 取最近 [limit] 个 `tag_sync_id`,再用 SharedLedgerTags 映射成 synthetic
+  /// Tag。映射复用 [_sharedTagAsMain],保证 id 口径与 [filterTagsForLedger] 返回
+  /// 的「全部标签」一致 —— picker 的选中态是按 `tag.id` 比的,口径不一致会错位。
+  ///
+  /// mirror 还没到齐(pull 未完成)导致某个 syncId 查不到时跳过该条;全都查不到
+  /// 就返回空列表,调用方 tag_selector 已有 `recentTags.isEmpty →
+  /// SizedBox.shrink()`,区块会自然隐藏。
+  Future<List<Tag>> recentSharedTagsForLedger({
+    required int ledgerId,
+    required String ledgerSyncId,
+    int limit = 10,
+  }) async {
+    final rows = await customSelect(
+      '''
+      SELECT o.tag_sync_id AS tag_sync_id, MAX(tx.happened_at) AS last_used
+      FROM transaction_tag_overrides o
+      INNER JOIN transactions tx ON tx.sync_id = o.transaction_sync_id
+      WHERE tx.ledger_id = ?
+      GROUP BY o.tag_sync_id
+      ORDER BY last_used DESC
+      LIMIT ?
+      ''',
+      variables: [Variable.withInt(ledgerId), Variable.withInt(limit)],
+      readsFrom: {transactionTagOverrides, transactions, sharedLedgerTags},
+    ).get();
+    if (rows.isEmpty) return const [];
+    final orderedSyncIds = [
+      for (final r in rows) r.read<String>('tag_sync_id'),
+    ];
+    final mirror = await (select(sharedLedgerTags)
+          ..where((t) => t.ledgerSyncId.equals(ledgerSyncId))
+          ..where((t) => t.syncId.isIn(orderedSyncIds)))
+        .get();
+    final bySyncId = {for (final t in mirror) t.syncId: t};
+    return [
+      for (final syncId in orderedSyncIds)
+        if (bySyncId[syncId] != null) _sharedTagAsMain(bySyncId[syncId]!),
+    ];
   }
 
   /// 把 SharedLedgerCategory 转成 Category(synthetic id < 0,syncId 来自 Owner)。

--- a/test/providers/recent_tags_for_current_ledger_test.dart
+++ b/test/providers/recent_tags_for_current_ledger_test.dart
@@ -1,0 +1,109 @@
+// #443 回归:共享账本 Editor 的「最近使用」标签不能等于「全部标签」。
+//
+// 旧实现把 getRecentlyUsedTags 的子集喂给 filterTagsForLedger,后者在 Editor
+// 分支整个丢弃入参、返回全量 mirror,于是两个区块内容一字不差。本测试直接比对
+// recentTagsForCurrentLedgerProvider 与 tagsForCurrentLedgerProvider 的结果。
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+import 'package:beecount/providers/database_providers.dart';
+import 'package:beecount/providers/tag_providers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  ProviderContainer containerFor(int ledgerId) {
+    final c = ProviderContainer(overrides: [
+      databaseProvider.overrideWithValue(db),
+      repositoryProvider.overrideWithValue(repo),
+      currentLedgerIdProvider.overrideWith((ref) => ledgerId),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('共享账本 Editor:最近使用是真子集,不等于全部标签', () async {
+    const ledgerSyncId = 'ledger-ext-1';
+    final ledgerId = await db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '共享账本',
+          type: const Value('shared'),
+          syncId: const Value(ledgerSyncId),
+          myRole: const Value('editor'),
+          isShared: const Value(true),
+        ));
+    // Owner mirror 下来 4 个标签
+    for (var i = 1; i <= 4; i++) {
+      await db.into(db.sharedLedgerTags).insert(
+            SharedLedgerTagsCompanion.insert(
+              ledgerSyncId: ledgerSyncId,
+              syncId: 'tag-$i',
+              name: '标签$i',
+              updatedAt: DateTime.utc(2026, 1, 1),
+            ),
+          );
+    }
+    // Editor 只用过其中 1 个(关联落在 override 表,不在主表 transaction_tags)
+    await db.into(db.transactions).insert(TransactionsCompanion.insert(
+          ledgerId: ledgerId,
+          type: 'expense',
+          amount: 12.0,
+          happenedAt: Value(DateTime.utc(2026, 8, 1)),
+          syncId: const Value('tx-1'),
+        ));
+    await db
+        .into(db.transactionTagOverrides)
+        .insert(TransactionTagOverridesCompanion.insert(
+          transactionSyncId: 'tx-1',
+          tagSyncId: 'tag-3',
+          createdAt: DateTime.utc(2026, 8, 1),
+        ));
+
+    final c = containerFor(ledgerId);
+    final recent = await c.read(recentTagsForCurrentLedgerProvider.future);
+    final all = await c.read(tagsForCurrentLedgerProvider.future);
+
+    expect(all.map((t) => t.name).toList(), ['标签1', '标签2', '标签3', '标签4']);
+    expect(recent.map((t) => t.name).toList(), ['标签3']);
+    // 修复前这两行是相等的 —— 「最近使用」被放大成了全量 mirror
+    expect(recent.map((t) => t.id).toList(),
+        isNot(equals(all.map((t) => t.id).toList())));
+    // synthetic id 口径与「全部标签」一致,picker 选中态才对得上
+    expect(recent.single.id, all.firstWhere((t) => t.syncId == 'tag-3').id);
+  });
+
+  test('单人账本:仍走主表 transaction_tags 的最近使用', () async {
+    final ledgerId = await db
+        .into(db.ledgers)
+        .insert(LedgersCompanion.insert(name: '我的账本'));
+    final tagUsed = await repo.createTag(name: '用过的');
+    await repo.createTag(name: '没用过的');
+    final txId = await db.into(db.transactions).insert(
+          TransactionsCompanion.insert(
+            ledgerId: ledgerId,
+            type: 'expense',
+            amount: 8.0,
+            happenedAt: Value(DateTime.utc(2026, 8, 2)),
+            syncId: const Value('tx-personal'),
+          ),
+        );
+    await repo.updateTransactionTags(transactionId: txId, tagIds: [tagUsed]);
+
+    final c = containerFor(ledgerId);
+    final recent = await c.read(recentTagsForCurrentLedgerProvider.future);
+    expect(recent.map((t) => t.name).toList(), ['用过的']);
+  });
+}

--- a/test/utils/shared_ledger_picker_filter_recent_tags_test.dart
+++ b/test/utils/shared_ledger_picker_filter_recent_tags_test.dart
@@ -1,0 +1,227 @@
+// 共享账本 Editor「最近使用」标签取数契约测试(#443)。
+//
+// 锁死三件事:
+// 1. Editor 的 recent 从 transaction_tag_overrides 取,不是主表 transaction_tags
+//    (主表在 Editor 下永远空)。
+// 2. recent 是真子集 —— 不能退化成 filterTagsForLedger 的全量 mirror,否则
+//    「最近使用」跟「全部标签」一模一样。
+// 3. synthetic id 与 filterTagsForLedger 同口径,picker 选中态才不会错位。
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/utils/shared_ledger_picker_filter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late BeeDatabase db;
+
+  const ledgerSyncId = 'ledger-ext-1';
+  const otherLedgerSyncId = 'ledger-ext-2';
+  late int ledgerId;
+  late int otherLedgerId;
+
+  /// 造一条 Editor 视角的 tx(categoryId/accountId 留空,只关心 tag override)。
+  Future<void> insertTx({
+    required int inLedgerId,
+    required String syncId,
+    required DateTime happenedAt,
+    required List<String> tagSyncIds,
+  }) async {
+    await db.into(db.transactions).insert(TransactionsCompanion.insert(
+          ledgerId: inLedgerId,
+          type: 'expense',
+          amount: 10.0,
+          happenedAt: Value(happenedAt),
+          syncId: Value(syncId),
+        ));
+    for (final tagSyncId in tagSyncIds) {
+      await db
+          .into(db.transactionTagOverrides)
+          .insert(TransactionTagOverridesCompanion.insert(
+            transactionSyncId: syncId,
+            tagSyncId: tagSyncId,
+            createdAt: happenedAt,
+          ));
+    }
+  }
+
+  Future<void> insertMirrorTag(String ledger, String syncId, String name) {
+    return db.into(db.sharedLedgerTags).insert(
+          SharedLedgerTagsCompanion.insert(
+            ledgerSyncId: ledger,
+            syncId: syncId,
+            name: name,
+            updatedAt: DateTime.utc(2026, 1, 1),
+          ),
+        );
+  }
+
+  setUp(() async {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    ledgerId = await db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '共享账本',
+          type: const Value('shared'),
+          syncId: const Value(ledgerSyncId),
+          myRole: const Value('editor'),
+          isShared: const Value(true),
+        ));
+    otherLedgerId = await db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '另一个共享账本',
+          type: const Value('shared'),
+          syncId: const Value(otherLedgerSyncId),
+          myRole: const Value('editor'),
+          isShared: const Value(true),
+        ));
+    // mirror:5 个标签,其中只有一部分会被 tx 用到
+    for (var i = 1; i <= 5; i++) {
+      await insertMirrorTag(ledgerSyncId, 'tag-$i', '标签$i');
+    }
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('Editor 的最近使用只含真正用过的标签,不等于全量 mirror', () async {
+    await insertTx(
+      inLedgerId: ledgerId,
+      syncId: 'tx-1',
+      happenedAt: DateTime.utc(2026, 8, 1),
+      tagSyncIds: ['tag-2'],
+    );
+    await insertTx(
+      inLedgerId: ledgerId,
+      syncId: 'tx-2',
+      happenedAt: DateTime.utc(2026, 8, 3),
+      tagSyncIds: ['tag-4'],
+    );
+
+    final recent = await db.recentSharedTagsForLedger(
+      ledgerId: ledgerId,
+      ledgerSyncId: ledgerSyncId,
+    );
+    final ctx = await db.loadLedgerPickerContext(ledgerId);
+    final all = await db.filterTagsForLedger(const [], ctx);
+
+    // 最近使用:按 happened_at 倒序 → tag-4 在前
+    expect(recent.map((t) => t.name).toList(), ['标签4', '标签2']);
+    // 全部标签仍是全量 5 个 —— 两个区块内容必须不同(#443 的核心症状)
+    expect(all.length, 5);
+    expect(recent.length, lessThan(all.length));
+  });
+
+  test('synthetic id 与 filterTagsForLedger 同口径(选中态不错位)', () async {
+    await insertTx(
+      inLedgerId: ledgerId,
+      syncId: 'tx-1',
+      happenedAt: DateTime.utc(2026, 8, 1),
+      tagSyncIds: ['tag-3'],
+    );
+
+    final recent = await db.recentSharedTagsForLedger(
+      ledgerId: ledgerId,
+      ledgerSyncId: ledgerSyncId,
+    );
+    final ctx = await db.loadLedgerPickerContext(ledgerId);
+    final all = await db.filterTagsForLedger(const [], ctx);
+
+    final fromAll = all.firstWhere((t) => t.syncId == 'tag-3');
+    expect(recent.single.id, fromAll.id);
+    expect(recent.single.id, syntheticIdForSyncId('tag-3'));
+    expect(recent.single.id, isNegative);
+  });
+
+  test('同一标签多次使用只出现一次,按最后一次使用时间排序', () async {
+    await insertTx(
+      inLedgerId: ledgerId,
+      syncId: 'tx-1',
+      happenedAt: DateTime.utc(2026, 8, 1),
+      tagSyncIds: ['tag-1'],
+    );
+    await insertTx(
+      inLedgerId: ledgerId,
+      syncId: 'tx-2',
+      happenedAt: DateTime.utc(2026, 8, 2),
+      tagSyncIds: ['tag-2'],
+    );
+    // tag-1 又用了一次,时间最新 → 应排到最前
+    await insertTx(
+      inLedgerId: ledgerId,
+      syncId: 'tx-3',
+      happenedAt: DateTime.utc(2026, 8, 5),
+      tagSyncIds: ['tag-1'],
+    );
+
+    final recent = await db.recentSharedTagsForLedger(
+      ledgerId: ledgerId,
+      ledgerSyncId: ledgerSyncId,
+    );
+    expect(recent.map((t) => t.name).toList(), ['标签1', '标签2']);
+  });
+
+  test('limit 生效', () async {
+    for (var i = 1; i <= 5; i++) {
+      await insertTx(
+        inLedgerId: ledgerId,
+        syncId: 'tx-$i',
+        happenedAt: DateTime.utc(2026, 8, i),
+        tagSyncIds: ['tag-$i'],
+      );
+    }
+    final recent = await db.recentSharedTagsForLedger(
+      ledgerId: ledgerId,
+      ledgerSyncId: ledgerSyncId,
+      limit: 2,
+    );
+    expect(recent.map((t) => t.name).toList(), ['标签5', '标签4']);
+  });
+
+  test('其它账本用过的标签不混进来', () async {
+    await insertMirrorTag(otherLedgerSyncId, 'tag-9', '别的账本标签');
+    await insertTx(
+      inLedgerId: otherLedgerId,
+      syncId: 'tx-other',
+      happenedAt: DateTime.utc(2026, 8, 9),
+      tagSyncIds: ['tag-9'],
+    );
+    await insertTx(
+      inLedgerId: ledgerId,
+      syncId: 'tx-mine',
+      happenedAt: DateTime.utc(2026, 8, 1),
+      tagSyncIds: ['tag-1'],
+    );
+
+    final recent = await db.recentSharedTagsForLedger(
+      ledgerId: ledgerId,
+      ledgerSyncId: ledgerSyncId,
+    );
+    expect(recent.map((t) => t.name).toList(), ['标签1']);
+  });
+
+  test('mirror 未到齐时跳过查不到的 syncId,全查不到则返回空', () async {
+    await insertTx(
+      inLedgerId: ledgerId,
+      syncId: 'tx-1',
+      happenedAt: DateTime.utc(2026, 8, 1),
+      tagSyncIds: ['tag-not-mirrored-yet'],
+    );
+
+    final recent = await db.recentSharedTagsForLedger(
+      ledgerId: ledgerId,
+      ledgerSyncId: ledgerSyncId,
+    );
+    expect(recent, isEmpty);
+  });
+
+  test('没有任何 override 关联时返回空(区块自然隐藏)', () async {
+    final recent = await db.recentSharedTagsForLedger(
+      ledgerId: ledgerId,
+      ledgerSyncId: ledgerSyncId,
+    );
+    expect(recent, isEmpty);
+  });
+}


### PR DESCRIPTION
Closes #443

## 问题

共享账本 Editor 打开记账页的标签选择器,「最近使用」与「全部标签」两个区块内容一字不差。个人账本 / Owner 视角正常。

## 根因(两层)

**① 子集被静默放大成全量**

`recentTagsForCurrentLedgerProvider` 先查出真正的最近 10 条,再交给 `filterTagsForLedger` 过滤:

```dart
final recent = await repo.getRecentlyUsedTags(limit: 10);
return repo.db.filterTagsForLedger(recent, ctx);   // ← 入参被整个丢掉
```

而 `filterTagsForLedger` 在 Editor 分支是**「丢弃入参、返回该账本全量 mirror」**的语义(文件头 §7「完全替换」)。其余调用方(全部标签 / account_selector / transfer_form / category_selector)传的都是全量列表,这个语义正是预期;只有「最近使用」传的是子集,于是被放大成全量。

**② 即便不放大,Editor 的 recent 本来也是空的**

`getRecentlyUsedTags` 查的是 `tags ⨝ transaction_tags ⨝ transactions` 主表关联,但 Editor 记账的 tag 关联落在 `transaction_tag_overrides`(按 `tag_sync_id`),主表一条都没有。

## 修法

provider 两条分支**各自取数,不再共用** `filterTagsForLedger`:

- 单人账本 / Owner → 原样走主表 `getRecentlyUsedTags`。
- 共享账本 Editor → 新增 `recentSharedTagsForLedger`:从 `transaction_tag_overrides` join **当前账本**的 `transactions`,按 `MAX(happened_at)` 取最近 N 个 `tag_sync_id`,再用 `shared_ledger_tags` 映射成 synthetic Tag。

几个关键点:

- 映射复用 `_sharedTagAsMain`,**id 口径与「全部标签」严格一致** —— picker 选中态是按 `tag.id` 比的,口径不一致会让「最近使用」里点一下、「全部标签」里不高亮。
- mirror 还没 pull 到齐时跳过查不到的 syncId;全查不到返回空列表 —— `tag_selector` 已有 `recentTags.isEmpty → SizedBox.shrink()`,区块自然隐藏,不会出现空标题。
- `filterTagsForLedger` 补了文档警示:入参只能传全量,子集场景另开专用取数。

## 不在本次范围

issue 里提的第三点(`getRecentlyUsedTags` 没有账本维度,是跨全部账本的全局「最近使用」)按最小改动原则**保持现状** —— 标签本身是 user-scoped,这是个独立的产品口径问题,不跟 bug 一起改。Editor 新分支因为 override 表天然按账本 join,是账本内的。

顺带删掉 `tag_providers.dart` 里一行失效导入(`sync_providers.dart show currentLedgerIdProvider`,该库并未导出这个名字,analyzer 一直在报 warning;实际来源是已导入的 `database_providers.dart`)。

## 测试

**provider 层**(`test/providers/recent_tags_for_current_ledger_test.dart`)—— 直接锁死症状:

- 共享账本 Editor:mirror 4 个标签、只用过 1 个 → recent 必须只有那 1 个,且 `recent.ids != all.ids`,synthetic id 与「全部标签」对得上。
  修复前这条是**红**的:`Expected: ['标签3'] Actual: ['标签1','标签2','标签3','标签4']`,与 issue 描述的症状一致。
- 单人账本:仍走主表 `transaction_tags`。

**DB 层**(`test/utils/shared_ledger_picker_filter_recent_tags_test.dart`)—— 锁死取数契约:取数来源是 override 表、按最后使用时间倒序且去重、`limit` 生效、其它账本用过的标签不混入、mirror 缺失时跳过、无关联返回空。

全量 `flutter test`:618 passed(1 pre-existing skip);改动文件 `flutter analyze` 干净。

## 待验证

真机侧只需确认一件事:共享账本 Editor 下打开标签选择器,「最近使用」显示的是自己在这个账本里近期用过的标签(没用过则区块不出现),且点选后与「全部标签」区块的高亮同步。
