### PR TITLE
feat: 周期账单支持选择货币 (#444)

### DIFF
--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -163,6 +163,11 @@ class RecurringTransactions extends Table {
   IntColumn get toAccountId => integer().nullable()(); // 转账的目标账户
   TextColumn get note => text().nullable()();
 
+  /// v32 周期账单币种(issue #444):模板币种(ISO 大写)。
+  /// NULL = 账本本位币(存量语义);挂了账户时生成仍以账户币种为准(账户内不混币)。
+  /// 汇率不锁在模板上 —— 每次生成按当日有效汇率折算 nativeAmount。
+  TextColumn get currencyCode => text().nullable()();
+
   // 重复规则
   TextColumn get frequency => text()(); // daily / weekly / monthly / yearly
   IntColumn get interval =>
@@ -442,7 +447,7 @@ class BeeDatabase extends _$BeeDatabase {
   BeeDatabase.forTesting(QueryExecutor executor) : super(executor);
 
   @override
-  int get schemaVersion => 31; // v31: 账户隐藏 — accounts.hidden
+  int get schemaVersion => 32; // v32: 周期账单币种 — recurring_transactions.currency_code
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1156,6 +1161,13 @@ class BeeDatabase extends _$BeeDatabase {
             await _addColumnIfMissing('accounts', 'hidden',
                 'ALTER TABLE accounts ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;');
             logger.info('DBMigration', 'v31 迁移完成');
+          }
+          if (from < 32) {
+            logger.info('DBMigration', '开始迁移到 v32: 周期账单币种(currency_code)');
+            // 不回填:NULL = 账本本位币/跟随账户,与迁移前生成行为一字不差。
+            await _addColumnIfMissing('recurring_transactions', 'currency_code',
+                'ALTER TABLE recurring_transactions ADD COLUMN currency_code TEXT;');
+            logger.info('DBMigration', 'v32 迁移完成');
           }
         },
         onCreate: (m) async {

--- a/lib/data/db.g.dart
+++ b/lib/data/db.g.dart
@@ -2973,6 +2973,12 @@ class $RecurringTransactionsTable extends RecurringTransactions
   late final GeneratedColumn<String> note = GeneratedColumn<String>(
       'note', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _currencyCodeMeta =
+      const VerificationMeta('currencyCode');
+  @override
+  late final GeneratedColumn<String> currencyCode = GeneratedColumn<String>(
+      'currency_code', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _frequencyMeta =
       const VerificationMeta('frequency');
   @override
@@ -3059,6 +3065,7 @@ class $RecurringTransactionsTable extends RecurringTransactions
         accountId,
         toAccountId,
         note,
+        currencyCode,
         frequency,
         interval,
         dayOfMonth,
@@ -3122,6 +3129,12 @@ class $RecurringTransactionsTable extends RecurringTransactions
     if (data.containsKey('note')) {
       context.handle(
           _noteMeta, note.isAcceptableOrUnknown(data['note']!, _noteMeta));
+    }
+    if (data.containsKey('currency_code')) {
+      context.handle(
+          _currencyCodeMeta,
+          currencyCode.isAcceptableOrUnknown(
+              data['currency_code']!, _currencyCodeMeta));
     }
     if (data.containsKey('frequency')) {
       context.handle(_frequencyMeta,
@@ -3204,6 +3217,8 @@ class $RecurringTransactionsTable extends RecurringTransactions
           .read(DriftSqlType.int, data['${effectivePrefix}to_account_id']),
       note: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}note']),
+      currencyCode: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}currency_code']),
       frequency: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}frequency'])!,
       interval: attachedDatabase.typeMapping
@@ -3245,6 +3260,11 @@ class RecurringTransaction extends DataClass
   final int? accountId;
   final int? toAccountId;
   final String? note;
+
+  /// v32 周期账单币种(issue #444):模板币种(ISO 大写)。
+  /// NULL = 账本本位币(存量语义);挂了账户时生成仍以账户币种为准(账户内不混币)。
+  /// 汇率不锁在模板上 —— 每次生成按当日有效汇率折算 nativeAmount。
+  final String? currencyCode;
   final String frequency;
   final int interval;
   final int? dayOfMonth;
@@ -3265,6 +3285,7 @@ class RecurringTransaction extends DataClass
       this.accountId,
       this.toAccountId,
       this.note,
+      this.currencyCode,
       required this.frequency,
       required this.interval,
       this.dayOfMonth,
@@ -3294,6 +3315,9 @@ class RecurringTransaction extends DataClass
     }
     if (!nullToAbsent || note != null) {
       map['note'] = Variable<String>(note);
+    }
+    if (!nullToAbsent || currencyCode != null) {
+      map['currency_code'] = Variable<String>(currencyCode);
     }
     map['frequency'] = Variable<String>(frequency);
     map['interval'] = Variable<int>(interval);
@@ -3335,6 +3359,9 @@ class RecurringTransaction extends DataClass
           ? const Value.absent()
           : Value(toAccountId),
       note: note == null && nullToAbsent ? const Value.absent() : Value(note),
+      currencyCode: currencyCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(currencyCode),
       frequency: Value(frequency),
       interval: Value(interval),
       dayOfMonth: dayOfMonth == null && nullToAbsent
@@ -3371,6 +3398,7 @@ class RecurringTransaction extends DataClass
       accountId: serializer.fromJson<int?>(json['accountId']),
       toAccountId: serializer.fromJson<int?>(json['toAccountId']),
       note: serializer.fromJson<String?>(json['note']),
+      currencyCode: serializer.fromJson<String?>(json['currencyCode']),
       frequency: serializer.fromJson<String>(json['frequency']),
       interval: serializer.fromJson<int>(json['interval']),
       dayOfMonth: serializer.fromJson<int?>(json['dayOfMonth']),
@@ -3397,6 +3425,7 @@ class RecurringTransaction extends DataClass
       'accountId': serializer.toJson<int?>(accountId),
       'toAccountId': serializer.toJson<int?>(toAccountId),
       'note': serializer.toJson<String?>(note),
+      'currencyCode': serializer.toJson<String?>(currencyCode),
       'frequency': serializer.toJson<String>(frequency),
       'interval': serializer.toJson<int>(interval),
       'dayOfMonth': serializer.toJson<int?>(dayOfMonth),
@@ -3420,6 +3449,7 @@ class RecurringTransaction extends DataClass
           Value<int?> accountId = const Value.absent(),
           Value<int?> toAccountId = const Value.absent(),
           Value<String?> note = const Value.absent(),
+          Value<String?> currencyCode = const Value.absent(),
           String? frequency,
           int? interval,
           Value<int?> dayOfMonth = const Value.absent(),
@@ -3440,6 +3470,8 @@ class RecurringTransaction extends DataClass
         accountId: accountId.present ? accountId.value : this.accountId,
         toAccountId: toAccountId.present ? toAccountId.value : this.toAccountId,
         note: note.present ? note.value : this.note,
+        currencyCode:
+            currencyCode.present ? currencyCode.value : this.currencyCode,
         frequency: frequency ?? this.frequency,
         interval: interval ?? this.interval,
         dayOfMonth: dayOfMonth.present ? dayOfMonth.value : this.dayOfMonth,
@@ -3466,6 +3498,9 @@ class RecurringTransaction extends DataClass
       toAccountId:
           data.toAccountId.present ? data.toAccountId.value : this.toAccountId,
       note: data.note.present ? data.note.value : this.note,
+      currencyCode: data.currencyCode.present
+          ? data.currencyCode.value
+          : this.currencyCode,
       frequency: data.frequency.present ? data.frequency.value : this.frequency,
       interval: data.interval.present ? data.interval.value : this.interval,
       dayOfMonth:
@@ -3495,6 +3530,7 @@ class RecurringTransaction extends DataClass
           ..write('accountId: $accountId, ')
           ..write('toAccountId: $toAccountId, ')
           ..write('note: $note, ')
+          ..write('currencyCode: $currencyCode, ')
           ..write('frequency: $frequency, ')
           ..write('interval: $interval, ')
           ..write('dayOfMonth: $dayOfMonth, ')
@@ -3520,6 +3556,7 @@ class RecurringTransaction extends DataClass
       accountId,
       toAccountId,
       note,
+      currencyCode,
       frequency,
       interval,
       dayOfMonth,
@@ -3543,6 +3580,7 @@ class RecurringTransaction extends DataClass
           other.accountId == this.accountId &&
           other.toAccountId == this.toAccountId &&
           other.note == this.note &&
+          other.currencyCode == this.currencyCode &&
           other.frequency == this.frequency &&
           other.interval == this.interval &&
           other.dayOfMonth == this.dayOfMonth &&
@@ -3566,6 +3604,7 @@ class RecurringTransactionsCompanion
   final Value<int?> accountId;
   final Value<int?> toAccountId;
   final Value<String?> note;
+  final Value<String?> currencyCode;
   final Value<String> frequency;
   final Value<int> interval;
   final Value<int?> dayOfMonth;
@@ -3586,6 +3625,7 @@ class RecurringTransactionsCompanion
     this.accountId = const Value.absent(),
     this.toAccountId = const Value.absent(),
     this.note = const Value.absent(),
+    this.currencyCode = const Value.absent(),
     this.frequency = const Value.absent(),
     this.interval = const Value.absent(),
     this.dayOfMonth = const Value.absent(),
@@ -3607,6 +3647,7 @@ class RecurringTransactionsCompanion
     this.accountId = const Value.absent(),
     this.toAccountId = const Value.absent(),
     this.note = const Value.absent(),
+    this.currencyCode = const Value.absent(),
     required String frequency,
     this.interval = const Value.absent(),
     this.dayOfMonth = const Value.absent(),
@@ -3632,6 +3673,7 @@ class RecurringTransactionsCompanion
     Expression<int>? accountId,
     Expression<int>? toAccountId,
     Expression<String>? note,
+    Expression<String>? currencyCode,
     Expression<String>? frequency,
     Expression<int>? interval,
     Expression<int>? dayOfMonth,
@@ -3653,6 +3695,7 @@ class RecurringTransactionsCompanion
       if (accountId != null) 'account_id': accountId,
       if (toAccountId != null) 'to_account_id': toAccountId,
       if (note != null) 'note': note,
+      if (currencyCode != null) 'currency_code': currencyCode,
       if (frequency != null) 'frequency': frequency,
       if (interval != null) 'interval': interval,
       if (dayOfMonth != null) 'day_of_month': dayOfMonth,
@@ -3676,6 +3719,7 @@ class RecurringTransactionsCompanion
       Value<int?>? accountId,
       Value<int?>? toAccountId,
       Value<String?>? note,
+      Value<String?>? currencyCode,
       Value<String>? frequency,
       Value<int>? interval,
       Value<int?>? dayOfMonth,
@@ -3696,6 +3740,7 @@ class RecurringTransactionsCompanion
       accountId: accountId ?? this.accountId,
       toAccountId: toAccountId ?? this.toAccountId,
       note: note ?? this.note,
+      currencyCode: currencyCode ?? this.currencyCode,
       frequency: frequency ?? this.frequency,
       interval: interval ?? this.interval,
       dayOfMonth: dayOfMonth ?? this.dayOfMonth,
@@ -3736,6 +3781,9 @@ class RecurringTransactionsCompanion
     }
     if (note.present) {
       map['note'] = Variable<String>(note.value);
+    }
+    if (currencyCode.present) {
+      map['currency_code'] = Variable<String>(currencyCode.value);
     }
     if (frequency.present) {
       map['frequency'] = Variable<String>(frequency.value);
@@ -3784,6 +3832,7 @@ class RecurringTransactionsCompanion
           ..write('accountId: $accountId, ')
           ..write('toAccountId: $toAccountId, ')
           ..write('note: $note, ')
+          ..write('currencyCode: $currencyCode, ')
           ..write('frequency: $frequency, ')
           ..write('interval: $interval, ')
           ..write('dayOfMonth: $dayOfMonth, ')
@@ -12145,6 +12194,7 @@ typedef $$RecurringTransactionsTableCreateCompanionBuilder
   Value<int?> accountId,
   Value<int?> toAccountId,
   Value<String?> note,
+  Value<String?> currencyCode,
   required String frequency,
   Value<int> interval,
   Value<int?> dayOfMonth,
@@ -12167,6 +12217,7 @@ typedef $$RecurringTransactionsTableUpdateCompanionBuilder
   Value<int?> accountId,
   Value<int?> toAccountId,
   Value<String?> note,
+  Value<String?> currencyCode,
   Value<String> frequency,
   Value<int> interval,
   Value<int?> dayOfMonth,
@@ -12212,6 +12263,9 @@ class $$RecurringTransactionsTableFilterComposer
 
   ColumnFilters<String> get note => $composableBuilder(
       column: $table.note, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get currencyCode => $composableBuilder(
+      column: $table.currencyCode, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get frequency => $composableBuilder(
       column: $table.frequency, builder: (column) => ColumnFilters(column));
@@ -12281,6 +12335,10 @@ class $$RecurringTransactionsTableOrderingComposer
   ColumnOrderings<String> get note => $composableBuilder(
       column: $table.note, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get currencyCode => $composableBuilder(
+      column: $table.currencyCode,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<String> get frequency => $composableBuilder(
       column: $table.frequency, builder: (column) => ColumnOrderings(column));
 
@@ -12348,6 +12406,9 @@ class $$RecurringTransactionsTableAnnotationComposer
 
   GeneratedColumn<String> get note =>
       $composableBuilder(column: $table.note, builder: (column) => column);
+
+  GeneratedColumn<String> get currencyCode => $composableBuilder(
+      column: $table.currencyCode, builder: (column) => column);
 
   GeneratedColumn<String> get frequency =>
       $composableBuilder(column: $table.frequency, builder: (column) => column);
@@ -12422,6 +12483,7 @@ class $$RecurringTransactionsTableTableManager extends RootTableManager<
             Value<int?> accountId = const Value.absent(),
             Value<int?> toAccountId = const Value.absent(),
             Value<String?> note = const Value.absent(),
+            Value<String?> currencyCode = const Value.absent(),
             Value<String> frequency = const Value.absent(),
             Value<int> interval = const Value.absent(),
             Value<int?> dayOfMonth = const Value.absent(),
@@ -12443,6 +12505,7 @@ class $$RecurringTransactionsTableTableManager extends RootTableManager<
             accountId: accountId,
             toAccountId: toAccountId,
             note: note,
+            currencyCode: currencyCode,
             frequency: frequency,
             interval: interval,
             dayOfMonth: dayOfMonth,
@@ -12464,6 +12527,7 @@ class $$RecurringTransactionsTableTableManager extends RootTableManager<
             Value<int?> accountId = const Value.absent(),
             Value<int?> toAccountId = const Value.absent(),
             Value<String?> note = const Value.absent(),
+            Value<String?> currencyCode = const Value.absent(),
             required String frequency,
             Value<int> interval = const Value.absent(),
             Value<int?> dayOfMonth = const Value.absent(),
@@ -12485,6 +12549,7 @@ class $$RecurringTransactionsTableTableManager extends RootTableManager<
             accountId: accountId,
             toAccountId: toAccountId,
             note: note,
+            currencyCode: currencyCode,
             frequency: frequency,
             interval: interval,
             dayOfMonth: dayOfMonth,

--- a/lib/data/repositories/local/local_recurring_transaction_repository.dart
+++ b/lib/data/repositories/local/local_recurring_transaction_repository.dart
@@ -46,6 +46,7 @@ class LocalRecurringTransactionRepository implements RecurringTransactionReposit
     required DateTime startDate,
     DateTime? endDate,
     bool enabled = true,
+    String? currencyCode,
   }) async {
     return await db.into(db.recurringTransactions).insert(
       RecurringTransactionsCompanion.insert(
@@ -64,8 +65,16 @@ class LocalRecurringTransactionRepository implements RecurringTransactionReposit
         startDate: startDate,
         endDate: d.Value(endDate),
         enabled: d.Value(enabled),
+        currencyCode: d.Value(_normalizeCurrency(currencyCode)),
       ),
     );
+  }
+
+  /// 币种统一大写存储(与 transactions.currency_code 一致);空串按 null。
+  static String? _normalizeCurrency(String? code) {
+    if (code == null) return null;
+    final trimmed = code.trim();
+    return trimmed.isEmpty ? null : trimmed.toUpperCase();
   }
 
   @override
@@ -87,6 +96,7 @@ class LocalRecurringTransactionRepository implements RecurringTransactionReposit
     DateTime? endDate,
     bool? enabled,
     DateTime? lastGeneratedDate,
+    String? currencyCode,
   }) async {
     await (db.update(db.recurringTransactions)..where((t) => t.id.equals(id)))
         .write(
@@ -107,6 +117,8 @@ class LocalRecurringTransactionRepository implements RecurringTransactionReposit
         endDate: d.Value(endDate),
         enabled: enabled != null ? d.Value(enabled) : const d.Value.absent(),
         lastGeneratedDate: d.Value(lastGeneratedDate),
+        // null 即写 NULL(改回本位币要能清掉旧外币),与本方法其它字段同语义
+        currencyCode: d.Value(_normalizeCurrency(currencyCode)),
         updatedAt: d.Value(DateTime.now()),
       ),
     );

--- a/lib/data/repositories/local/local_repository.dart
+++ b/lib/data/repositories/local/local_repository.dart
@@ -2154,6 +2154,7 @@ class LocalRepository extends BaseRepository {
     required DateTime startDate,
     DateTime? endDate,
     bool enabled = true,
+    String? currencyCode,
   }) =>
       _recurringTransactionRepo.addRecurringTransaction(
         ledgerId: ledgerId,
@@ -2171,6 +2172,7 @@ class LocalRepository extends BaseRepository {
         startDate: startDate,
         endDate: endDate,
         enabled: enabled,
+        currencyCode: currencyCode,
       );
 
   @override
@@ -2192,6 +2194,7 @@ class LocalRepository extends BaseRepository {
     DateTime? endDate,
     bool? enabled,
     DateTime? lastGeneratedDate,
+    String? currencyCode,
   }) =>
       _recurringTransactionRepo.updateRecurringTransaction(
         id: id,
@@ -2211,6 +2214,7 @@ class LocalRepository extends BaseRepository {
         endDate: endDate,
         enabled: enabled,
         lastGeneratedDate: lastGeneratedDate,
+        currencyCode: currencyCode,
       );
 
   @override

--- a/lib/data/repositories/recurring_transaction_repository.dart
+++ b/lib/data/repositories/recurring_transaction_repository.dart
@@ -14,6 +14,9 @@ abstract class RecurringTransactionRepository {
       int ledgerId);
 
   /// 添加周期记账
+  ///
+  /// [currencyCode] v32(issue #444)模板币种(ISO,大小写不敏感)。
+  /// null = 账本本位币;挂了账户时生成仍以账户币种为准(账户内不混币)。
   Future<int> addRecurringTransaction({
     required int ledgerId,
     required String type,
@@ -30,6 +33,7 @@ abstract class RecurringTransactionRepository {
     required DateTime startDate,
     DateTime? endDate,
     bool enabled = true,
+    String? currencyCode,
   });
 
   /// 更新周期记账
@@ -50,6 +54,7 @@ abstract class RecurringTransactionRepository {
     required DateTime startDate,
     DateTime? endDate,
     bool? enabled,
+    String? currencyCode,
   });
 
   /// 删除周期记账

--- a/lib/pages/transaction/recurring_transaction_edit_page.dart
+++ b/lib/pages/transaction/recurring_transaction_edit_page.dart
@@ -11,6 +11,9 @@ import '../../l10n/app_localizations.dart';
 import '../../services/data/recurring_transaction_service.dart';
 import '../../services/system/logger_service.dart';
 import '../../utils/category_utils.dart';
+import '../../utils/currencies.dart';
+import '../../widgets/currency/currency_flag.dart';
+import '../../widgets/currency/currency_picker_sheet.dart';
 
 class RecurringTransactionEditPage extends ConsumerStatefulWidget {
   final RecurringTransaction? recurring;
@@ -39,6 +42,13 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
   bool _hasAttemptedSave = false; // 是否已尝试保存
   int? _selectedLedgerId; // 选中的账本ID
 
+  /// v32(issue #444)模板币种:null = 所选账本的本位币。
+  /// 与记账页 L12 同构 —— 币种优先联动:改币种 → 账户列表按新币种过滤、已选账户清空。
+  String? _currencyCode;
+
+  /// 所选账本的本位币(异步查,用于判断"是否外币"与币种选择器的汇率基准)。
+  String? _ledgerCurrency;
+
   bool get _isEditing => widget.recurring != null;
 
   @override
@@ -55,6 +65,7 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
       _selectedToAccountId = widget.recurring!.toAccountId;
       _enabled = widget.recurring!.enabled;
       _selectedLedgerId = widget.recurring!.ledgerId;
+      _currencyCode = widget.recurring!.currencyCode?.toUpperCase();
       _amountController.text = widget.recurring!.amount.toStringAsFixed(2);
       _noteController.text = widget.recurring!.note ?? '';
       _loadCategoryAndAccount();
@@ -69,11 +80,34 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
       _selectedLedgerId = ref.read(currentLedgerIdProvider);
     }
 
+    _loadLedgerCurrency();
+
     // 监听金额输入变化，更新按钮状态
     _amountController.addListener(() {
       setState(() {});
     });
   }
+
+  /// 加载所选账本的本位币。账本切换后重新加载(币种字段与账户过滤都依赖它)。
+  Future<void> _loadLedgerCurrency() async {
+    final ledgerId = _selectedLedgerId;
+    if (ledgerId == null) return;
+    final ledger = await ref.read(repositoryProvider).getLedgerById(ledgerId);
+    if (!mounted) return;
+    setState(() {
+      _ledgerCurrency = (ledger?.currency.isNotEmpty ?? false)
+          ? ledger!.currency.toUpperCase()
+          : 'CNY';
+      // 模板币种恰等于新账本本位币 → 归一成 null(非外币)
+      if (_currencyCode?.toUpperCase() == _ledgerCurrency) {
+        _currencyCode = null;
+      }
+    });
+  }
+
+  /// 有效币种:模板币种 ?? 账本本位币。账户列表按它过滤,交易生成也落它。
+  String _effectiveCurrency() =>
+      _currencyCode ?? _ledgerCurrency ?? ref.read(currentLedgerCurrencyProvider);
 
   Future<void> _loadCategoryAndAccount() async {
     if (_isEditing && widget.recurring!.categoryId != null) {
@@ -125,6 +159,10 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
 
                   // Ledger selection
                   _buildLedgerSelector(l10n),
+                  const SizedBox(height: 16),
+
+                  // Currency (v32 / issue #444)
+                  _buildCurrencySelector(l10n),
                   const SizedBox(height: 16),
 
                   // Amount
@@ -314,6 +352,30 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
             final ledgerName = snapshot.data?.name ?? l10n.ledgerSelect;
             return Text(ledgerName);
           },
+        ),
+      ),
+    );
+  }
+
+  /// 币种字段(v32 / issue #444)。默认=账本本位币,点开可改;改了之后账户列表
+  /// 按新币种过滤(已选账户清空)。汇率不在此锁定 —— 每次生成按当日汇率折算,
+  /// 故不展示折算预览,以免暗示"这笔换算已定"。
+  Widget _buildCurrencySelector(AppLocalizations l10n) {
+    final currency = _effectiveCurrency();
+    return InkWell(
+      onTap: _selectCurrency,
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: l10n.txCurrencyLabel,
+          border: const OutlineInputBorder(),
+        ),
+        child: Row(
+          children: [
+            currencyFlag(context, currency, width: 22, height: 16, radius: 4),
+            const SizedBox(width: 8),
+            Expanded(child: Text(displayCurrency(currency, context))),
+            const Icon(Icons.arrow_drop_down, size: 24),
+          ],
         ),
       ),
     );
