### PR TITLE
fix: added android localized app name

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,6 +42,7 @@ android {
         targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        manifestPlaceholders += [appName: "@string/app_name"]
     // 当未在命令行指定 --flavor 时，默认选择 dev 风味，避免 Flutter 调试找不到 APK。
     missingDimensionStrategy "env", "dev"
     }
@@ -51,11 +52,10 @@ android {
         dev {
             dimension "env"
             applicationIdSuffix ".dev"
-            resValue "string", "app_name", "蜜蜂记账测试版"
+            manifestPlaceholders += [appName: "@string/app_name_test"]
         }
         prod {
             dimension "env"
-            resValue "string", "app_name", "蜜蜂记账"
         }
     }
 
@@ -143,7 +143,7 @@ android {
             // Debug 构建追加独立后缀，名称显示为测试版，便于与生产包共存
             applicationIdSuffix ".debug"
             versionNameSuffix "-debug"
-            resValue "string", "app_name", "蜜蜂记账测试版"
+            manifestPlaceholders += [appName: "@string/app_name_test"]
         }
         release {
             // Use a stable release keystore so upgrades don't require uninstall

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     
     <application
-        android:label="@string/app_name"
+        android:label="${appName}"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true">

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -3,6 +3,8 @@
     <!-- 桌面小组件名称 / 描述(英文)。Android 桌面选择器按「系统语言」取,
          走此资源目录;简体见 values/、繁体见 values-zh-rTW/。app_name 等未在此
          覆盖的字符串按 Android 机制回退到 values/ 默认值。 -->
+    <string name="app_name">BeeCount</string>
+    <string name="app_name_test">BeeCount Test</string>
     <!-- Widget names (android:label in the launcher picker) -->
     <string name="widget_name">Overview (Medium)</string>
     <string name="widget_glance_small_name">Overview (Small)</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">꿀벌 가계부</string>
+    <string name="app_name_test">꿀벌 가계부 테스트 버전</string>
+</resources>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -3,6 +3,8 @@
     <!-- 桌面小組件名稱 / 描述(繁體中文)。Android 桌面選擇器按「系統語言」取,
          走此資源目錄;簡體見 values/、英文見 values-en/。未覆蓋的字串按 Android
          機制回退到 values/ 預設值。 -->
+    <string name="app_name">蜜蜂記帳</string>
+    <string name="app_name_test">蜜蜂記帳測試版</string>
     <!-- 小組件名稱(選擇器 android:label) -->
     <string name="widget_name">收支速覽·中</string>
     <string name="widget_glance_small_name">收支速覽·小</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <!-- 通用资源 -->
     <string name="app_name">蜜蜂记账</string>
+    <string name="app_name_test">蜜蜂记账测试版</string>
     <!-- 桌面小组件:选择器里显示的名称(android:label)。每个 receiver 各用一个,
          否则都继承 app_name「蜜蜂记账」、无法区分。 -->
     <string name="widget_name">收支速览·中</string>


### PR DESCRIPTION
## 变更说明 / What & Why

- Uses a manifest placeholder to select localized app-name resources.
- Adds English, Korean, and Traditional Chinese app-name resources.
- Keeps Simplified Chinese as the default fallback.

## 关联 Issue / Related Issue

Close #472 

## 自测情况 / Self-tested

- [x] `flutter analyze` 无新增告警 / no new warnings
- [X] `flutter test` 通过 / tests pass
- [X] 已实机运行验证；UI 变更已附截图 / verified on a real device; screenshots attached for UI changes
- [ ] 涉及文案变更：已更新 `lib/l10n/*.arb` 并用 Flutter 3.27.3 运行 `flutter gen-l10n` / for copy changes: arb files updated and `flutter gen-l10n` run with Flutter 3.27.3

## 贡献者许可条款 / Contributor License Terms

- [X] 我已阅读并同意贡献者许可条款 / I have read and agree to the [Contributor License Terms](../CONTRIBUTING.md#贡献者许可条款contributor-license-terms)
