### PR TITLE
fix(android): targetSdk 提到 36 并移除 Android 侧 Google Play 结算库

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,7 +36,10 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 23  // Required by record_android for voice recording
-        targetSdk = flutter.targetSdkVersion
+        // 硬编码 36(Android 16):Google Play 自 2026-11-01 起要求 targetSdk >= 36,
+        // 而当前锁定的 Flutter 3.27.3 内置 flutter.targetSdkVersion 仍为 35。
+        // 升 Flutter 后可考虑改回 flutter.targetSdkVersion。
+        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     // 当未在命令行指定 --flavor 时，默认选择 dev 风味，避免 Flutter 调试找不到 APK。

--- a/lib/pages/donation/donation_page.dart
+++ b/lib/pages/donation/donation_page.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:in_app_purchase_platform_interface/in_app_purchase_platform_interface.dart';
 
 import '../../widgets/ui/ui.dart';
 import '../../widgets/biz/biz.dart';

--- a/lib/services/payment/donation_service.dart
+++ b/lib/services/payment/donation_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:in_app_purchase_platform_interface/in_app_purchase_platform_interface.dart';
+import 'package:in_app_purchase_storekit/in_app_purchase_storekit.dart';
 
 import '../system/logger_service.dart';
 
@@ -17,8 +18,30 @@ class DonationService {
   factory DonationService() => _instance;
   DonationService._internal();
 
+  // StoreKit 平台实现是否已注册
+  //
+  // 本服务原先依赖 `in_app_purchase` 联合插件，由 `InAppPurchase.instance`
+  // 按平台自动注册实现。为了不把 Google Play 结算库打进 Android 包
+  // (Android 从来不显示打赏入口，见 pubspec.yaml 注释)，现在只依赖
+  // iOS 专属的 `in_app_purchase_storekit`，注册需要自己做。
+  // 必须保证幂等：重复 registerPlatform 会换掉实例，导致已有的
+  // purchaseStream 订阅失效。
+  static bool _storeKitRegistered = false;
+
   // IAP实例
-  final InAppPurchase _iap = InAppPurchase.instance;
+  InAppPurchasePlatform get _iap {
+    if (!_supported) {
+      throw UnsupportedError('DonationService 仅支持 iOS/macOS');
+    }
+    if (!_storeKitRegistered) {
+      InAppPurchaseStoreKitPlatform.registerPlatform();
+      _storeKitRegistered = true;
+    }
+    return InAppPurchasePlatform.instance;
+  }
+
+  /// 当前平台是否支持打赏（仅 StoreKit 平台）
+  static bool get _supported => Platform.isIOS || Platform.isMacOS;
 
   // 购买监听订阅
   StreamSubscription<List<PurchaseDetails>>? _subscription;
@@ -87,7 +110,7 @@ class DonationService {
   Future<bool> initialize() async {
     try {
       // 仅支持iOS平台
-      if (!Platform.isIOS) {
+      if (!_supported) {
         logger.info('Donation', 'Android平台暂不支持打赏功能');
         return false;
       }
@@ -123,6 +146,9 @@ class DonationService {
   ///
   /// 返回: 商品列表
   Future<List<ProductDetails>> queryProducts() async {
+    if (!_supported) {
+      return [];
+    }
     try {
       logger.info('Donation', '开始查询商品，Product IDs: $kProductIds');
       final response = await _iap.queryProductDetails(kProductIds);
@@ -187,6 +213,9 @@ class DonationService {
   /// [product] 商品信息
   /// 返回: true=请求成功, false=请求失败
   Future<bool> donate(ProductDetails product) async {
+    if (!_supported) {
+      return false;
+    }
     try {
       logger.info('Donation', '发起打赏: ${product.id}');
 
@@ -279,6 +308,9 @@ class DonationService {
 
   /// 恢复购买（消耗型商品通常不需要）
   Future<void> restorePurchases() async {
+    if (!_supported) {
+      return;
+    }
     try {
       logger.info('Donation', '开始恢复购买');
       await _iap.restorePurchases();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -863,24 +863,8 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
-  in_app_purchase:
-    dependency: "direct main"
-    description:
-      name: in_app_purchase
-      sha256: "50004f9e4392deabc7e2585587c38aed4d08d782869cb31c610b657c9a43207b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
-  in_app_purchase_android:
-    dependency: transitive
-    description:
-      name: in_app_purchase_android
-      sha256: "9f320659b13e34529cd7d53508f7ead500f03b42e7a2435bd4efce5210546051"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.0+3"
   in_app_purchase_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: in_app_purchase_platform_interface
       sha256: "1d353d38251da5b9fea6635c0ebfc6bb17a2d28d0e86ea5e083bf64244f1fb4c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,8 +58,17 @@ dependencies:
   qr_flutter: ^4.1.0
   gal: ^2.3.0
   archive: ^3.6.1
-  in_app_purchase: ^3.1.0
+  # 打赏(IAP)只在 iOS 提供,Android 从不显示入口(见 mine_page.dart / donation_service.dart)。
+  # 这里故意不依赖 `in_app_purchase` 联合插件:它会把 in_app_purchase_android
+  # 一并打进 AAB,从而带入 com.android.billingclient。Google Play 要求结算库
+  # >= 8.0.0(2026-11-01 截止),而官方插件升到 billing 8 的版本
+  # (in_app_purchase_android 0.5.0)要求 Flutter >= 3.38 / Dart ^3.10,
+  # 远超本项目锁定的 Flutter 3.27.3。既然 Android 根本不用结算,索性只依赖
+  # iOS 专属实现,让 AAB 里彻底不含结算库 —— 该策略要求随之不适用。
+  # ⚠️ 若将来要在 Android 上做内购(如付费皮肤),需改回 `in_app_purchase`
+  #    联合插件,并同步升级 Flutter 以获得 billing 8+ 的实现。
   in_app_purchase_storekit: ^0.3.6
+  in_app_purchase_platform_interface: ^1.4.0
   flutter_ai_kit:
     path: packages/flutter_ai_kit
   flutter_ai_kit_zhipu:


### PR DESCRIPTION
解决 Google Play Console 报的两条策略问题（均以 2026-11-01 为截止，延期已获批）。

## 1. 应用必须以 Android 16（API 36）或更高级别为目标平台

`android/app/build.gradle` 里把 `targetSdk = flutter.targetSdkVersion` 硬编码为 `36`。

`flutter.targetSdkVersion` 在锁定的 Flutter 3.27.3 里就是 **35**，所以在这个项目里它永远追不上 Play 的要求，除非升 Flutter。compileSdk 早已是 36、AGP 8.12.1、Gradle 8.13、CI 已装 android-36 platform，工具链无需改动。

## 2. 应用必须使用 Google Play 结算库版本 8.0.0 或更高版本

**处置方式是移除，而不是升级。** 理由：

- 官方插件升到 billing 8 的版本是 `in_app_purchase_android` 0.5.0，要求 **Flutter ≥ 3.38 / Dart ^3.10**，远超本项目锁定的 3.27.3。
- **Android 端从来没有内购功能**：打赏入口在 `mine_page.dart` 是 `if (Platform.isIOS)`，`DonationService.initialize()` 在非 iOS 直接 return false。billing 7.1.1 纯粹是 `in_app_purchase` 联合插件顺带打进 AAB 的死代码。

为一行都不会执行的代码去升整个 Flutter 不划算，所以改成只依赖 iOS 专属的 `in_app_purchase_storekit` + 显式的 `in_app_purchase_platform_interface`。AAB 里彻底不含 `com.android.billingclient`，该策略要求随之不适用——以后 billing 抬到 9、10 也不用跟。

代码侧改动很小：联合插件原本会按平台自动注册实现，改后 `DonationService` 自己调 `InAppPurchaseStoreKitPlatform.registerPlatform()`（**必须幂等**，重复调用会换掉实例，导致已有的 `purchaseStream` 订阅失效）。三个 public 方法加了平台守卫，保持 Android 上原有的「安全失败」语义。

## 验证结果

全部实际跑过，不是推断：

| 检查 | 结果 |
|---|---|
| `bundleProdRelease` 构建 | ✅ `app-prod-release.aab (47.8MB)` |
| merged manifest 的 targetSdk | ✅ `android:targetSdkVersion="36"`（minSdk 仍 23） |
| AAB dex 内 `billingclient` 类 | ✅ 0 处 |
| AAB dex 内 `InAppPurchase` 类 | ✅ 0 处 |
| merged manifest 内 billing 声明 | ✅ 0 处（`ProxyBillingActivity` + `com.android.vending.BILLING` 权限已消失） |
| `flutter analyze` | ✅ 无 error（803 个 info/warning 是既有基线） |
| `flutter test` | ✅ All tests passed（609 passed / 1 skipped） |
| iOS 侧 | ✅ `GeneratedPluginRegistrant.m` 仍注册 `InAppPurchasePlugin`，`Podfile.lock` 未变 |

> 注：`unzip -l` 只看文件名查不出 dex 里的类。上面用的是解包 AAB 后 `strings base/dex/*.dex | grep -c billingclient`。

## 需要注意

- ⚠️ **将来若在 Android 上做内购（如付费皮肤），必须改回 `in_app_purchase` 联合插件并同步升级 Flutter**。这是真实的技术天花板，不是随手能加回来的。pubspec 注释里已标注。
- iOS 打赏链路只验证到编译与插件注册层，**实际购买流程建议真机过一遍再发版**。
- 顺带发现（本 PR 未改）：`useLegacyPackaging = true` 上方那条「支持 16KB 页面大小」的注释方向是反的——`true` 表示压缩 .so 走 legacy 解压路径，而 16KB 支持要的是未压缩页对齐。Play Console 目前没报这条，留待单独核实与改正。