### PR TITLE
docs: 修复 Star 历史曲线图失效

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,11 +380,11 @@ A: 使用自己的服务器 / Storage / Bucket,WebDAV 和 S3 建议 HTTPS 加密
 <details>
 <summary>查看 Star 历史曲线</summary>
 
-<a href="https://www.star-history.com/?repos=tnt-likely%2Fbeecount&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tnt-likely/beecount&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tnt-likely/beecount&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tnt-likely/beecount&type=date&legend=top-left" />
+ <a href="https://star-history.dera.page/#tnt-likely/beecount&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tnt-likely/beecount&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tnt-likely/beecount&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tnt-likely/beecount&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -380,11 +380,11 @@ For commercial licensing pricing and process, see [COMMERCIAL_LICENSE.md](COMMER
 <details>
 <summary>View Star history chart</summary>
 
-<a href="https://www.star-history.com/?repos=tnt-likely%2Fbeecount&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tnt-likely/beecount&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tnt-likely/beecount&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tnt-likely/beecount&type=date&legend=top-left" />
+ <a href="https://star-history.dera.page/#tnt-likely/beecount&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tnt-likely/beecount&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tnt-likely/beecount&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tnt-likely/beecount&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
当前 README 中的 Star 历史曲线图因数据源限制已无法正常加载，影响了项目展示。本次将 README 与 README_EN 中的曲线图地址更新为新的可用镜像，使其恢复显示，方便大家随时查看项目的 Star 增长情况。