@@ -639,7 +701,30 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
       setState(() {
         _selectedLedgerId = selected;
       });
+      // 新账本本位币可能不同 → 重载并归一币种(_loadLedgerCurrency 内部处理)
+      await _loadLedgerCurrency();
     }
+  }
+
+  Future<void> _selectCurrency() async {
+    final l10n = AppLocalizations.of(context)!;
+    final String base = _ledgerCurrency ?? ref.read(currentLedgerCurrencyProvider);
+    final picked = await showCurrencyPickerSheet(
+      context,
+      selected: _effectiveCurrency(),
+      primaryColor: ref.read(primaryColorProvider),
+      title: l10n.txCurrencyPickerTitle,
+      rateBase: base, // 展示各币种对账本本位币的汇率
+    );
+    if (picked == null || !mounted) return;
+    final upper = picked.toUpperCase();
+    if (upper == _effectiveCurrency()) return;
+    setState(() {
+      _currencyCode = upper == base.toUpperCase() ? null : upper;
+      // 币种优先联动:账户列表按币种过滤,旧账户可能已不符 → 清空重选
+      _selectedAccountId = null;
+      _selectedToAccountId = null;
+    });
   }
 
   Future<void> _selectCategory() async {
@@ -660,16 +745,14 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
 
   Future<void> _selectAccount({required bool isFromAccount}) async {
     final repo = ref.read(repositoryProvider);
-    final ledgerId = ref.read(currentLedgerIdProvider);
-    final ledger = await ref.read(ledgerByIdProvider(ledgerId).future);
 
-    if (ledger == null) return;
-
-    // 获取所有账户，然后过滤与当前账本币种相同的账户;排除已隐藏账户
+    // 按**本模板的有效币种**过滤(v32 / issue #444:此前硬按账本本位币过滤,
+    // 外币账户根本选不到);排除已隐藏账户
     // (账户隐藏 #240 E2:该处历史上也缺 isTradableType,本期只补 hidden,不扩范围)
+    final currency = _effectiveCurrency().toUpperCase();
     final allAccounts = await repo.getAllAccounts();
     var accounts = allAccounts
-        .where((a) => a.currency == ledger.currency && !a.hidden)
+        .where((a) => a.currency.toUpperCase() == currency && !a.hidden)
         .toList();
 
     // 如果是选择转入账户，排除已选择的转出账户
@@ -689,24 +772,28 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
         title: Text(title),
         content: SizedBox(
           width: double.maxFinite,
-          child: ListView.builder(
-            shrinkWrap: true,
-            itemCount: accounts.length + (_type == 'transfer' && !isFromAccount ? 0 : 1), // 转入账户不显示"无账户"
-            itemBuilder: (context, index) {
-              if (index == 0 && (_type != 'transfer' || isFromAccount)) {
-                return ListTile(
-                  title: Text(AppLocalizations.of(context)!.accountNone),
-                  onTap: () => Navigator.of(context).pop(null),
-                );
-              }
-              final accountIndex = _type == 'transfer' && !isFromAccount ? index : index - 1;
-              final account = accounts[accountIndex];
-              return ListTile(
-                title: Text(account.name),
-                onTap: () => Navigator.of(context).pop(account.id),
-              );
-            },
-          ),
+          // 转入账户不给"不选择账户"兜底 → 该币种没有可选账户时列表会全空,
+          // 给一句空态,别让用户对着空白弹窗猜(#444:切外币后常见)
+          child: accounts.isEmpty && _type == 'transfer' && !isFromAccount
+              ? Text(AppLocalizations.of(context)!.commonEmpty)
+              : ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: accounts.length + (_type == 'transfer' && !isFromAccount ? 0 : 1), // 转入账户不显示"无账户"
+                  itemBuilder: (context, index) {
+                    if (index == 0 && (_type != 'transfer' || isFromAccount)) {
+                      return ListTile(
+                        title: Text(AppLocalizations.of(context)!.accountNone),
+                        onTap: () => Navigator.of(context).pop(null),
+                      );
+                    }
+                    final accountIndex = _type == 'transfer' && !isFromAccount ? index : index - 1;
+                    final account = accounts[accountIndex];
+                    return ListTile(
+                      title: Text(account.name),
+                      onTap: () => Navigator.of(context).pop(account.id),
+                    );
+                  },
+                ),
         ),
       ),
     );
