### PR TITLE
fix: 创建标签后自动选中新标签

### DIFF
--- a/lib/pages/tag/tag_edit_page.dart
+++ b/lib/pages/tag/tag_edit_page.dart
@@ -257,6 +257,7 @@ class _TagEditPageState extends ConsumerState<TagEditPage> {
     setState(() => _isSubmitting = true);
 
     try {
+      Tag? savedTag;
       if (_isEditing) {
         // 更新标签
         await repo.updateTag(
@@ -264,15 +265,17 @@ class _TagEditPageState extends ConsumerState<TagEditPage> {
           name: name,
           color: _selectedColor,
         );
+        savedTag = await repo.getTagById(widget.tag!.id);
         if (mounted) {
           showToast(context, l10n.tagUpdateSuccess);
         }
       } else {
         // 创建标签
-        await repo.createTag(
+        final id = await repo.createTag(
           name: name,
           color: _selectedColor,
         );
+        savedTag = await repo.getTagById(id);
         if (mounted) {
           showToast(context, l10n.tagCreateSuccess);
         }
@@ -290,7 +293,7 @@ class _TagEditPageState extends ConsumerState<TagEditPage> {
       }
 
       if (mounted) {
-        Navigator.of(context).pop();
+        Navigator.of(context).pop(savedTag);
       }
     } catch (e) {
       if (mounted) {

--- a/lib/pages/tag/widgets/tag_selector.dart
+++ b/lib/pages/tag/widgets/tag_selector.dart
@@ -309,6 +309,8 @@ class _TagSelectorState extends ConsumerState<TagSelector> {
       ),
     );
 
+    if (!mounted) return;
+
     // 如果创建了新标签，自动选中
     if (result != null) {
       setState(() {

--- a/test/widgets/tag_edit_page_result_test.dart
+++ b/test/widgets/tag_edit_page_result_test.dart
@@ -1,0 +1,68 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+import 'package:beecount/l10n/app_localizations.dart';
+import 'package:beecount/pages/tag/tag_edit_page.dart';
+import 'package:beecount/providers/database_providers.dart';
+
+void main() {
+  late BeeDatabase db;
+  late LocalRepository repo;
+  Tag? routeResult;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+    routeResult = null;
+  });
+
+  tearDown(() async => db.close());
+
+  Widget host() {
+    return ProviderScope(
+      overrides: [
+        repositoryProvider.overrideWithValue(repo),
+        currentLedgerIdProvider.overrideWith((ref) => 0),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () async {
+                routeResult = await Navigator.of(context).push<Tag>(
+                  MaterialPageRoute(builder: (_) => const TagEditPage()),
+                );
+              },
+              child: const Text('打开'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('创建标签后将已保存的 Tag 返回给调用方', (tester) async {
+    await tester.pumpWidget(host());
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextFormField), '新标签');
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+
+    expect(routeResult, isNotNull);
+    expect(routeResult!.name, '新标签');
+    expect(routeResult!.id, greaterThan(0));
+    expect((await db.select(db.tags).get()).single.id, routeResult!.id);
+
+    // showToastOnOverlay 会保留一个 2 秒移除计时器；推进测试时钟，避免泄漏。
+    await tester.pump(const Duration(seconds: 3));
+  });
+}


### PR DESCRIPTION
## 问题

`TagSelector` 已经会读取 `TagEditPage` 的路由返回值，并在返回非空时自动选中标签；但 `TagEditPage` 保存成功后始终执行无返回值的 `pop()`，所以这段自动选中逻辑实际上从未生效。

本修复按 #436 的 review 意见从共享账本 Editor 权限修复中独立拆出，保持一个 PR 只处理一个问题。

## 修改

- 创建或编辑标签后重新读取已保存的 `Tag`，通过路由返回给调用方
- 数据读取不到时返回 `null`，正常关闭页面，不使用强制解包
- `TagSelector` 在异步页面返回后检查 `mounted`，再更新选择状态和刷新列表
- 增加 widget 回归测试，验证新建标签会返回完整且已落库的 `Tag`

## 验证

在 Flutter 3.27.3 容器中限制 1.5 GB 内存并使用单并发运行：

```text
flutter test --concurrency=1 test/widgets/tag_edit_page_result_test.dart
1/1 passed
```
