### PR TITLE
feat: 标签详情页支持按月/年/全部时间维度筛选统计 (#461)

### DIFF
--- a/lib/data/repositories/local/local_repository.dart
+++ b/lib/data/repositories/local/local_repository.dart
@@ -2466,8 +2466,9 @@ class LocalRepository extends BaseRepository {
       _tagRepo.getAllTagTransactionCounts();
 
   @override
-  Future<({int count, double expense, double income})> getTagStats(int tagId, {int? ledgerId}) =>
-      _tagRepo.getTagStats(tagId, ledgerId: ledgerId);
+  Future<({int count, double expense, double income})> getTagStats(int tagId,
+          {int? ledgerId, DateTime? start, DateTime? end}) =>
+      _tagRepo.getTagStats(tagId, ledgerId: ledgerId, start: start, end: end);
 
   @override
   Future<List<Transaction>> getTransactionsByTag(int tagId) =>
@@ -2496,8 +2497,10 @@ class LocalRepository extends BaseRepository {
       _tagRepo.watchTagsForTransaction(transactionId);
 
   @override
-  Stream<List<Transaction>> watchTransactionsByTag(int tagId, {int? ledgerId}) =>
-      _tagRepo.watchTransactionsByTag(tagId, ledgerId: ledgerId);
+  Stream<List<Transaction>> watchTransactionsByTag(int tagId,
+          {int? ledgerId, DateTime? start, DateTime? end}) =>
+      _tagRepo.watchTransactionsByTag(tagId,
+          ledgerId: ledgerId, start: start, end: end);
 
   @override
   Future<bool> isTagNameDuplicate({required String name, int? excludeId}) =>

--- a/lib/data/repositories/local/local_tag_repository.dart
+++ b/lib/data/repositories/local/local_tag_repository.dart
@@ -356,12 +356,20 @@ class LocalTagRepository implements TagRepository {
   }
 
   @override
-  Future<({int count, double expense, double income})> getTagStats(int tagId, {int? ledgerId}) async {
+  Future<({int count, double expense, double income})> getTagStats(int tagId,
+      {int? ledgerId, DateTime? start, DateTime? end}) async {
     // §7 共享账本:负 id 是 synthetic tag，经 TransactionTagOverrides 反查统计
-    if (tagId < 0) return _sharedTagStatsBySyntheticId(tagId, ledgerId);
+    if (tagId < 0) {
+      return _sharedTagStatsBySyntheticId(tagId, ledgerId,
+          start: start, end: end);
+    }
     final ledgerFilter = ledgerId != null ? 'AND tx.ledger_id = ?' : '';
+    final startFilter = start != null ? 'AND tx.happened_at >= ?' : '';
+    final endFilter = end != null ? 'AND tx.happened_at < ?' : '';
     final vars = <d.Variable>[d.Variable.withInt(tagId)];
     if (ledgerId != null) vars.add(d.Variable.withInt(ledgerId));
+    if (start != null) vars.add(d.Variable.withDateTime(start));
+    if (end != null) vars.add(d.Variable.withDateTime(end));
     final result = await db.customSelect(
       '''
       SELECT
@@ -370,7 +378,7 @@ class LocalTagRepository implements TagRepository {
         COALESCE(SUM(CASE WHEN tx.type = 'income' AND tx.exclude_from_stats = 0 THEN COALESCE(tx.native_amount, tx.amount) ELSE 0 END), 0) as income
       FROM transaction_tags tt
       INNER JOIN transactions tx ON tt.transaction_id = tx.id
-      WHERE tt.tag_id = ? $ledgerFilter
+      WHERE tt.tag_id = ? $ledgerFilter $startFilter $endFilter
       ''',
       variables: vars,
       readsFrom: {db.transactionTags, db.transactions},
@@ -533,7 +541,8 @@ class LocalTagRepository implements TagRepository {
 
   /// 共享账本:synthetic tag 下的交易 — 经 TransactionTagOverrides(tagSyncId)反查。
   Stream<List<Transaction>> _watchSharedTxByTagSyntheticId(
-      int syntheticId, int? ledgerId) {
+      int syntheticId, int? ledgerId,
+      {DateTime? start, DateTime? end}) {
     final ctrl = StreamController<List<Transaction>>();
     StreamSubscription? sub;
     String? matchedSyncId;
@@ -572,6 +581,12 @@ class LocalTagRepository implements TagRepository {
       if (ledgerId != null) {
         q.where((t) => t.ledgerId.equals(ledgerId));
       }
+      if (start != null) {
+        q.where((t) => t.happenedAt.isBiggerOrEqualValue(start));
+      }
+      if (end != null) {
+        q.where((t) => t.happenedAt.isSmallerThanValue(end));
+      }
       final list = await q.get();
       if (!ctrl.isClosed) ctrl.add(list);
     }
@@ -592,7 +607,8 @@ class LocalTagRepository implements TagRepository {
 
   /// 共享账本:synthetic tag 的统计 — 基于 override 关联的交易聚合。
   Future<({int count, double expense, double income})>
-      _sharedTagStatsBySyntheticId(int syntheticId, int? ledgerId) async {
+      _sharedTagStatsBySyntheticId(int syntheticId, int? ledgerId,
+          {DateTime? start, DateTime? end}) async {
     String? matchedSyncId;
     final rows = await db.select(db.sharedLedgerTags).get();
     for (final s in rows) {
@@ -611,6 +627,12 @@ class LocalTagRepository implements TagRepository {
       ..where((t) => t.syncId.isIn(txSyncIds));
     if (ledgerId != null) {
       q.where((t) => t.ledgerId.equals(ledgerId));
+    }
+    if (start != null) {
+      q.where((t) => t.happenedAt.isBiggerOrEqualValue(start));
+    }
+    if (end != null) {
+      q.where((t) => t.happenedAt.isSmallerThanValue(end));
     }
     final txs = await q.get();
     var count = 0;
@@ -653,40 +675,38 @@ class LocalTagRepository implements TagRepository {
   }
 
   @override
-  Stream<List<Transaction>> watchTransactionsByTag(int tagId, {int? ledgerId}) {
+  Stream<List<Transaction>> watchTransactionsByTag(int tagId,
+      {int? ledgerId, DateTime? start, DateTime? end}) {
     // §7 共享账本:负 id 是 synthetic tag，经 TransactionTagOverrides 反查交易
-    if (tagId < 0) return _watchSharedTxByTagSyntheticId(tagId, ledgerId);
-    final ledgerFilter = ledgerId != null ? 'AND tx.ledger_id = ?' : '';
-    final vars = <d.Variable>[d.Variable.withInt(tagId)];
-    if (ledgerId != null) vars.add(d.Variable.withInt(ledgerId));
-    return db.customSelect(
-      '''
-      SELECT tx.*
-      FROM transactions tx
-      INNER JOIN transaction_tags tt ON tx.id = tt.transaction_id
-      WHERE tt.tag_id = ? $ledgerFilter
-      ORDER BY tx.happened_at DESC
-      ''',
-      variables: vars,
-      readsFrom: {db.transactions, db.transactionTags},
-    ).watch().map((rows) {
-      return rows.map((row) {
-        return Transaction(
-          id: row.read<int>('id'),
-          ledgerId: row.read<int>('ledger_id'),
-          type: row.read<String>('type'),
-          amount: row.read<double>('amount'),
-          categoryId: row.read<int?>('category_id'),
-          accountId: row.read<int?>('account_id'),
-          toAccountId: row.read<int?>('to_account_id'),
-          happenedAt: row.read<DateTime>('happened_at'),
-          note: row.read<String?>('note'),
-          recurringId: row.read<int?>('recurring_id'),
-          excludeFromStats: row.read<bool>('exclude_from_stats'),
-          excludeFromBudget: row.read<bool>('exclude_from_budget'),
-        );
-      }).toList();
-    });
+    if (tagId < 0) {
+      return _watchSharedTxByTagSyntheticId(tagId, ledgerId,
+          start: start, end: end);
+    }
+    // drift join + readTable 全字段映射;旧手写映射漏掉 currencyCode/
+    // nativeAmount/categorySyncIdOverride 等列,外币交易在详情页显示会错。
+    final query = db.select(db.transactions).join([
+      d.innerJoin(
+        db.transactionTags,
+        db.transactionTags.transactionId.equalsExp(db.transactions.id),
+      ),
+    ])
+      ..where(db.transactionTags.tagId.equals(tagId))
+      ..orderBy([
+        d.OrderingTerm(
+            expression: db.transactions.happenedAt, mode: d.OrderingMode.desc),
+      ]);
+    if (ledgerId != null) {
+      query.where(db.transactions.ledgerId.equals(ledgerId));
+    }
+    if (start != null) {
+      query.where(db.transactions.happenedAt.isBiggerOrEqualValue(start));
+    }
+    if (end != null) {
+      query.where(db.transactions.happenedAt.isSmallerThanValue(end));
+    }
+    return query
+        .watch()
+        .map((rows) => rows.map((row) => row.readTable(db.transactions)).toList());
   }
 
   // ============================================

--- a/lib/data/repositories/tag_repository.dart
+++ b/lib/data/repositories/tag_repository.dart
@@ -97,8 +97,10 @@ abstract class TagRepository {
   /// 获取所有标签的交易数量
   Future<Map<int, int>> getAllTagTransactionCounts();
 
-  /// 获取标签统计信息（总笔数、总支出、总收入）
-  Future<({int count, double expense, double income})> getTagStats(int tagId, {int? ledgerId});
+  /// 获取标签统计信息（总笔数、总支出、总收入）。
+  /// [start]/[end] 可选,半开区间 [start, end) 过滤 happenedAt;不传 = 全部历史。
+  Future<({int count, double expense, double income})> getTagStats(int tagId,
+      {int? ledgerId, DateTime? start, DateTime? end});
 
   /// 获取标签下的所有交易
   Future<List<Transaction>> getTransactionsByTag(int tagId);
@@ -126,8 +128,10 @@ abstract class TagRepository {
   /// 监听交易的标签
   Stream<List<Tag>> watchTagsForTransaction(int transactionId);
 
-  /// 监听标签下的交易
-  Stream<List<Transaction>> watchTransactionsByTag(int tagId, {int? ledgerId});
+  /// 监听标签下的交易。
+  /// [start]/[end] 可选,半开区间 [start, end) 过滤 happenedAt;不传 = 全部历史。
+  Stream<List<Transaction>> watchTransactionsByTag(int tagId,
+      {int? ledgerId, DateTime? start, DateTime? end});
 
   // ============================================
   // 辅助方法

--- a/lib/pages/tag/tag_detail_page.dart
+++ b/lib/pages/tag/tag_detail_page.dart
@@ -11,7 +11,9 @@ import '../../styles/tokens.dart';
 import '../../utils/transaction_edit_utils.dart';
 import '../../services/billing/post_processor.dart';
 import '../../utils/category_utils.dart';
+import '../../utils/month_range.dart';
 import '../../utils/shared_ledger_picker_filter.dart';
+import '../../widgets/ui/capsule_switcher.dart';
 import '../../l10n/app_localizations.dart';
 import 'tag_edit_page.dart';
 
@@ -36,6 +38,11 @@ class TagDetailPage extends ConsumerStatefulWidget {
 class _TagDetailPageState extends ConsumerState<TagDetailPage> {
   // 缓存分类数据
   Map<int, db.Category> _categoryCache = {};
+
+  // #461 时间维度:month | year | all。默认 all 保持旧行为(与标签管理列表的总笔数对得上)。
+  String _scope = 'all';
+  // 月/年视角选中的周期标签(DateTime(y,m,1));null = 当前周期
+  DateTime? _selMonth;
 
   @override
   void initState() {
@@ -71,54 +78,138 @@ class _TagDetailPageState extends ConsumerState<TagDetailPage> {
     }
   }
 
+  /// 当前 scope 的统计/列表时间范围;all 返回 null(全部历史,含未来的预记账)。
+  /// 月/年周期口径与洞察页一致(自定义每月起始日,periodForLabel/yearRangeFor)。
+  DateRange? _rangeForScope(int startDay, DateTime selMonth) {
+    switch (_scope) {
+      case 'month':
+        return periodForLabel(selMonth.year, selMonth.month, startDay);
+      case 'year':
+        return yearRangeFor(selMonth.year, startDay);
+      default:
+        return null;
+    }
+  }
+
+  // 显示周期选择器(对齐洞察页:月=年月轮盘,年=年轮盘)
+  void _showPeriodPicker(DateTime selMonth) async {
+    if (_scope == 'month') {
+      final res = await showWheelDatePicker(
+        context,
+        initial: selMonth,
+        mode: WheelDatePickerMode.ym,
+        maxDate: DateTime.now(),
+      );
+      if (res != null) {
+        setState(() => _selMonth = DateTime(res.year, res.month, 1));
+      }
+    } else if (_scope == 'year') {
+      final res = await showWheelDatePicker(
+        context,
+        initial: selMonth,
+        mode: WheelDatePickerMode.y,
+        maxDate: DateTime.now(),
+      );
+      if (res != null) {
+        setState(() => _selMonth = DateTime(res.year, 1, 1));
+      }
+    }
+  }
+
+  Widget _buildScopeBar(AppLocalizations l10n, DateTime selMonth) {
+    final periodLabel = _scope == 'year'
+        ? '${selMonth.year}'
+        : '${selMonth.year}-${selMonth.month.toString().padLeft(2, '0')}';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: CapsuleSwitcher<String>(
+              selectedValue: _scope,
+              options: [
+                CapsuleOption(value: 'month', label: l10n.analyticsMonth),
+                CapsuleOption(value: 'year', label: l10n.analyticsYear),
+                CapsuleOption(value: 'all', label: l10n.analyticsAll),
+              ],
+              onChanged: (value) => setState(() => _scope = value),
+            ),
+          ),
+          if (_scope != 'all') ...[
+            const SizedBox(width: 12),
+            InkWell(
+              onTap: () => _showPeriodPicker(selMonth),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(periodLabel, style: BeeTextTokens.title(context)),
+                  Icon(
+                    Icons.arrow_drop_down,
+                    size: 20,
+                    color: BeeTokens.textPrimary(context),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final tagAsync = ref.watch(_tagStreamProvider(widget.tagId));
     final ledgerScope = widget.allLedgers ? null : ref.watch(currentLedgerIdProvider);
-    final statsAsync = ref.watch(_tagStatsProvider((tagId: widget.tagId, ledgerId: ledgerScope)));
-    final transactionsAsync = ref.watch(_tagTransactionsStreamProvider((tagId: widget.tagId, ledgerId: ledgerScope)));
+    final startDay = ref.watch(currentMonthStartDayProvider);
+    final selMonth = _selMonth ?? labelForDate(DateTime.now(), startDay);
+    final range = _rangeForScope(startDay, selMonth);
+    final statsAsync = ref.watch(_tagStatsProvider((
+      tagId: widget.tagId,
+      ledgerId: ledgerScope,
+      start: range?.start,
+      end: range?.end,
+    )));
+    final transactionsAsync = ref.watch(_tagTransactionsStreamProvider((
+      tagId: widget.tagId,
+      ledgerId: ledgerScope,
+      start: range?.start,
+      end: range?.end,
+    )));
+    final tag = tagAsync.valueOrNull;
 
     return Scaffold(
       backgroundColor: BeeTokens.scaffoldBackground(context),
       body: Column(
         children: [
-          // Header
-          tagAsync.when(
-            loading: () => PrimaryHeader(
-              title: l10n.tagDetailTitle,
-              showBack: true,
-            ),
-            error: (error, stack) => PrimaryHeader(
-              title: l10n.tagDetailTitle,
-              showBack: true,
-            ),
-            data: (tag) => PrimaryHeader(
-              title: l10n.tagDetailTitle,
-              showBack: true,
-              actions: [
-                IconButton(
-                  icon: const Icon(Icons.edit_outlined),
-                  tooltip: l10n.commonEdit,
-                  onPressed: tag != null
-                      ? () async {
-                          await Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (_) => TagEditPage(tag: tag),
-                            ),
-                          );
-                        }
-                      : null,
-                ),
-                IconButton(
-                  icon: const Icon(Icons.delete_outline),
-                  tooltip: l10n.commonDelete,
-                  onPressed: tag != null
-                      ? () => _confirmDelete(tag, l10n)
-                      : null,
-                ),
-              ],
-            ),
+          // Header(tag 未加载完时编辑/删除禁用)
+          PrimaryHeader(
+            title: l10n.tagDetailTitle,
+            showBack: true,
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.edit_outlined),
+                tooltip: l10n.commonEdit,
+                onPressed: tag != null
+                    ? () async {
+                        await Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => TagEditPage(tag: tag),
+                          ),
+                        );
+                      }
+                    : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                tooltip: l10n.commonDelete,
+                onPressed: tag != null
+                    ? () => _confirmDelete(tag, l10n)
+                    : null,
+              ),
+            ],
+            bottom: _buildScopeBar(l10n, selMonth),
           ),
           Expanded(
             child: Column(
@@ -446,15 +537,31 @@ final _tagStreamProvider = StreamProvider.family<db.Tag?, int>((ref, tagId) {
   return repo.watchTag(tagId);
 });
 
-/// 获取标签统计信息
-final _tagStatsProvider = FutureProvider.family<({int count, double expense, double income}), ({int tagId, int? ledgerId})>((ref, params) async {
+/// 获取标签统计信息(start/end 为 #461 时间维度筛选,null = 全部)。
+/// autoDispose:参数含时间范围,用户切换周期会产生新 family 实例,旧实例及时释放。
+final _tagStatsProvider = FutureProvider.autoDispose.family<
+    ({int count, double expense, double income}),
+    ({int tagId, int? ledgerId, DateTime? start, DateTime? end})>((ref, params) async {
   ref.watch(tagListRefreshProvider);
   final repo = ref.watch(repositoryProvider);
-  return await repo.getTagStats(params.tagId, ledgerId: params.ledgerId);
+  return await repo.getTagStats(
+    params.tagId,
+    ledgerId: params.ledgerId,
+    start: params.start,
+    end: params.end,
+  );
 });
 
-/// 监听标签下的交易
-final _tagTransactionsStreamProvider = StreamProvider.family<List<db.Transaction>, ({int tagId, int? ledgerId})>((ref, params) {
+/// 监听标签下的交易(start/end 为 #461 时间维度筛选,null = 全部)。
+/// autoDispose:同上,切换周期后旧范围的 drift watch 订阅随之取消。
+final _tagTransactionsStreamProvider = StreamProvider.autoDispose.family<
+    List<db.Transaction>,
+    ({int tagId, int? ledgerId, DateTime? start, DateTime? end})>((ref, params) {
   final repo = ref.watch(repositoryProvider);
-  return repo.watchTransactionsByTag(params.tagId, ledgerId: params.ledgerId);
+  return repo.watchTransactionsByTag(
+    params.tagId,
+    ledgerId: params.ledgerId,
+    start: params.start,
+    end: params.end,
+  );
 });

--- a/test/repositories/tag_stats_range_test.dart
+++ b/test/repositories/tag_stats_range_test.dart
@@ -1,0 +1,254 @@
+// #461 标签详情页按 月/年/全部 时间维度筛选:
+// getTagStats / watchTransactionsByTag 增加可选 [start, end) 半开区间过滤。
+// 共享账本 synthetic tag(负 id)分支同样生效。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+import 'package:beecount/utils/shared_ledger_picker_filter.dart'
+    show syntheticIdForSyncId;
+
+void main() {
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Future<int> seedLedger() {
+    return db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '测试账本',
+          monthStartDay: const Value(1),
+        ));
+  }
+
+  /// 造一笔带标签的交易,返回交易 id。
+  Future<int> seedTaggedTx({
+    required int ledgerId,
+    required int tagId,
+    required DateTime happenedAt,
+    String type = 'expense',
+    double amount = 100,
+    bool excludeFromStats = false,
+    String? currencyCode,
+    double? nativeAmount,
+  }) async {
+    final txId = await repo.addTransaction(
+      ledgerId: ledgerId,
+      type: type,
+      amount: amount,
+      happenedAt: happenedAt,
+      excludeFromStats: excludeFromStats,
+      currencyCode: currencyCode,
+      nativeAmount: nativeAmount,
+    );
+    await repo.addTagToTransaction(transactionId: txId, tagId: tagId);
+    return txId;
+  }
+
+  test('getTagStats 带 [start,end) 只统计范围内交易,边界半开', () async {
+    final lid = await seedLedger();
+    final tagId = await repo.createTag(name: '旅行');
+
+    // 范围外(5 月末)
+    await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2026, 5, 31), amount: 1);
+    // == start,应计入
+    await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2026, 6, 1), amount: 10);
+    // 范围内收入
+    await seedTaggedTx(
+        ledgerId: lid,
+        tagId: tagId,
+        happenedAt: DateTime(2026, 6, 15),
+        type: 'income',
+        amount: 200);
+    // == end,不计入
+    await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2026, 7, 1), amount: 1000);
+
+    final stats = await repo.getTagStats(
+      tagId,
+      ledgerId: lid,
+      start: DateTime(2026, 6, 1),
+      end: DateTime(2026, 7, 1),
+    );
+
+    expect(stats.count, 2);
+    expect(stats.expense, 10.0);
+    expect(stats.income, 200.0);
+  });
+
+  test('getTagStats 不带范围仍返回全量(回归)', () async {
+    final lid = await seedLedger();
+    final tagId = await repo.createTag(name: '旅行');
+    await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2006, 1, 1), amount: 7);
+    await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2026, 6, 1), amount: 3);
+
+    final stats = await repo.getTagStats(tagId, ledgerId: lid);
+
+    expect(stats.count, 2);
+    expect(stats.expense, 10.0);
+  });
+
+  test('getTagStats 范围内 excludeFromStats 金额仍被排除,笔数照常', () async {
+    final lid = await seedLedger();
+    final tagId = await repo.createTag(name: '旅行');
+    await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2026, 6, 2), amount: 100);
+    await seedTaggedTx(
+        ledgerId: lid,
+        tagId: tagId,
+        happenedAt: DateTime(2026, 6, 3),
+        amount: 500,
+        excludeFromStats: true);
+
+    final stats = await repo.getTagStats(
+      tagId,
+      ledgerId: lid,
+      start: DateTime(2026, 6, 1),
+      end: DateTime(2026, 7, 1),
+    );
+
+    expect(stats.count, 2);
+    expect(stats.expense, 100.0);
+  });
+
+  test('watchTransactionsByTag 带 [start,end) 只返回范围内交易', () async {
+    final lid = await seedLedger();
+    final tagId = await repo.createTag(name: '旅行');
+    await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2026, 5, 31));
+    final inRangeId = await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2026, 6, 15));
+    await seedTaggedTx(
+        ledgerId: lid, tagId: tagId, happenedAt: DateTime(2026, 7, 1));
+
+    final list = await repo
+        .watchTransactionsByTag(
+          tagId,
+          ledgerId: lid,
+          start: DateTime(2026, 6, 1),
+          end: DateTime(2026, 7, 1),
+        )
+        .first;
+
+    expect(list.map((t) => t.id).toList(), [inRangeId]);
+  });
+
+  test('watchTransactionsByTag 返回完整字段(currencyCode/nativeAmount)', () async {
+    final lid = await seedLedger();
+    final tagId = await repo.createTag(name: '旅行');
+    await seedTaggedTx(
+      ledgerId: lid,
+      tagId: tagId,
+      happenedAt: DateTime(2026, 6, 15),
+      amount: 100,
+      currencyCode: 'USD',
+      nativeAmount: 720,
+    );
+
+    final list = await repo.watchTransactionsByTag(tagId, ledgerId: lid).first;
+
+    expect(list, hasLength(1));
+    expect(list.single.currencyCode, 'USD');
+    expect(list.single.nativeAmount, 720.0);
+  });
+
+  group('共享账本 synthetic tag', () {
+    const ledgerSyncId = 'ledger-ext-1';
+    const tagSyncId = 'tag-s1';
+
+    Future<int> seedSharedLedger() async {
+      final lid = await db.into(db.ledgers).insert(LedgersCompanion.insert(
+            name: '共享账本',
+            type: const Value('shared'),
+            syncId: const Value(ledgerSyncId),
+            myRole: const Value('editor'),
+            isShared: const Value(true),
+          ));
+      await db.into(db.sharedLedgerTags).insert(SharedLedgerTagsCompanion.insert(
+            ledgerSyncId: ledgerSyncId,
+            syncId: tagSyncId,
+            name: '共享标签',
+            updatedAt: DateTime.utc(2026, 1, 1),
+          ));
+      return lid;
+    }
+
+    Future<void> seedSharedTx({
+      required int ledgerId,
+      required String txSyncId,
+      required DateTime happenedAt,
+      double amount = 100,
+    }) async {
+      await db.into(db.transactions).insert(TransactionsCompanion.insert(
+            ledgerId: ledgerId,
+            type: 'expense',
+            amount: amount,
+            happenedAt: Value(happenedAt),
+            syncId: Value(txSyncId),
+          ));
+      await db
+          .into(db.transactionTagOverrides)
+          .insert(TransactionTagOverridesCompanion.insert(
+            transactionSyncId: txSyncId,
+            tagSyncId: tagSyncId,
+            createdAt: DateTime.utc(2026, 1, 1),
+          ));
+    }
+
+    test('getTagStats 对 synthetic tag 同样按范围过滤', () async {
+      final lid = await seedSharedLedger();
+      await seedSharedTx(
+          ledgerId: lid,
+          txSyncId: 'tx-1',
+          happenedAt: DateTime(2026, 6, 10),
+          amount: 30);
+      await seedSharedTx(
+          ledgerId: lid,
+          txSyncId: 'tx-2',
+          happenedAt: DateTime(2026, 7, 10),
+          amount: 500);
+
+      final synthId = syntheticIdForSyncId(tagSyncId);
+      final stats = await repo.getTagStats(
+        synthId,
+        ledgerId: lid,
+        start: DateTime(2026, 6, 1),
+        end: DateTime(2026, 7, 1),
+      );
+
+      expect(stats.count, 1);
+      expect(stats.expense, 30.0);
+    });
+
+    test('watchTransactionsByTag 对 synthetic tag 同样按范围过滤', () async {
+      final lid = await seedSharedLedger();
+      await seedSharedTx(
+          ledgerId: lid, txSyncId: 'tx-1', happenedAt: DateTime(2026, 6, 10));
+      await seedSharedTx(
+          ledgerId: lid, txSyncId: 'tx-2', happenedAt: DateTime(2026, 7, 10));
+
+      final synthId = syntheticIdForSyncId(tagSyncId);
+      final list = await repo
+          .watchTransactionsByTag(
+            synthId,
+            ledgerId: lid,
+            start: DateTime(2026, 6, 1),
+            end: DateTime(2026, 7, 1),
+          )
+          .first;
+
+      expect(list.map((t) => t.syncId).toList(), ['tx-1']);
+    });
+  });
+}

--- a/test/widgets/tag_detail_scope_filter_test.dart
+++ b/test/widgets/tag_detail_scope_filter_test.dart
@@ -1,0 +1,103 @@
+// #461 标签详情页按 月/年/全部 时间维度筛选:
+// 默认「全部」保持旧行为;切「月」只看当前周期;切「年」只看当前年周期。
+// 统计卡片与交易列表共用同一范围。
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:beecount/data/db.dart';
+import 'package:beecount/data/repositories/local/local_repository.dart';
+import 'package:beecount/l10n/app_localizations.dart';
+import 'package:beecount/pages/tag/tag_detail_page.dart';
+import 'package:beecount/providers/database_providers.dart';
+import 'package:beecount/widgets/biz/biz.dart' show TransactionListItem;
+
+void main() {
+  late BeeDatabase db;
+  late LocalRepository repo;
+
+  setUp(() {
+    db = BeeDatabase.forTesting(NativeDatabase.memory());
+    repo = LocalRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Widget host(int ledgerId, int tagId) {
+    return ProviderScope(
+      overrides: [
+        repositoryProvider.overrideWithValue(repo),
+        currentLedgerIdProvider.overrideWith((ref) => ledgerId),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: TagDetailPage(tagId: tagId, tagName: '旅行'),
+      ),
+    );
+  }
+
+  testWidgets('默认全部;切月/年后统计与列表只显示对应周期', (tester) async {
+    final ledgerId = await db.into(db.ledgers).insert(LedgersCompanion.insert(
+          name: '测试账本',
+        ));
+    final tagId = await repo.createTag(name: '旅行');
+
+    Future<void> seed(DateTime happenedAt, double amount) async {
+      final txId = await repo.addTransaction(
+        ledgerId: ledgerId,
+        type: 'expense',
+        amount: amount,
+        happenedAt: happenedAt,
+      );
+      await repo.addTagToTransaction(transactionId: txId, tagId: tagId);
+    }
+
+    final now = DateTime.now();
+    // 本月一笔(月/年/全部都可见)
+    await seed(DateTime(now.year, now.month, 15), 100);
+    // 今年另一个月一笔(年/全部可见;now 在 1 月时取 2 月,年范围含未来周期)
+    final otherMonth = now.month == 1 ? 2 : 1;
+    await seed(DateTime(now.year, otherMonth, 15), 20);
+    // 久远一笔(仅全部可见)
+    await seed(DateTime(2006, 1, 15), 7);
+
+    await tester.pumpWidget(host(ledgerId, tagId));
+    await tester.pumpAndSettle();
+
+    // 默认「全部」:3 笔全显示(保持旧行为)
+    expect(find.byType(TransactionListItem), findsNWidgets(3));
+    expect(find.text('3笔'), findsOneWidget);
+
+    // 切「月」:只剩本月 1 笔
+    await tester.tap(find.text('月'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TransactionListItem), findsNWidgets(1));
+    expect(find.text('1笔'), findsOneWidget);
+    // 显示当前周期标签,可再点开选择器换周期
+    final monthLabel =
+        '${now.year}-${now.month.toString().padLeft(2, '0')}';
+    expect(find.text(monthLabel), findsOneWidget);
+
+    // 切「年」:本年 2 笔
+    await tester.tap(find.text('年'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TransactionListItem), findsNWidgets(2));
+    expect(find.text('2笔'), findsOneWidget);
+    expect(find.text('${now.year}'), findsOneWidget);
+
+    // 切回「全部」:恢复 3 笔
+    await tester.tap(find.text('全部'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TransactionListItem), findsNWidgets(3));
+    expect(find.text('3笔'), findsOneWidget);
+
+    // 手动拆树:drift QueryStream 取消订阅时会排一个 zero-duration Timer,
+    // 留给框架自动拆树会触发 "A Timer is still pending" 断言。
+    // pump 必须带时长——不带时不推进 FakeAsync 时钟,timer 不会执行。
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump(const Duration(milliseconds: 1));
+  });
+}


### PR DESCRIPTION
Closes #461

## 需求

标签详情页目前只能看到该标签下**所有历史数据**的总和(会统计到 20 年前),无法像「洞察」页那样按时间维度分析近期开销。本 PR 为标签详情页增加 **月 / 年 / 全部** 三档时间筛选,统计卡片与关联交易列表共用同一范围。

## 方案

**Repository 层**
- `getTagStats` / `watchTransactionsByTag` 增加可选 `start`/`end` 参数,半开区间 `[start, end)`,不传 = 全部历史(现有调用方零改动)
- 共享账本 synthetic tag(负 id)分支同步支持范围过滤

**页面层**
- Header 底部新增 `CapsuleSwitcher`(月/年/全部,复用洞察页 l10n,**零新增 key**);月/年视角显示可点的周期标签,弹与洞察页一致的轮盘选择器
- 周期口径与洞察页对齐:`periodForLabel` / `yearRangeFor`,**支持自定义每月起始日**
- 页面统计/交易 provider 改 `autoDispose`:family 参数含时间范围,切换周期后旧范围的 drift watch 订阅及时释放

## 设计决策(可讨论)

1. **默认「全部」**:保持旧行为零回归,从标签管理列表(显示总笔数)点进来数字对得上;issue 的核心诉求是「能切换」
2. **月/年取完整周期**(不像洞察页截断到「今天」):洞察截断是为图表不画空白天;这里是统计+列表,完整周期让周期内的预记账可见,「全部」视角也不会切掉未来交易
3. **顺手修复**:旧 `watchTransactionsByTag` 手写 SQL 映射漏掉 `currencyCode`/`nativeAmount`/`categorySyncIdOverride` 等列,外币交易在标签详情列表会显示原币金额而非折算金额;改为 drift join + `readTable` 全字段映射,并补了回归测试

## 测试

- 新增 `test/repositories/tag_stats_range_test.dart`(7 测):范围边界(含 start 不含 end)、无范围回归、excludeFromStats 口径、ledgerId 组合、字段映射回归、共享 synthetic tag 范围过滤
- 新增 `test/widgets/tag_detail_scope_filter_test.dart`:默认全部 → 切月 → 切年 → 切回全部,统计与列表笔数逐一断言
- 全量 `flutter test`:647 passed;`flutter analyze` 改动文件零告警

## 真机验证(iOS 模拟器 iPhone 16 Pro Max,真实字体渲染)

造数:本月 2 支出 1 收入 + 今年 3 月 1 笔 + 2006 年 1 笔,全部挂「旅行」标签

| 视角 | 预期 | 实测 |
|---|---|---|
| 全部 | 5 笔 / 支出 493.4 / 收入 500 | ✅ 一致 |
| 月(2026-08) | 3 笔 / 398.4 / 500,label「2026-08▾」 | ✅ 一致 |
| 年(2026) | 4 笔 / 486.4 / 500,label「2026▾」 | ✅ 一致 |
| 轮盘选 2026-03 | 1 笔 / 88 / 0,列表仅剩 3 月交易 | ✅ 一致 |

胶囊 + 周期标签一行排布无溢出;「全部」视角不显示周期标签。Android 端未实测(同一套 Flutter 布局,组件均为现有组件)。