@@ -770,6 +857,7 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
           startDate: _startDate,
           endDate: _endDate,
           enabled: _enabled,
+          currencyCode: _currencyCode, // null = 账本本位币
         );
 
         // 如果需要重置最后生成日期，单独更新
@@ -795,6 +883,7 @@ class _RecurringTransactionEditPageState extends ConsumerState<RecurringTransact
           monthOfYear: null,
           startDate: _startDate,
           endDate: _endDate,
+          currencyCode: _currencyCode, // null = 账本本位币
         );
       }
 

--- a/lib/pages/transaction/recurring_transaction_page.dart
+++ b/lib/pages/transaction/recurring_transaction_page.dart
@@ -111,6 +111,17 @@ class _RecurringTransactionCard extends ConsumerWidget {
 
   const _RecurringTransactionCard({required this.recurring});
 
+  /// 模板币种是否为外币(≠所属账本本位币)。null 币种 = 本位币,恒非外币。
+  /// 账本还在异步加载时先当外币展示 —— 保存路径下"本位币"一律落 null,
+  /// 故非 null 几乎必然是外币,这样避免符号从无到有的闪动。
+  bool _isForeign(WidgetRef ref) {
+    final code = recurring.currencyCode;
+    if (code == null || code.isEmpty) return false;
+    final base =
+        ref.watch(ledgerByIdProvider(recurring.ledgerId)).valueOrNull?.currency;
+    return code.toUpperCase() != (base?.toUpperCase() ?? '');
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final repo = ref.watch(repositoryProvider);
@@ -288,13 +299,15 @@ class _RecurringTransactionCard extends ConsumerWidget {
                   crossAxisAlignment: CrossAxisAlignment.end,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // 金额
+                    // 金额(v32 / issue #444:外币模板带币种符号,与交易列表口径一致)
                     AmountText(
                       value: recurring.type == 'expense'
                           ? -recurring.amount
                           : recurring.amount,
                       signed: recurring.type != 'transfer',
                       decimals: 2,
+                      showCurrency: _isForeign(ref),
+                      currencyCode: recurring.currencyCode,
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.w700,

--- a/lib/pages/transaction/recurring_transaction_page.dart
+++ b/lib/pages/transaction/recurring_transaction_page.dart
@@ -299,24 +299,42 @@ class _RecurringTransactionCard extends ConsumerWidget {
                   crossAxisAlignment: CrossAxisAlignment.end,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // 金额(v32 / issue #444:外币模板带币种符号,与交易列表口径一致)
-                    AmountText(
-                      value: recurring.type == 'expense'
-                          ? -recurring.amount
-                          : recurring.amount,
-                      signed: recurring.type != 'transfer',
-                      decimals: 2,
-                      showCurrency: _isForeign(ref),
-                      currencyCode: recurring.currencyCode,
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w700,
-                        color: recurring.type == 'expense'
-                            ? BeeTokens.error(context)
-                            : recurring.type == 'income'
-                                ? BeeTokens.success(context)
-                                : BeeTokens.textPrimary(context),
-                      ),
+                    // 金额(v32 / issue #444:外币模板在金额左侧标 ISO 码)
+                    //
+                    // 标**码**而不是符号:JPY/CNY 的符号都是「¥」,只换符号
+                    // 的话 5000 日元和 5000 元长得一模一样,等于没标。
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        if (_isForeign(ref)) ...[
+                          Text(
+                            recurring.currencyCode!.toUpperCase(),
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                              color: BeeTokens.textSecondary(context),
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                        ],
+                        AmountText(
+                          value: recurring.type == 'expense'
+                              ? -recurring.amount
+                              : recurring.amount,
+                          signed: recurring.type != 'transfer',
+                          decimals: 2,
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w700,
+                            color: recurring.type == 'expense'
+                                ? BeeTokens.error(context)
+                                : recurring.type == 'income'
+                                    ? BeeTokens.success(context)
+                                    : BeeTokens.textPrimary(context),
+                          ),
+                        ),
+                      ],
                     ),
                     const SizedBox(height: 2),
                     // 开关

--- a/lib/services/data/recurring_transaction_service.dart
+++ b/lib/services/data/recurring_transaction_service.dart
@@ -225,6 +225,17 @@ class RecurringTransactionService {
               '周期交易 id=${currentRecurring.id} 生成一笔: happenedAt=$nextDate amount=${currentRecurring.amount} type=${currentRecurring.type}');
 
           // 生成交易记录
+          //
+          // 币种(v32 / issue #444):
+          // - 挂了账户 → 传 null,让 repo 从账户解析(账户内不混币,
+          //   .docs/multi-currency-ledger 01 §4.1);账户事后被改币种时模板值
+          //   可能已漂移,以账户为准才不会往账户里塞异币种交易。
+          // - 无账户 → 用模板币种(L12 手选;null 即账本本位币,存量行为不变)。
+          // nativeAmount 一律不传:由 repo 按**本次生成当日**的有效汇率折算 ——
+          // 周期账单的语义是"每月 10 美元",不是"每月固定 72 元"。
+          final txCurrency = currentRecurring.accountId != null
+              ? null
+              : currentRecurring.currencyCode;
           final transactionId = await repository.addTransaction(
             ledgerId: currentRecurring.ledgerId,
             type: currentRecurring.type,
@@ -234,6 +245,7 @@ class RecurringTransactionService {
             toAccountId: currentRecurring.toAccountId,
             happenedAt: nextDate,
             note: currentRecurring.note,
+            currencyCode: txCurrency,
           );
 
           // 更新最后生成日期

--- a/lib/services/export/config_export_service.dart
+++ b/lib/services/export/config_export_service.dart
@@ -777,6 +777,7 @@ class RecurringTransactionItem {
   final String startDate; // ISO 8601 format
   final String? endDate;
   final bool enabled;
+  final String? currencyCode; // v32(#444)模板币种;null = 账本本位币
 
   const RecurringTransactionItem({
     required this.ledgerName,
@@ -794,6 +795,7 @@ class RecurringTransactionItem {
     required this.startDate,
     this.endDate,
     required this.enabled,
+    this.currencyCode,
   });
 
   Map<String, dynamic> toMap() {
@@ -814,6 +816,7 @@ class RecurringTransactionItem {
     if (dayOfWeek != null) map['day_of_week'] = dayOfWeek;
     if (monthOfYear != null) map['month_of_year'] = monthOfYear;
     if (endDate != null) map['end_date'] = endDate;
+    if (currencyCode != null) map['currency_code'] = currencyCode;
     return map;
   }
 
@@ -834,6 +837,7 @@ class RecurringTransactionItem {
       startDate: map['start_date'] as String,
       endDate: map['end_date'] as String?,
       enabled: map['enabled'] as bool,
+      currencyCode: map['currency_code'] as String?,
     );
   }
 
@@ -860,6 +864,7 @@ class RecurringTransactionItem {
       startDate: rt.startDate.toIso8601String(),
       endDate: rt.endDate?.toIso8601String(),
       enabled: rt.enabled,
+      currencyCode: rt.currencyCode,
     );
   }
 }
@@ -2069,6 +2074,10 @@ class ConfigExportService {
             buffer.writeln('      end_date: "${itemMap['end_date']}"');
           }
           buffer.writeln('      enabled: ${itemMap['enabled']}');
+          if (itemMap.containsKey('currency_code') &&
+              itemMap['currency_code'] != null) {
+            buffer.writeln('      currency_code: "${itemMap['currency_code']}"');
+          }
         }
       }
       buffer.writeln();
@@ -2752,6 +2761,7 @@ class ConfigExportService {
             startDate: DateTime.parse(item.startDate),
             endDate: item.endDate != null ? DateTime.parse(item.endDate!) : null,
             enabled: item.enabled,
+            currencyCode: item.currencyCode,
           );
           importedCount++;
         }

--- a/test/data/sync_pull_errors_schema_test.dart
+++ b/test/data/sync_pull_errors_schema_test.dart
@@ -2,7 +2,7 @@
 //
 // v25 → v26 migration 是所有用户启动必跑的关键路径,出错 = 整体崩盘。
 // 本测试验证:
-//   1. schemaVersion 在最新版本(当前为 31,v31 加了 accounts.hidden)
+//   1. schemaVersion 在最新版本(当前为 32,v32 加了 recurring_transactions.currency_code)
 //   2. sync_pull_errors 表完整 schema,所有列存在 + 默认值正确
 //   3. UNIQUE(change_id) 约束生效
 //   4. CRUD 基本操作正常
@@ -31,8 +31,8 @@ void main() {
     await db.close();
   });
 
-  test('schemaVersion = 31(确保 sync_pull_errors 表已纳入 schema)', () {
-    expect(db.schemaVersion, 31);
+  test('schemaVersion = 32(确保 sync_pull_errors 表已纳入 schema)', () {
+    expect(db.schemaVersion, 32);
   });
 
   test('sync_pull_errors 表存在,所有列就位', () async {

--- a/test/services/data/recurring_transaction_currency_test.dart
+++ b/test/services/data/recurring_transaction_currency_test.dart
@@ -1,0 +1,184 @@
+// 周期账单币种(issue #444):模板带 currencyCode → 生成的交易落该币种,
+// 并按**生成当日**有效汇率折算 nativeAmount(模板不锁汇率)。
+//
+// 口径(.docs/multi-currency-ledger 01 §4.1 / §4.5 L12):
+//  - 有账户 → 交易币种恒等于账户币种(账户内不混币),模板币种不得覆盖它;
+//  - 无账户 → 用模板币种(L12 手选);模板币种为 null → 账本本位币(存量行为)。
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+import 'package:beecount/services/data/recurring_transaction_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late BeeDatabase db;
+  late LocalRepository repo;
+  late int ledgerId;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+    ledgerId = await repo.createLedger(name: 'test', currency: 'CNY');
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  /// 插一条自动汇率(方向同 ExchangeRates:1 quote = rate base)。
+  Future<void> seedRate(String quote, String rate) async {
+    await db.customStatement(
+        "INSERT INTO exchange_rates (base_currency, quote_currency, rate_date, "
+        "rate, source, fetched_at) VALUES ('CNY', '$quote', '2026-08-01', "
+        "'$rate', 'test', ${DateTime.now().millisecondsSinceEpoch ~/ 1000})");
+  }
+
+  /// 跑一次生成器,返回唯一那笔交易。
+  Future<Transaction> generateOne() async {
+    final generated =
+        await RecurringTransactionService(repo).generatePendingTransactions();
+    expect(generated, hasLength(1));
+    return generated.first;
+  }
+
+  test('无账户 + 模板币种 JPY → 交易 currencyCode=JPY,按当日汇率折算', () async {
+    await seedRate('JPY', '0.05');
+    await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 5000,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now(),
+      currencyCode: 'JPY',
+    );
+
+    final tx = await generateOne();
+    expect(tx.currencyCode, 'JPY');
+    expect(tx.nativeAmount, closeTo(250.0, 0.001)); // 5000 * 0.05
+  });
+
+  test('无账户 + 模板币种 JPY 但本地无汇率 → nativeAmount 回落 =amount(L11 可捞回)',
+      () async {
+    await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 5000,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now(),
+      currencyCode: 'JPY',
+    );
+
+    final tx = await generateOne();
+    expect(tx.currencyCode, 'JPY');
+    expect(tx.nativeAmount, 5000.0);
+  });
+
+  test('模板币种为 null → 账本本位币(存量行为不变)', () async {
+    await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now(),
+    );
+
+    final tx = await generateOne();
+    expect(tx.currencyCode, 'CNY');
+    expect(tx.nativeAmount, 10.0);
+  });
+
+  test('挂外币账户 → 交易跟账户币种(模板币种同为该币种)', () async {
+    await seedRate('USD', '7.2');
+    final accountId = await repo.createAccount(
+        ledgerId: ledgerId, name: 'Chase', currency: 'USD');
+    await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      accountId: accountId,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now(),
+      currencyCode: 'USD',
+    );
+
+    final tx = await generateOne();
+    expect(tx.currencyCode, 'USD');
+    expect(tx.nativeAmount, closeTo(72.0, 0.001));
+  });
+
+  test('模板币种与所挂账户币种漂移 → 以账户币种为准(账户内不混币)', () async {
+    await seedRate('USD', '7.2');
+    final accountId = await repo.createAccount(
+        ledgerId: ledgerId, name: 'Chase', currency: 'USD');
+    // 模板存 JPY(例如账户事后被改币种),生成时必须跟账户 USD,
+    // 否则 USD 账户里混进一笔 JPY 交易,余额口径就烂了。
+    await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      accountId: accountId,
+      frequency: 'daily',
+      interval: 1,
+      startDate: DateTime.now(),
+      currencyCode: 'JPY',
+    );
+
+    final tx = await generateOne();
+    expect(tx.currencyCode, 'USD');
+    expect(tx.nativeAmount, closeTo(72.0, 0.001));
+  });
+
+  test('模板 currencyCode 可增改删(编辑页保存路径)', () async {
+    final id = await repo.addRecurringTransaction(
+      ledgerId: ledgerId,
+      type: 'expense',
+      amount: 10,
+      frequency: 'monthly',
+      interval: 1,
+      startDate: DateTime.now(),
+      currencyCode: 'usd', // 小写入参也应规整为大写
+    );
+    var all = await repo.getAllRecurringTransactions();
+    expect(all.firstWhere((r) => r.id == id).currencyCode, 'USD');
+
+    Future<void> save(String? currency) => repo.updateRecurringTransaction(
+          id: id,
+          ledgerId: ledgerId,
+          type: 'expense',
+          amount: 10,
+          frequency: 'monthly',
+          interval: 1,
+          startDate: DateTime.now(),
+          currencyCode: currency,
+        );
+
+    await save('JPY');
+    all = await repo.getAllRecurringTransactions();
+    expect(all.firstWhere((r) => r.id == id).currencyCode, 'JPY');
+
+    await save(null); // 改回本位币 → 落 null
+    all = await repo.getAllRecurringTransactions();
+    expect(all.firstWhere((r) => r.id == id).currencyCode, isNull);
+  });
+
+  test('v32 schema:recurring_transactions 带可空 currency_code 列', () async {
+    final cols = await db
+        .customSelect("PRAGMA table_info(recurring_transactions)")
+        .get();
+    final currencyCol = cols
+        .where((r) => r.read<String>('name') == 'currency_code')
+        .toList();
+    expect(currencyCol, hasLength(1));
+    expect(currencyCol.first.read<int>('notnull'), 0); // 可空:存量行留 NULL
+  });
+}

--- a/test/widgets/recurring_edit_currency_test.dart
+++ b/test/widgets/recurring_edit_currency_test.dart
@@ -1,0 +1,136 @@
+/// 周期账单编辑页的币种交互(issue #444):
+///   - 币种字段默认 = 账本本位币;编辑外币模板时回显模板币种
+///   - 账户候选按**模板有效币种**过滤(此前硬按账本本位币过滤 → 外币账户选不到)
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+import 'package:beecount/l10n/app_localizations.dart';
+import 'package:beecount/pages/transaction/recurring_transaction_edit_page.dart';
+import 'package:beecount/providers/database_providers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues({});
+
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Ledger cnyLedger() => Ledger(
+        id: 1,
+        name: 'L',
+        currency: 'CNY',
+        type: 'personal',
+        createdAt: DateTime(2026, 1, 1),
+        myRole: 'owner',
+        memberCount: 1,
+        isShared: false,
+        monthStartDay: 1,
+      );
+
+  /// 直接建账户行 —— 不走 repo.createAccount,避开它内部 logger 的 2s 落盘
+  /// 定时器(widget test 结束时会因 pending timer 失败)。
+  Future<void> seedAccount(String name, String currency) async {
+    await db.customStatement(
+        "INSERT INTO accounts (ledger_id, name, type, currency) "
+        "VALUES (1, '$name', 'cash', '$currency')");
+  }
+
+  /// 造一条模板(直接建表行,拿回实体喂给编辑页)。
+  Future<RecurringTransaction> seedTemplate({String? currencyCode}) async {
+    await db.customStatement(
+        "INSERT INTO ledgers (id, name, currency) VALUES (1, 'L', 'CNY')");
+    final id = await repo.addRecurringTransaction(
+      ledgerId: 1,
+      type: 'expense',
+      amount: 100,
+      frequency: 'monthly',
+      interval: 1,
+      startDate: DateTime(2026, 8, 1),
+      currencyCode: currencyCode,
+    );
+    final all = await repo.getAllRecurringTransactions();
+    return all.firstWhere((r) => r.id == id);
+  }
+
+  Widget host(RecurringTransaction recurring) {
+    return ProviderScope(
+      overrides: [
+        repositoryProvider.overrideWithValue(repo),
+        currentLedgerProvider
+            .overrideWith((ref) => Stream<Ledger?>.value(cnyLedger())),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: RecurringTransactionEditPage(recurring: recurring),
+      ),
+    );
+  }
+
+  testWidgets('模板未设币种 → 币种字段显示账本本位币', (tester) async {
+    final recurring = await seedTemplate();
+    await tester.pumpWidget(host(recurring));
+    await tester.pumpAndSettle();
+
+    expect(find.text('人民币 (CNY)'), findsOneWidget);
+  });
+
+  testWidgets('外币模板 → 币种字段回显模板币种', (tester) async {
+    final recurring = await seedTemplate(currencyCode: 'JPY');
+    await tester.pumpWidget(host(recurring));
+    await tester.pumpAndSettle();
+
+    expect(find.text('日元 (JPY)'), findsOneWidget);
+    expect(find.text('人民币 (CNY)'), findsNothing);
+  });
+
+  testWidgets('外币模板的账户候选 = 同币种账户,本位币账户不出现(#444 核心修复)',
+      (tester) async {
+    final recurring = await seedTemplate(currencyCode: 'JPY');
+    await seedAccount('工资卡', 'CNY');
+    await seedAccount('日本旅行卡', 'JPY');
+
+    await tester.pumpWidget(host(recurring));
+    await tester.pumpAndSettle();
+
+    // 点开账户选择弹窗(点 label 文字命中不到装饰层,取其外层 InkWell)
+    await tester.tap(find
+        .ancestor(of: find.text('选择账户'), matching: find.byType(InkWell))
+        .first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('日本旅行卡'), findsOneWidget);
+    expect(find.text('工资卡'), findsNothing,
+        reason: '外币模板不该再被硬过滤成本位币账户列表');
+  });
+
+  testWidgets('本位币模板的账户候选 = 本位币账户(旧行为不回归)', (tester) async {
+    final recurring = await seedTemplate();
+    await seedAccount('工资卡', 'CNY');
+    await seedAccount('日本旅行卡', 'JPY');
+
+    await tester.pumpWidget(host(recurring));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find
+        .ancestor(of: find.text('选择账户'), matching: find.byType(InkWell))
+        .first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('工资卡'), findsOneWidget);
+    expect(find.text('日本旅行卡'), findsNothing);
+  });
+}


### PR DESCRIPTION
Closes #444

## 问题

周期账单从来没有币种概念,三处叠加导致**外币周期账单根本记不了**:

1. 编辑页账户候选被硬过滤成「= 账本本位币」(`recurring_transaction_edit_page.dart` 旧 672 行)→ 外币账户选不到;
2. 没有记账页那样的手选币种入口(多币种设计 L12「无账户手选币种」),周期页缺失;
3. 生成器调 `addTransaction` 不传 `currencyCode`,靠 repo 从账户兜底 —— 而账户又只能是本位币 → 生成的交易永远落本位币。

多币种 phase 2 的技术设计里其实已经预设了「周期模板挂外币账户」这条路径(`02-tech-design-app.md` §兜底),只是编辑页的老过滤把入口焊死了。

## 改动

| 层 | 改动 |
|---|---|
| DB | v32:`recurring_transactions.currency_code`(可空)。**不回填** —— NULL = 账本本位币,存量模板行为一字不差 |
| Repository | `add/updateRecurringTransaction` 增 `currencyCode`(接口 + 本地实现 + LocalRepository 委托),统一大写存储 |
| 生成器 | 有账户 → 以账户币种为准(账户内不混币,§4.1);无账户 → 用模板币种;`nativeAmount` 不传,由 repo 按**生成当日**有效汇率折算 |
| 编辑页 | 新增「币种」字段(复用 `showCurrencyPickerSheet`);币种优先联动:改币种即按新币种过滤账户候选并清空已选账户 |
| 列表页 | 外币模板在金额左侧标 ISO 码 |
| 配置导出/导入 | `currency_code` 往返 |

### 几个刻意的取舍

- **汇率不锁在模板上**:周期账单的语义是「每月 10 美元」,不是「每月固定 72 元」,所以每次生成按当日有效汇率折算,编辑页也不展示折算预览(免得暗示"这笔换算已定")。生成当时若本地无该币种汇率 → `nativeAmount` 回落 = amount,正好命中 L11 检测条件,统计页「按当前汇率重算」横幅可捞回。
- **列表页标 ISO 码而不是币种符号**:JPY 和 CNY 的符号都是「¥」,只换符号的话 5000 日元和 5000 元长得一模一样(这条是真机上发现的,一开始写的是 `showCurrency`)。
- **跨币种转账仍不支持**(§4.4):转账两端按同一有效币种过滤,天然同币种;该币种没有可选转入账户时给一句空态,不让用户对着空白弹窗猜。
- 顺手修了 `_selectAccount` 读 `currentLedgerIdProvider` 而不是页面上所选账本的老问题。

周期账单**不参与云同步**(只进 config 导出/导入),**服务端零改动**。

## 验证

- `flutter test` 全绿:620 passed(新增 11 条)
  - `test/services/data/recurring_transaction_currency_test.dart`:外币模板落币种 + 按当日汇率折算 / 无汇率回落 / 模板币种为 null 保持存量 / 挂外币账户 / **模板币种与账户币种漂移时以账户为准** / v32 列可空
  - `test/widgets/recurring_edit_currency_test.dart`:币种字段默认本位币、外币回显、**账户候选按有效币种过滤(核心修复)**、本位币模板旧行为不回归
  - `test/data/sync_pull_errors_schema_test.dart` 的 schemaVersion 守卫同步到 32
- iOS 模拟器真机走查(iPhone 16 / iOS 18.6,全新干净设备):新建周期账单 → 币种字段渲染正常 → 选日元 → 存 5000 → 列表显示 `JPY -5,000`
